### PR TITLE
Map fixes (Dark Carnival 2-4, The Parish 2-3)

### DIFF
--- a/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
+++ b/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
@@ -1492,7 +1492,7 @@ add:
 	"normal.x" "0.00"
 	"team" "2"
 	"classname" "func_simpleladder"
-	"origin" "-2877.82 3453.54 -12.63"
+	"origin" "-2856.82 3294 -12.63"
 	"angles" "0.00 0.00 0.00"
 }
 ; -- Add Infected ladder near saferoom (2/2)

--- a/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
+++ b/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
@@ -1492,7 +1492,7 @@ add:
 	"normal.x" "0.00"
 	"team" "2"
 	"classname" "func_simpleladder"
-	"origin" "-2856.82 3294 -12.63"
+	"origin" "-2856.82 3294 0"
 	"angles" "0.00 0.00 0.00"
 }
 ; -- Add Infected ladder near saferoom (2/2)

--- a/cfg/stripper/zonemod/maps/c2m3_coaster.cfg
+++ b/cfg/stripper/zonemod/maps/c2m3_coaster.cfg
@@ -756,12 +756,12 @@ add:
 	"classname" "env_physics_blocker"
 }
 
-; --- block a way to skip the last half of the coaster
+; --- block a way to skip the last half of the coaster - extended for both sides
 
 {
-	"origin" "-3848 1976 72"
-	"mins" "-10 -10 -72"
-	"maxs" "10 10 72"
+	"origin" "-3904 1976 72"
+	"mins" "-66 -10 -72"
+	"maxs" "66 10 72"
 	"initialstate" "1"
 	"BlockType" "1"
 	"classname" "env_physics_blocker"
@@ -897,6 +897,51 @@ add:
 	"origin" "-3910 896 289"
 	"mins" "-69.5 -237 -145.5"
 	"maxs" "69.5 237 145.5"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
+; --- Block jumping on shelves at tunnel of love exit
+{
+	"origin" "-664 2016 96"
+	"mins" "-80 -33.5 -96"
+	"maxs" "80 33.5 96"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
+; --- Block jumping on truck before coaster and walking on roof trimming
+{
+	"origin" "-1327 1984 481"
+	"mins" "-46 -44 -479"
+	"maxs" "46 44 479"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
+{
+	"origin" "-1477 1986 557"
+	"mins" "-119.5 -58.5 -403.5"
+	"maxs" "119.5 58.5 403.5"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
+{
+	"origin" "-1366 1938 481"
+	"angles" "0 40 0"
+	"boxmins" "-12 -4 -479"
+	"boxmaxs" "12 4 479"
+	"mins" "-12 -4 -479"
+	"maxs" "12 4 479"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
+{
+	"origin" "-1536 2046 561"
+	"mins" "-260 -2 -399.5"
+	"maxs" "260 2 399.5"
 	"initialstate" "1"
 	"BlockType" "1"
 	"classname" "env_physics_blocker"

--- a/cfg/stripper/zonemod/maps/c2m4_barns.cfg
+++ b/cfg/stripper/zonemod/maps/c2m4_barns.cfg
@@ -413,6 +413,15 @@ add:
 	"BlockType" "1"
 	"classname" "env_physics_blocker"
 }
+; --- block jump on shelves after bumper cars
+{
+	"origin" "1039 1224 -74"
+	"mins" "-33 -80 -74"
+	"maxs" "33 80 74"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
 ; --- block top of hedge near dumpsters
 {
 	; invisible block above hedge

--- a/cfg/stripper/zonemod/maps/c5m2_park.cfg
+++ b/cfg/stripper/zonemod/maps/c5m2_park.cfg
@@ -586,6 +586,24 @@ add:
 	"BlockType" "1"
 	"classname" "env_physics_blocker"
 }
+;Block tickrate jump on filing cabinets at event
+add:
+{
+	"origin" "-6589 -5725 -189"
+	"mins" "-6.5 -57 -68"
+	"maxs" "6.5 57 68"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
+{
+	"origin" "-6826 -5785.5 -189"
+	"mins" "-57 -6.5 -68"
+	"maxs" "57 6.5 68"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
 
 ; =====================================================
 ; ================  NUISANCE CHANGES  =================

--- a/cfg/stripper/zonemod/maps/c5m3_cemetery.cfg
+++ b/cfg/stripper/zonemod/maps/c5m3_cemetery.cfg
@@ -398,6 +398,14 @@ add:
 	"BlockType" "1"
 	"classname" "env_physics_blocker"
 }
+{
+	"origin" "4660 4156 480"
+	"mins" "-196 -212 -160"
+	"maxs" "196 212 160"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
 
 ; =====================================================
 ; ================  NUISANCE CHANGES  =================

--- a/cfg/stripper/zonemod/maps/c5m3_cemetery.cfg
+++ b/cfg/stripper/zonemod/maps/c5m3_cemetery.cfg
@@ -367,6 +367,37 @@ add:
 	"BlockType" "0"
 	"classname" "env_physics_blocker"
 }
+;Block shack roof and jump onto electrical box
+{
+	"origin" "4802 3750 320"
+	"mins" "-30.5 -5.5 -320"
+	"maxs" "30.5 5.5 320"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
+{
+	"origin" "4658 4057 229"
+	"angles" "0 0 -6.5"
+	"boxmins" "-185 -103 -74.5"
+	"boxmaxs" "185 103 74.5"
+	"mins" "-185 -103 -74.5"
+	"maxs" "185 103 74.5"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
+{
+	"origin" "4633 4255 218"
+	"angles" "0 0 -6"
+	"boxmins" "-142.5 -98 -87.5"
+	"boxmaxs" "142.5 98 87.5"
+	"mins" "-142.5 -98 -87.5"
+	"maxs" "142.5 98 87.5"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
 
 ; =====================================================
 ; ================  NUISANCE CHANGES  =================
@@ -376,6 +407,24 @@ filter:
 ; --- remove barrels due to exploit potential
 {
 	"model" "models/props_urban/oil_drum001.mdl"
+}
+;Clipping to prevent getting stuck on draped bodies before sewers
+add:
+{
+	"origin" "3249 1715 5"
+	"mins" "-40.5 -46 -6"
+	"maxs" "40.5 46 6"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
+}
+{
+	"origin" "3186 1722 5"
+	"mins" "-22.5 -30.5 -6"
+	"maxs" "22.5 30.5 6"
+	"initialstate" "1"
+	"BlockType" "1"
+	"classname" "env_physics_blocker"
 }
 
 ; =====================================================


### PR DESCRIPTION
c2m3:
Extended clip to block jump at end of coaster to both sides
Blocked jumping on shelves at tunnel of love exit
Blocked jumping on the truck before coaster and walking on the roof trim

c2m4:
Blocked jumping on shelves after bumper cars

c5m2:
Blocked tickrate jump on filing cabinets at event, also blocks common jump/bhop methods
Does not prevent access to shelves entirely, e.g. punched up there by tank, just blocks the only methods of intentionally getting on them

c5m3:
Blocked the jump onto the electrical box, and blocked the shack roof completely as there are multiple other ways to access it
Improved clipping on draped dead bodies before the sewer drop area to prevent getting stuck when walking over them

c2m2:
Moved infected ladder outside start saferoom to be more visible and not stop survivors running alongside the wall