### PR TITLE
fix MaxClients and MAXPLAYERS off by one errors

### DIFF
--- a/addons/sourcemod/scripting/confoglcompmod.sp
+++ b/addons/sourcemod/scripting/confoglcompmod.sp
@@ -3,7 +3,7 @@
 #if defined(AUTOVERSION)
 #include "version.inc"
 #else
-#define PLUGIN_VERSION	"2.2.3"
+#define PLUGIN_VERSION	"2.2.4"
 #endif
 
 #if !defined(DEBUG_ALL)

--- a/addons/sourcemod/scripting/confoglcompmod.sp
+++ b/addons/sourcemod/scripting/confoglcompmod.sp
@@ -3,7 +3,7 @@
 #if defined(AUTOVERSION)
 #include "version.inc"
 #else
-#define PLUGIN_VERSION	"2.2.4"
+#define PLUGIN_VERSION	"2.2.5"
 #endif
 
 #if !defined(DEBUG_ALL)

--- a/addons/sourcemod/scripting/include/l4d2_direct.inc
+++ b/addons/sourcemod/scripting/include/l4d2_direct.inc
@@ -795,7 +795,7 @@ stock Float:L4D2Direct_GetFlowDistance(client)
  */
 stock L4D2Direct_DoAnimationEvent(client, event)
 {
-	if(client <= 0 || client > MaxClients+1)
+	if (client < 1 || client > MaxClients)
 	{
 		return;
 	}

--- a/addons/sourcemod/scripting/l4d2_godframes_control_merge.sp
+++ b/addons/sourcemod/scripting/l4d2_godframes_control_merge.sp
@@ -98,7 +98,7 @@ new Float: fFakeGodframeEnd[MAXPLAYERS + 1];
 new iLastSI[MAXPLAYERS + 1];
 
 //shotgun ff
-new pelletsShot[MAXPLAYERS][MAXPLAYERS];
+new pelletsShot[MAXPLAYERS + 1][MAXPLAYERS + 1];
 
 //frustration
 new frustrationOffset[MAXPLAYERS + 1];
@@ -117,7 +117,7 @@ public Plugin:myinfo =
 {
 	name = "L4D2 Godframes Control combined with FF Plugins",
 	author = "Stabby, CircleSquared, Tabun, Visor, dcx, Sir, Spoon",
-	version = "0.6",
+	version = "0.6.1",
 	description = "Allows for control of what gets godframed and what doesnt along with integrated FF Support from l4d2_survivor_ff (by dcx and Visor) and l4d2_shotgun_ff (by Visor)"
 };
 
@@ -513,7 +513,7 @@ public Action:OnTakeDamage(victim, &attacker, &inflictor, &Float:damage, &damage
 
 stock IsClientAndInGame(client)
 {
-	if (0 < client && client < MaxClients)
+	if (0 < client && client <= MaxClients)
 	{	
 		return IsClientInGame(client);
 	}

--- a/addons/sourcemod/scripting/l4d2_uniform_spit.sp
+++ b/addons/sourcemod/scripting/l4d2_uniform_spit.sp
@@ -42,7 +42,7 @@ public Plugin:myinfo =
     name = "L4D2 Uniform Spit",
     author = "Visor, Sir",
     description = "Make the spit deal a set amount of DPS under all circumstances",
-    version = "1.3",
+    version = "1.3.1",
     url = "https://github.com/Attano/smplugins"
 };
 
@@ -92,8 +92,8 @@ public OnEntityCreated(entity, const String:classname[])
         decl String:trieKey[8];
         IndexToKey(entity, trieKey, sizeof(trieKey));
 
-        new count[MaxClients];
-        SetTrieArray(hPuddles, trieKey, count, MaxClients);
+        new count[MaxClients + 1];
+        SetTrieArray(hPuddles, trieKey, count, MaxClients + 1);
     }
 }
 
