### PR TITLE
fix client is not in game error

### DIFF
--- a/addons/sourcemod/scripting/sv_consistency_fix.sp
+++ b/addons/sourcemod/scripting/sv_consistency_fix.sp
@@ -2,7 +2,7 @@
 #include <sourcemod>
 #include <colors>
 
-#define PLUGIN_VERSION "1.3"
+#define PLUGIN_VERSION "1.3.1"
 #define PLUGIN_URL "http://step.l4dnation.com/"
 
 new bool:bTimerCheater[MAXPLAYERS + 1];
@@ -37,12 +37,15 @@ public OnPluginStart()
 
 public Action:Event_PlayerConnectFull(Handle:event, const String:name[], bool:dontBroadcast)
 {
-	CreateTimer(0.1, PrintWhitelist, GetClientOfUserId(GetEventInt(event, "userid")));
+	CreateTimer(0.1, PrintWhitelist, GetEventInt(event, "userid"));
 	return Plugin_Continue;
 }
 
-public Action:PrintWhitelist(Handle:timer, any:client)
+public Action:PrintWhitelist(Handle:timer, any:userid)
 {
+	new client = GetClientOfUserId(userid);
+	if (client == 0 || !IsClientInGame(client) || IsFakeClient(client)) return;
+
 	new String:sMessage[128];
 	GetConVarString(hCvarServerMessage, sMessage, sizeof(sMessage));
 


### PR DESCRIPTION
This PR should fix this error from my logs:
```
L 10/13/2019 - 01:26:54: [SM] Native "PrintToConsole" reported: Client 10 is not in game
L 10/13/2019 - 01:26:54: [SM] Displaying call stack trace for plugin "optional/zonemod/sv_consistency_fix.smx":
L 10/13/2019 - 01:26:54: [SM]   [0]  Line 48, C:\Users\Sir\Documents\NewScripting\sv_consistency_fix.sp::PrintWhitelist()
```