### PR TITLE
This version of eq_finale_tanks replace bridge_escape_fix.sp

### DIFF
--- a/addons/sourcemod/scripting/eq_finale_tanks.sp
+++ b/addons/sourcemod/scripting/eq_finale_tanks.sp
@@ -4,7 +4,28 @@
 #include <sdktools>
 #include <l4d2_direct>
 
-#define FINALE_STAGE_TANK 8
+// from https://developer.valvesoftware.com/wiki/L4D2_Director_Scripts
+enum ()
+{
+	FINALE_GAUNTLET_1 = 0,
+	FINALE_HORDE_ATTACK_1 = 1,
+	FINALE_HALFTIME_BOSS = 2,
+	FINALE_GAUNTLET_2 = 3,
+	FINALE_HORDE_ATTACK_2 = 4,
+	FINALE_FINAL_BOSS = 5,
+	FINALE_HORDE_ESCAPE	= 6,
+	FINALE_CUSTOM_PANIC	= 7,
+	FINALE_CUSTOM_TANK	= 8,
+	FINALE_CUSTOM_SCRIPTED	= 9,
+	FINALE_CUSTOM_DELAY	= 10,
+	FINALE_CUSTOM_CLEAROUT = 11,
+	FINALE_GAUNTLET_START = 12,
+	FINALE_GAUNTLET_HORDE = 13,
+	FINALE_GAUNTLET_HORDE_BONUSTIME	= 14,
+	FINALE_GAUNTLET_BOSS_INCOMING = 15,
+	FINALE_GAUNTLET_BOSS = 16,
+	FINALE_GAUNTLET_ESCAPE = 17
+};
 
 enum TankSpawningScheme
 {
@@ -22,9 +43,9 @@ new tankCount;
 public Plugin:myinfo =
 {
 	name = "EQ2 Finale Tank Manager",
-	author = "Visor",
+	author = "Visor, Electr0",
 	description = "Either two event tanks or one flow and one (second) event tank",
-	version = "2.4",
+	version = "2.5",
 	url = "https://github.com/Attano/Equilibrium"
 };
 
@@ -83,10 +104,11 @@ public Action:ProcessTankSpawn(Handle:timer)
 }
 
 public Action:L4D2_OnChangeFinaleStage(&finaleType, const String:arg[]) 
-{
-	// PrintToChatAll("Finale type %i has commenced", finaleType);
-	if (finaleType == FINALE_STAGE_TANK) 
+{	
+	if (spawnScheme != Skip && (finaleType == FINALE_CUSTOM_TANK || finaleType == FINALE_GAUNTLET_BOSS || finaleType == FINALE_GAUNTLET_ESCAPE))
 	{
+		//PrintToChatAll("Finale type %i has commenced", finaleType);
+		
 		tankCount++;
 		
 		if ((spawnScheme == FlowAndSecondOnEvent && tankCount != 2)

--- a/addons/sourcemod/scripting/l4d2_fireworks_noise_block.sp
+++ b/addons/sourcemod/scripting/l4d2_fireworks_noise_block.sp
@@ -1,0 +1,26 @@
+#include <sourcemod>
+#include <sdktools>
+
+public Plugin:myinfo =
+{
+	name = "L4D2 Fireworks Noise Blocker",
+	description = "Focus on SI!",
+	author = "Visor",
+	version = "0.3",
+	url = "https://github.com/Attano/L4D2-Competitive-Framework"
+};
+
+public OnPluginStart()
+{
+	AddNormalSoundHook(NormalSHook:OnNormalSound);
+	AddAmbientSoundHook(AmbientSHook:OnAmbientSound);
+}
+
+public Action:OnNormalSound(int clients[64], int &numClients, char sample[PLATFORM_MAX_PATH], int &entity, int &channel, float &volume, int &level, int &pitch, int &flags)
+{
+	return (StrContains(sample, "firewerks", true) > -1) ? Plugin_Stop : Plugin_Continue;
+}
+public Action:OnAmbientSound(char sample[PLATFORM_MAX_PATH], int &entity, float &volume, int &level, int &pitch, float pos[3], int &flags, float &delay)
+{
+	return (StrContains(sample, "firewerks", true) > -1) ? Plugin_Stop : Plugin_Continue;
+}


### PR DESCRIPTION
This version of eq_finale_tanks replace bridge_escape_fix.sp, also this with more accurate method blocks escape tanks,

also this version do not make tank counting if map not in tank_map_flow_and_second_event or tank_map_only_first_event (status of spawnScheme  is Skip  in this case but original plugin was do counting that absolutly not need)