### PR TITLE
add si fire immunity source

### DIFF
--- a/addons/sourcemod/scripting/si_fire_immunity.sp
+++ b/addons/sourcemod/scripting/si_fire_immunity.sp
@@ -4,64 +4,85 @@
 #include <sdktools>
 
 new Handle:infected_fire_immunity;
+new Handle:tank_fire_immunity;
 new bool:inWait[MAXPLAYERS + 1] = false;
 
 public Plugin:myinfo = 
 {
     name = "SI Fire Immunity",
-    author = "Jacob",
+    author = "Jacob, darkid",
     description = "Special Infected fire damage management.",
-    version = "2.0",
+    version = "2.3",
     url = "github.com/jacob404/myplugins"
 }
 
 public OnPluginStart()
 {
-	infected_fire_immunity = CreateConVar("infected_fire_immunity", "0", "What type of fire immunity should infected have? 0 = None, 3 = Extinguish burns, 2 = Prevent burns, 1 = Complete immunity", FCVAR_PLUGIN, true, 0.0, true, 3.0);
+	infected_fire_immunity = CreateConVar("infected_fire_immunity", "3", "What type of fire immunity should infected have? 0 = None, 3 = Extinguish burns, 2 = Prevent burns, 1 = Complete immunity", FCVAR_PLUGIN, true, 0.0, true, 3.0);
+	tank_fire_immunity = CreateConVar("tank_fire_immunity", "2", "What type of fire immunity should the tank have? 0 = None, 3 = Extinguish burns, 2 = Prevent burns, 1 = Complete immunity", FCVAR_PLUGIN, true, 0.0, true, 3.0);
 	HookEvent("player_hurt",SIOnFire);
 }
 
-public OnMapStart()
-{
-	for(new i = 1; i < MaxClients+1; i++)
-	{
-		inWait[i] = false;
-	}
-}
-
-public Action:SIOnFire(Handle:event, const String:name[], bool:dontBroadcast)
+public SIOnFire(Handle:event, const String:name[], bool:dontBroadcast)
 {
     new client = GetClientOfUserId(GetEventInt(event, "userid"));
-    if(IsValidClient(client) && (GetClientTeam(client) == 3) && GetEventInt(event,"type") == 8)
+
+	if (!IsValidClient(client) || !(GetClientTeam(client) == 3))
+		return;
+
+	decl String:weapon[64];
+	GetEventString(event, "weapon", weapon, 64);
+	new attacker = GetEventInt(event, "attacker");
+
+	if (strcmp(weapon, "inferno") == 0 || attacker == 0 || strcmp(weapon, "entityflame") == 0)
 	{
-		if(GetEntProp(client, Prop_Send, "m_zombieClass") == 8) ExtinguishEntity(client);
-
-		if(GetConVarInt(infected_fire_immunity) == 3) CreateTimer(1.0, Extinguish, client);
-
-		if(GetConVarInt(infected_fire_immunity) <= 2) ExtinguishEntity(client);
-		
-		if(GetConVarInt(infected_fire_immunity) == 1)
+		if(GetEntProp(client, Prop_Send, "m_zombieClass") == 8)
 		{
-			new CurHealth = GetClientHealth(client);
-			new DmgDone	= GetEventInt(event,"dmg_health");
-			SetEntityHealth(client,(CurHealth + DmgDone));
+			if (GetConVarInt(tank_fire_immunity) == 3)
+			{
+				CreateTimer(1.0, Extinguish, client);
+			}
+			if (GetConVarInt(tank_fire_immunity) <= 2)
+			{
+				ExtinguishEntity(client);
+			}
+			if (GetConVarInt(tank_fire_immunity) == 1)
+			{
+				new CurHealth = GetClientHealth(client);
+				new DmgDone = GetEventInt(event, "dmg_health");
+				SetEntityHealth(client,(CurHealth + DmgDone));
+			}
+		}
+		else
+		{
+			if(GetConVarInt(infected_fire_immunity) == 3) CreateTimer(1.0, Extinguish, client);
+
+			if(GetConVarInt(infected_fire_immunity) <= 2) ExtinguishEntity(client);
+			
+			if(GetConVarInt(infected_fire_immunity) == 1)
+			{
+				new CurHealth = GetClientHealth(client);
+				new DmgDone	= GetEventInt(event,"dmg_health");
+				SetEntityHealth(client,(CurHealth + DmgDone));
+			}
 		}
 	}
 }
  
 public Action:Extinguish(Handle:timer, any:client)
 {
-    if(!inWait[client])
+    if(IsValidClient(client) && !inWait[client])
     {
         ExtinguishEntity(client);
         inWait[client] = true;
-        CreateTimer(0.9, ExtinguishWait, client);
+        CreateTimer(1.2, ExtinguishWait, client);
     }
 }
 
 public Action:ExtinguishWait(Handle:timer, any:client)
 {
-   inWait[client] = false;
+	if (IsValidClient(client))
+		inWait[client] = false;
 }
 
 stock bool:IsValidClient(client, bool:nobots = true)

