### PR TITLE
execute sm_spechud for casters joining the server

### DIFF
--- a/addons/sourcemod/scripting/caster_assister.sp
+++ b/addons/sourcemod/scripting/caster_assister.sp
@@ -2,14 +2,18 @@
 
 #include <sourcemod>
 #include <sdktools>
+#undef REQUIRE_PLUGIN
+#include <readyup>
 #define MAX_SPEED 2
+
+new bool:readyUpIsAvailable;
 
 public Plugin:myinfo =
 {
     name = "Caster Assister",
     author = "CanadaRox, Sir",
     description = "Allows spectators to control their own specspeed and move vertically",
-    version = "2.1",
+    version = "2.2",
     url = ""
 };
 
@@ -26,6 +30,35 @@ public OnPluginStart()
     RegConsoleCmd("sm_set_vertical_increment", SetVerticalIncrement_Cmd);
 
     HookEvent("player_team", PlayerTeam_Event);
+}
+
+public OnAllPluginsLoaded()
+{
+    readyUpIsAvailable = LibraryExists("readyup");
+}
+
+public OnLibraryRemoved(const String:name[])
+{
+    if (StrEqual(name, "readyup"))
+    {
+        readyUpIsAvailable = false;
+    }
+}
+
+public OnLibraryAdded(const String:name[])
+{
+    if (StrEqual(name, "readyup"))
+    {
+        readyUpIsAvailable = true;
+    }
+}
+
+public OnClientPutInServer(client)
+{
+    if (readyUpIsAvailable && IsClientCaster(client))
+    {
+        FakeClientCommand(client, "sm_spechud");
+    }
 }
 
 public PlayerTeam_Event(Handle:event, const String:name[], bool:dontBroadcast)


### PR DESCRIPTION
This feature existed in [caster_assister v1.0.1](https://github.com/SirPlease/ZoneMod/blob/e44044669636af8cc7797f4897d0184a0b021f27/addons/sourcemod/plugins/optional/zonemod/caster_assister.smx) before the recent crash exploit fix in v2.1. I think this was removed unintentionally so this PR adds it back.

Also, [Server4Dead-Project](https://github.com/SirPlease/Server4Dead-Project/blob/master/Competitive%20Configs/addons/sourcemod/plugins/optional/zonemod/caster_assister.smx) never got updated with the crash exploit fix like the ZoneMod repo did, so it's still using version 1.0.1.