@@ -102,8 +102,8 @@ public OnEntityDestroyed(entity)
     decl String:trieKey[8];
     IndexToKey(entity, trieKey, sizeof(trieKey));
 
-    decl count[MaxClients];
-    if (GetTrieArray(hPuddles, trieKey, count, MaxClients))
+    decl count[MaxClients + 1];
+    if (GetTrieArray(hPuddles, trieKey, count, MaxClients + 1))
     {
         RemoveFromTrie(hPuddles, trieKey);
     }
@@ -123,8 +123,8 @@ public Action:OnTakeDamage(victim, &attacker, &inflictor, &Float:damage, &damage
         decl String:trieKey[8];
         IndexToKey(inflictor, trieKey, sizeof(trieKey));
 
-        decl count[MaxClients];
-        if (GetTrieArray(hPuddles, trieKey, count, MaxClients))
+        decl count[MaxClients + 1];
+        if (GetTrieArray(hPuddles, trieKey, count, MaxClients + 1))
         {
             count[victim]++;
 
@@ -135,7 +135,7 @@ public Action:OnTakeDamage(victim, &attacker, &inflictor, &Float:damage, &damage
             }
 
             // Update the array with stored tickcounts
-            SetTrieArray(hPuddles, trieKey, count, MaxClients);
+            SetTrieArray(hPuddles, trieKey, count, MaxClients + 1);
 
             // Let's see what do we have here
             if (damagePerTick > -1.0)

--- a/addons/sourcemod/scripting/modules/EntityRemover.sp
+++ b/addons/sourcemod/scripting/modules/EntityRemover.sp
@@ -337,7 +337,7 @@ public Action:ER_RoundStart_Timer(Handle:timer)
 	if(kERData != INVALID_HANDLE) KvRewind(kERData);
 	
 	new iEntCount = GetEntityCount();
-	for (new ent = MAXPLAYERS+1; ent < iEntCount; ent++)
+	for (new ent = MaxClients+1; ent < iEntCount; ent++)
 	{
 		if (IsValidEntity(ent))
 		{

--- a/addons/sourcemod/scripting/modules/EntityRemover.sp
+++ b/addons/sourcemod/scripting/modules/EntityRemover.sp
@@ -337,7 +337,7 @@ public Action:ER_RoundStart_Timer(Handle:timer)
 	if(kERData != INVALID_HANDLE) KvRewind(kERData);
 	
 	new iEntCount = GetEntityCount();
-	for (new ent = MaxClients+1; ent < iEntCount; ent++)
+	for (new ent = MaxClients+1; ent <= iEntCount; ent++)
 	{
 		if (IsValidEntity(ent))
 		{

--- a/addons/sourcemod/scripting/modules/GhostWarp.sp
+++ b/addons/sourcemod/scripting/modules/GhostWarp.sp
@@ -110,7 +110,7 @@ GW_FindNextSurvivor(client,charz)
 		charz = 0;
 	}
 	
-	for(new index = charz;index<MaxClients;index++)
+	for(new index = charz;index<=MaxClients;index++)
 	{
 		if (index >= NUM_OF_SURVIVORS)
 		{

--- a/addons/sourcemod/scripting/modules/ItemTracking.sp
+++ b/addons/sourcemod/scripting/modules/ItemTracking.sp
@@ -240,7 +240,7 @@ static KillRegisteredItems()
 {
 	decl ItemList:itemindex;
 	new psychonic = GetEntityCount();
-	for(new i =0; i < psychonic; i++)
+	for(new i =0; i <= psychonic; i++)
 	{
 		if(IsValidEntity(i))
 		{
@@ -307,7 +307,7 @@ static EnumerateSpawns()
 	new ItemList:itemindex;
 	decl curitem[ItemTracking], Float:origins[3], Float:angles[3];
 	new psychonic = GetEntityCount();
-	for(new i =0; i < psychonic; i++)
+	for(new i =0; i <= psychonic; i++)
 	{
 		if(IsValidEntity(i))
 		{

--- a/addons/sourcemod/scripting/modules/MapInfo.sp
+++ b/addons/sourcemod/scripting/modules/MapInfo.sp
@@ -16,8 +16,8 @@ static Float:Start_Extra_Dist;
 static Float:End_Dist;
 
 static iMapMaxDistance;
-static iIsInEditMode[MAXPLAYERS];
-static Float:fLocTemp[MAXPLAYERS][3];
+static iIsInEditMode[MAXPLAYERS + 1];
+static Float:fLocTemp[MAXPLAYERS + 1][3];
 
 public MI_OnModuleStart()
 {
@@ -49,7 +49,7 @@ public MI_OnMapEnd()
 {
 	KvRewind(kMIData);
 	MapDataAvailable = false;
-	for (new i; i < MAXPLAYERS; i++) iIsInEditMode[i] = 0;
+	for (new i; i <= MAXPLAYERS; i++) iIsInEditMode[i] = 0;
 }
 
 public MI_OnModuleEnd()
@@ -60,7 +60,7 @@ public MI_OnModuleEnd()
 public PlayerDisconnect_Event(Handle:event, const String:name[], bool:dontBroadcast)
 {
 	new client = GetClientOfUserId(GetEventInt(event, "userid"));
-	if (client > -1 && client < MAXPLAYERS) iIsInEditMode[client] = 0;
+	if (client > -1 && client <= MAXPLAYERS) iIsInEditMode[client] = 0;
 }
 
 public Action:MI_KV_CmdSave(client, args)

--- a/addons/sourcemod/scripting/modules/PasswordSystem.sp
+++ b/addons/sourcemod/scripting/modules/PasswordSystem.sp
@@ -121,7 +121,7 @@ PS_SetPasswordOnClients()
 	decl String:pwbuffer[128];
 	GetConVarString(PS_hPassword,pwbuffer,128);
 	
-	for(new client = 1;client<MaxClients;client++)
+	for(new client = 1;client<=MaxClients;client++)
 	{
 		if(!IsClientInGame(client) || IsFakeClient(client)){continue;}
 		LogMessage("Set password on %N, password %s",client,pwbuffer);

--- a/addons/sourcemod/scripting/modules/SI_Targeting.sp
+++ b/addons/sourcemod/scripting/modules/SI_Targeting.sp
@@ -1,7 +1,7 @@
 #include "includes/hardcoop_util.sp"
 
 new Handle:arraySurvivors; // dynamic array holding only the survivor entity IDs
-new targetSurvivor[MAXPLAYERS]; // survivor target of each special infected
+new targetSurvivor[MAXPLAYERS + 1]; // survivor target of each special infected
 
 public SI_TargetingModule_Start() 
 {
@@ -23,7 +23,7 @@ public SI_TargetingModule_Start()
 RefreshTargets() {
 	// Refresh survivor array
 	ClearArray(arraySurvivors);
-	for (new i = 1; i < MaxClients; i++) 
+	for (new i = 1; i <= MaxClients; i++)
 	{
 		if (IsSurvivor(i)) {
 			PushArrayCell(arraySurvivors, i);
@@ -31,7 +31,7 @@ RefreshTargets() {
 	}
 	 
 	// Assign targets
-	for (new i = 1; i < MaxClients; i++) 
+	for (new i = 1; i <= MaxClients; i++)
 	{
 		if (IsBotCapper(i) && IsPlayerAlive(i)) {
 			targetSurvivor[i] = GetTargetSurvivor();


### PR DESCRIPTION
These are all cases where MAXPLAYERS and MaxClients are used to create client arrays or they're used in a loop involving a client index or being compared to a client index.

For the one change in `addons/sourcemod/scripting/modules/EntityRemover.sp`, I referred to this [alliedmodders post](https://forums.alliedmods.net/showpost.php?p=1710686&postcount=11) to determine that the loop in is starting off with the wrong index.