--- a/addons/sourcemod/scripting/si_fire_immunity.sp
+++ b/addons/sourcemod/scripting/si_fire_immunity.sp
@@ -1,0 +1,74 @@
+#pragma semicolon 1
+
+#include <sourcemod>
+#include <sdktools>
+
+new Handle:infected_fire_immunity;
+new bool:inWait[MAXPLAYERS + 1] = false;
+
+public Plugin:myinfo = 
+{
+    name = "SI Fire Immunity",
+    author = "Jacob",
+    description = "Special Infected fire damage management.",
+    version = "2.0",
+    url = "github.com/jacob404/myplugins"
+}
+
+public OnPluginStart()
+{
+	infected_fire_immunity = CreateConVar("infected_fire_immunity", "0", "What type of fire immunity should infected have? 0 = None, 3 = Extinguish burns, 2 = Prevent burns, 1 = Complete immunity", FCVAR_PLUGIN, true, 0.0, true, 3.0);
+	HookEvent("player_hurt",SIOnFire);
+}
+
+public OnMapStart()
+{
+	for(new i = 1; i < MaxClients+1; i++)
+	{
+		inWait[i] = false;
+	}
+}
+
+public Action:SIOnFire(Handle:event, const String:name[], bool:dontBroadcast)
+{
+    new client = GetClientOfUserId(GetEventInt(event, "userid"));
+    if(IsValidClient(client) && (GetClientTeam(client) == 3) && GetEventInt(event,"type") == 8)
+	{
+		if(GetEntProp(client, Prop_Send, "m_zombieClass") == 8) ExtinguishEntity(client);
+
+		if(GetConVarInt(infected_fire_immunity) == 3) CreateTimer(1.0, Extinguish, client);
+
+		if(GetConVarInt(infected_fire_immunity) <= 2) ExtinguishEntity(client);
+		
+		if(GetConVarInt(infected_fire_immunity) == 1)
+		{
+			new CurHealth = GetClientHealth(client);
+			new DmgDone	= GetEventInt(event,"dmg_health");
+			SetEntityHealth(client,(CurHealth + DmgDone));
+		}
+	}
+}
+ 
+public Action:Extinguish(Handle:timer, any:client)
+{
+    if(!inWait[client])
+    {
+        ExtinguishEntity(client);
+        inWait[client] = true;
+        CreateTimer(0.9, ExtinguishWait, client);
+    }
+}
+
+public Action:ExtinguishWait(Handle:timer, any:client)
+{
+   inWait[client] = false;
+}
+
+stock bool:IsValidClient(client, bool:nobots = true)
+{ 
+    if (client <= 0 || client > MaxClients || !IsClientConnected(client) || (nobots && IsFakeClient(client)))
+    {
+        return false; 
+    }
+    return IsClientInGame(client); 
+}  


### PR DESCRIPTION
Source I started with from https://github.com/Attano/L4D2-Competitive-Framework/blob/master/addons/sourcemod/scripting/si_fire_immunity.sp

I've been basing reconstructions off of decompilation comparisons generated using [lysis decompiler](https://github.com/peace-maker/lysis-java). The decompiler has some bugs that don't always give a correct interpretation of logic chains resulting in ambiguous output. I haven't seen this come up in previous plugin reconstructions, but this time I did with this line from the decompilation, which clearly isn't how the original source is supposed to look:
```
if (strcmp(weapon, "inferno", true) && attacker && strcmp(weapon, "entityflame", true))
```

I dug in deeper with this tool that lets you see the raw instructions https://peace-maker.github.io/sourcepawn-disassembler-web
and found that it needed to be changed to
```if (strcmp(weapon, "inferno") == 0 || attacker == 0 || strcmp(weapon, "entityflame") == 0)``` (lysis incorrectly decompiles this to the same line as before)
to match the current plugin smx
The compiled plugin reconstruction ends up being the same byte for byte as the original except for the compiler version (1.6.3 vs 1.6.2) and compile date, so the reconstruction should be correct.