### PR TITLE
Add new parameter in GetMissionVersusBossSpawning

### DIFF
--- a/addons/sourcemod/gamedata/left4dhooks.l4d2.txt
+++ b/addons/sourcemod/gamedata/left4dhooks.l4d2.txt
@@ -369,6 +369,10 @@
 					{
 						"type"	"objectptr"
 					}
+					"a5"
+					{
+						"type"	"objectptr"
+					}
 				}
 			}
 


### PR DESCRIPTION
This seems to work fine as is, but according to asherkin it could cause bugs crashes. This adds support for the new `bool& allow_boss_mix` parameter on `CDirector::GetMissionVersusBossSpawning`.

SilverS was reporting this change as well. I'm sure we'll eventually pull in his official gamedata but I thought I'd open this just in case we need to fix more crashes soon