### PR TITLE
More reconstructed plugins sources

### DIFF
--- a/addons/sourcemod/scripting/changelog.sp
+++ b/addons/sourcemod/scripting/changelog.sp
@@ -1,0 +1,28 @@
+#pragma semicolon 1
+
+#include <sourcemod>
+#include <colors>
+
+public Plugin:myinfo =
+{
+	name = "L4D2 Change Log Command",
+	description = "Does things :)",
+	author = "Spoon",
+	version = "3.0.5",
+	url = "https://github.com/spoon-l4d2/"
+};
+
+new Handle:linkCVar;
+
+public OnPluginStart()
+{
+	linkCVar = CreateConVar("l4d2_cl_link", "https://github.com/spoon-l4d2/NextMod", "The to your change log");
+	RegConsoleCmd("sm_changelog", ChangeLog_CMD);
+}
+
+public Action:ChangeLog_CMD(client, args)
+{
+	new String:link[128];
+	GetConVarString(linkCVar, link, sizeof(link));
+	CPrintToChat(client, "{blue}[{green}ChangeLog{blue}]{default} You can view the change log @ {blue}%s", link);
+}

--- a/addons/sourcemod/scripting/l4d2_antimelee.sp
+++ b/addons/sourcemod/scripting/l4d2_antimelee.sp
@@ -1,0 +1,80 @@
+#pragma semicolon 1
+
+#include <sourcemod>
+#include <sdkhooks>
+#include <sdktools>
+
+new Handle:hCvarMeleeNerfPercentage;
+new bool:lateLoad;
+
+public Plugin:myinfo =
+{
+	name = "L4D2 AntiMelee",
+	description = "Nerfes melee damage against tanks by a set amount of %",
+	author = "Visor",
+	version = "1.0",
+	url = "https://github.com/Attano/L4D2-Competitive-Framework"
+};
+
+public APLRes:AskPluginLoad2(Handle:plugin, bool:late, String:error[], errMax)
+{
+	lateLoad = late;
+	return APLRes_Success;
+}
+
+public OnPluginStart()
+{
+	hCvarMeleeNerfPercentage = CreateConVar("l4d2_melee_tank_nerf", "0", "Percentage of melee damage nerf against tank", FCVAR_CHEAT|FCVAR_NOTIFY, true, 0.0, true, 100.0);
+	if (lateLoad)
+	{
+		for (new i = 1; i <= MaxClients; i++) 
+		{
+			if (IsClientInGame(i))
+			{
+				OnClientPutInServer(i);
+			}
+		}
+	}
+}
+
+public OnClientPutInServer(client)
+{
+	SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamage);
+}
+
+public OnClientDisconnect(client)
+{
+	SDKUnhook(client, SDKHook_OnTakeDamage, OnTakeDamage);
+}
+
+public Action:OnTakeDamage(victim, &attacker, &inflictor, &Float:damage, &damageType, &weapon, Float:damageForce[3], Float:damagePosition[3])
+{
+	if (!IsSurvivor(attacker) || !IsTank(victim) || !IsMelee(weapon))
+	{
+		return Plugin_Continue;
+	}
+	damage = damage / 100.0 * (100.0 - GetConVarFloat(hCvarMeleeNerfPercentage));
+	return Plugin_Changed;
+}
+
+bool:IsMelee(entity)
+{
+	if (entity > 0 && IsValidEntity(entity) && IsValidEdict(entity))
+	{
+		decl String:strClassName[64];
+		GetEdictClassname(entity, strClassName, 64);
+		return StrContains(strClassName, "melee", false) != -1;
+	}
+	return false;
+}
+
+bool:IsSurvivor(client)
+{
+	return client > 0 && client <= MaxClients && IsClientInGame(client) && GetClientTeam(client) == 2;
+}
+
+bool:IsTank(client)
+{
+	return client > 0 && client <= MaxClients && IsClientInGame(client) && GetClientTeam(client) == 3 && GetEntProp(client, Prop_Send, "m_zombieClass", 4, 0) == 8;
+}
+

--- a/addons/sourcemod/scripting/l4d2_byedoor.sp
+++ b/addons/sourcemod/scripting/l4d2_byedoor.sp
@@ -1,0 +1,37 @@
+#pragma semicolon 1
+
+#include <sourcemod>
+#include <sdktools>
+
+public Plugin:myinfo =
+{
+	name = "Byebye Door",
+	description = "Time to kill Saferoom Doors.",
+	author = "Sir",
+	version = "1.0",
+	url = ""
+};
+
+public OnPluginStart()
+{
+	HookEvent("round_start", Event_RoundStart, EventHookMode_Post);
+}
+
+public Action:Event_RoundStart(Handle:event, String:name[], bool:dontBroadcast)
+{
+	new EntityCount = GetEntityCount();
+	new String:EdictClassName[128];
+	for (new i = 0; i <= EntityCount; i++)
+	{
+		if (IsValidEntity(i))
+		{
+			GetEdictClassname(i, EdictClassName, 128);
+			if (StrContains(EdictClassName, "prop_door_rotating_checkpoint", false) != -1 && GetEntProp(i, Prop_Send, "m_bLocked", 4) == 1)
+			{
+				AcceptEntityInput(i, "Kill", -1, -1, 0);
+				return Plugin_Continue;
+			}
+		}
+	}
+}
+

--- a/addons/sourcemod/scripting/l4d2_smg_reload_tweak.sp
+++ b/addons/sourcemod/scripting/l4d2_smg_reload_tweak.sp
@@ -1,0 +1,99 @@
+#pragma semicolon 1
+
+#include <sourcemod>
+#include <sdktools>
+#include <l4d2_weapon_stocks>
+
+new Handle:hCvarReloadSpeedUzi;
+new Handle:hCvarReloadSpeedSilencedSmg;
+
+public Plugin:myinfo =
+{
+	name = "L4D2 SMG Reload Speed Tweaker",
+	description = "Allows cvar'd control over the reload durations for both types of SMG",
+	author = "Visor",
+	version = "1.1",
+	url = "https://github.com/Attano/L4D2-Competitive-Framework"
+};
+
+public OnPluginStart()
+{
+	hCvarReloadSpeedUzi = CreateConVar("l4d2_reload_speed_uzi", "0", "Reload duration of Uzi(normal SMG)", FCVAR_CHEAT|FCVAR_NOTIFY, true, 0.0, true, 10.0);
+	hCvarReloadSpeedSilencedSmg = CreateConVar("l4d2_reload_speed_silenced_smg", "0", "Reload duration of Silenced SMG", FCVAR_CHEAT|FCVAR_NOTIFY, true, 0.0, true, 10.0);
+	HookEvent("weapon_reload", OnWeaponReload, EventHookMode_Post);
+}
+
+public OnWeaponReload(Handle:event, String:name[], bool:dontBroadcast)
+{
+	new client = GetClientOfUserId(GetEventInt(event, "userid"));
+
+	if (!IsSurvivor(client) || !IsPlayerAlive(client) || IsFakeClient(client))
+		return;
+
+	new Float:originalReloadDuration = 0.0;
+	new Float:alteredReloadDuration = 0.0;
+	new weapon = GetPlayerWeaponSlot(client, 0);
+	new WeaponId:weaponId = IdentifyWeapon(weapon);
+	if (weaponId == WEPID_SMG)
+	{
+		originalReloadDuration = 2.235352;
+		alteredReloadDuration = GetConVarFloat(hCvarReloadSpeedUzi);
+	}
+	else if (weaponId == WEPID_SMG_SILENCED)
+	{
+		originalReloadDuration = 2.235291;
+		alteredReloadDuration = GetConVarFloat(hCvarReloadSpeedSilencedSmg);
+	}
+	else
+	{
+		return;
+	}
+
+	if (alteredReloadDuration <= 0.0)
+	{
+		return;
+	}
+
+	new Float:oldNextAttack = GetEntPropFloat(weapon, Prop_Send, "m_flNextPrimaryAttack", 0);
+	new Float:newNextAttack = oldNextAttack - originalReloadDuration + alteredReloadDuration;
+	new Float:playbackRate = originalReloadDuration / alteredReloadDuration;
+	SetEntPropFloat(weapon, Prop_Send, "m_flNextPrimaryAttack", newNextAttack);
+	SetEntPropFloat(client, Prop_Send, "m_flNextAttack", newNextAttack);
+	SetEntPropFloat(weapon, Prop_Send, "m_flPlaybackRate", playbackRate);
+}
+
+public Action:OnPlayerRunCmd(client, &buttons)
+{
+	if (!(buttons & IN_ATTACK2))
+		return Plugin_Continue;
+
+	if (!IsSurvivor(client) || !IsPlayerAlive(client) || IsFakeClient(client))
+		return Plugin_Continue;
+
+	new Float:originalReloadDuration = 0.0;
+	new Float:alteredReloadDuration = 0.0;
+	new weapon = GetPlayerWeaponSlot(client, 0);
+	new WeaponId:weaponId = IdentifyWeapon(weapon);
+	if (weaponId == WEPID_SMG)
+	{
+		originalReloadDuration = 2.235352;
+		alteredReloadDuration = GetConVarFloat(hCvarReloadSpeedUzi);
+	}
+	else if (weaponId == WEPID_SMG_SILENCED)
+	{
+		originalReloadDuration = 2.235291;
+		alteredReloadDuration = GetConVarFloat(hCvarReloadSpeedSilencedSmg);
+	}
+	else
+	{
+		return Plugin_Continue;
+	}
+	new Float:playbackRate = originalReloadDuration / alteredReloadDuration;
+	SetEntPropFloat(weapon, Prop_Send, "m_flPlaybackRate", playbackRate);
+}
+
+bool:IsSurvivor(client)
+{
+	return client > 0 && client <= MaxClients && IsClientInGame(client) && GetClientTeam(client) == 2;
+}
+

--- a/addons/sourcemod/scripting/l4d2_smoker_drag_damage_interval_zone.sp
+++ b/addons/sourcemod/scripting/l4d2_smoker_drag_damage_interval_zone.sp
@@ -1,0 +1,75 @@
+#pragma semicolon 1
+
+#include <sourcemod>
+
+new Handle:tongue_drag_damage_interval;
+
+public Plugin:myinfo =
+{
+	name = "L4D2 Smoker Drag Damage Interval",
+	author = "Visor",
+	description = "Implements a native-like cvar that should've been there out of the box",
+	version = "0.6",
+	url = "https://github.com/Attano/Equilibrium"
+};
+
+public OnPluginStart()
+{
+	HookEvent("tongue_grab", OnTongueGrab);
+
+	new String:value[32];
+	GetConVarString(FindConVar("tongue_choke_damage_interval"), value, sizeof(value));
+	tongue_drag_damage_interval = CreateConVar("tongue_drag_damage_interval", value, "How often the drag does damage.");
+	
+	HookConVarChange(FindConVar("tongue_choke_damage_amount"), tongue_choke_damage_amount_ValueChanged);
+}
+
+public tongue_choke_damage_amount_ValueChanged(Handle:convar, const String:oldValue[], const String:newValue[])
+{
+	SetConVarInt(convar, 1); // hack-hack: game tries to change this cvar for some reason, can't be arsed so HARDCODETHATSHIT
+}
+
+public OnTongueGrab(Handle:event, const String:name[], bool:dontBroadcast)
+{
+	new client = GetClientOfUserId(GetEventInt(event, "victim"));
+	
+	UpdateDragDamageInterval(client);
+	
+	CreateTimer(
+			GetConVarFloat(tongue_drag_damage_interval) + 0.1, 
+			FixDragInterval, 
+			client, 
+			TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE
+	);
+}
+
+public Action:FixDragInterval(Handle:timer, any:client)
+{
+	if (!IsSurvivor(client) || !IsSurvivorBeingDragged(client))
+	{
+		return Plugin_Stop;
+	}
+
+	UpdateDragDamageInterval(client);
+	return Plugin_Continue;
+}
+
+UpdateDragDamageInterval(client)
+{
+	SetEntDataFloat(client, 13352, (GetGameTime() + GetConVarFloat(tongue_drag_damage_interval)));
+}
+
+bool:IsSurvivorBeingDragged(client)
+{
+	return ((GetEntData(client, 13284) > 0) && !IsSurvivorBeingChoked(client));
+}
+
+bool:IsSurvivorBeingChoked(client)
+{
+	return (GetEntData(client, 13308) > 0);
+}
+
+bool:IsSurvivor(client)
+{
+	return (client > 0 && client <= MaxClients && IsClientInGame(client) && GetClientTeam(client) == 2);
+}

--- a/addons/sourcemod/scripting/l4d2_smoker_drag_damage_interval_zone.sp
+++ b/addons/sourcemod/scripting/l4d2_smoker_drag_damage_interval_zone.sp
@@ -1,15 +1,19 @@
 #pragma semicolon 1
 
 #include <sourcemod>
+#include <sdkhooks>
+#include <colors>
 
 new Handle:tongue_drag_damage_interval;
+new Handle:tongue_drag_first_damage_interval;
+new Handle:tongue_drag_first_damage;
 
 public Plugin:myinfo =
 {
 	name = "L4D2 Smoker Drag Damage Interval",
-	author = "Visor",
+	author = "Visor, Sir",
 	description = "Implements a native-like cvar that should've been there out of the box",
-	version = "0.6",
+	version = "0.7",
 	url = "https://github.com/Attano/Equilibrium"
 };
 
@@ -20,7 +24,9 @@ public OnPluginStart()
 	new String:value[32];
 	GetConVarString(FindConVar("tongue_choke_damage_interval"), value, sizeof(value));
 	tongue_drag_damage_interval = CreateConVar("tongue_drag_damage_interval", value, "How often the drag does damage.");
-	
+	tongue_drag_first_damage_interval = CreateConVar("tongue_drag_first_damage_interval", "0.0", "After how many seconds do we apply our first tick of damage? | 0.0 to Disable.");
+	tongue_drag_first_damage = CreateConVar("tongue_drag_first_damage", "3.0", "How much damage do we apply on the first tongue hit? | Only applies when first_damage_interval is used");
+
 	HookConVarChange(FindConVar("tongue_choke_damage_amount"), tongue_choke_damage_amount_ValueChanged);
 }
 
@@ -32,15 +38,44 @@ public tongue_choke_damage_amount_ValueChanged(Handle:convar, const String:oldVa
 public OnTongueGrab(Handle:event, const String:name[], bool:dontBroadcast)
 {
 	new client = GetClientOfUserId(GetEventInt(event, "victim"));
-	
-	UpdateDragDamageInterval(client);
-	
-	CreateTimer(
-			GetConVarFloat(tongue_drag_damage_interval) + 0.1, 
-			FixDragInterval, 
-			client, 
-			TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE
-	);
+	new Float:fFirst = GetConVarFloat(tongue_drag_first_damage_interval);
+
+	if (fFirst > 0.0)
+	{
+		UpdateDragDamageInterval(client, tongue_drag_first_damage_interval);
+		CreateTimer(fFirst, FirstDamage, client);
+	}
+	else
+	{
+		UpdateDragDamageInterval(client, tongue_drag_damage_interval);
+		
+		CreateTimer(
+				GetConVarFloat(tongue_drag_damage_interval) + 0.1, 
+				FixDragInterval, 
+				client, 
+				TIMER_REPEAT | TIMER_FLAG_NO_MAPCHANGE
+		);
+	}
+}
+
+public Action:FirstDamage(Handle:timer, any:client)
+{
+	if (!IsSurvivor(client) || !IsSurvivorBeingDragged(client))
+	{
+		return Plugin_Stop;
+	}
+
+	for (new i = 1; i < MaxClients + 1; i++)
+	{
+		if (IsTongue(i))
+		{
+			SDKHooks_TakeDamage(client, i, i, GetConVarFloat(tongue_drag_first_damage) - 1.0);
+			break;
+		}
+	}
+
+	UpdateDragDamageInterval(client, tongue_drag_damage_interval);
+	return Plugin_Continue;
 }
 
 public Action:FixDragInterval(Handle:timer, any:client)
@@ -50,13 +85,13 @@ public Action:FixDragInterval(Handle:timer, any:client)
 		return Plugin_Stop;
 	}
 
-	UpdateDragDamageInterval(client);
+	UpdateDragDamageInterval(client, tongue_drag_damage_interval);
 	return Plugin_Continue;
 }
 
-UpdateDragDamageInterval(client)
+UpdateDragDamageInterval(client, Handle:convar)
 {
-	SetEntDataFloat(client, 13352, (GetGameTime() + GetConVarFloat(tongue_drag_damage_interval)));
+	SetEntDataFloat(client, 13352, (GetGameTime() + GetConVarFloat(convar)));
 }
 
 bool:IsSurvivorBeingDragged(client)
@@ -72,4 +107,9 @@ bool:IsSurvivorBeingChoked(client)
 bool:IsSurvivor(client)
 {
 	return (client > 0 && client <= MaxClients && IsClientInGame(client) && GetClientTeam(client) == 2);
+}
+
+bool:IsTongue(client)
+{
+	return (client > 0 && client <= MaxClients && IsClientInGame(client) && GetEntPropEnt(client, Prop_Send, "m_tongueVictim") > 0);
 }

--- a/addons/sourcemod/scripting/simple_witch_bonus.sp
+++ b/addons/sourcemod/scripting/simple_witch_bonus.sp
@@ -1,0 +1,154 @@
+#pragma semicolon 1
+
+#include <sourcemod>
+#include <sdktools>
+#include <sdkhooks>
+#include <l4d2_penalty_bonus>
+
+#define IS_VALID_CLIENT(%1)     (%1 > 0 && %1 <= MaxClients)
+#define IS_SURVIVOR(%1)         (GetClientTeam(%1) == 2)
+#define IS_INFECTED(%1)         (GetClientTeam(%1) == 3)
+#define IS_VALID_INGAME(%1)     (IS_VALID_CLIENT(%1) && IsClientInGame(%1))
+#define IS_VALID_SURVIVOR(%1)   (IS_VALID_INGAME(%1) && IS_SURVIVOR(%1))
+#define IS_VALID_INFECTED(%1)   (IS_VALID_INGAME(%1) && IS_INFECTED(%1))
+#define IS_SURVIVOR_ALIVE(%1)   (IS_VALID_SURVIVOR(%1) && IsPlayerAlive(%1))
+#define IS_INFECTED_ALIVE(%1)   (IS_VALID_INFECTED(%1) && IsPlayerAlive(%1))
+
+
+new     bool:           g_bLateLoad                                         = false;
+new     Handle:         g_hCvarBonus                                        = INVALID_HANDLE;
+new     Handle:         g_hCvarPrint                                        = INVALID_HANDLE;
+new     Handle:         g_hCvarBonusAlways                                  = INVALID_HANDLE;
+new     Handle:         g_hTrieEntityCreated                                = INVALID_HANDLE;
+new     Handle:         g_hWitchTrie                                        = INVALID_HANDLE;
+
+// trie values: OnEntityCreated classname
+enum strOEC
+{
+    OEC_WITCH
+};
+
+
+public Plugin:myinfo = 
+{
+    name = "Simple Witch Kill Bonus",
+    author = "Tabun",
+    description = "Gives bonus for witches getting killed without doing damage to survivors (uses pbonus).",
+    version = "0.9.2",
+    url = "none"
+}
+
+public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
+{
+    g_bLateLoad = late;    
+    return APLRes_Success;
+}
+
+public OnPluginStart()
+{
+    HookEvent("witch_spawn", Event_WitchSpawned, EventHookMode_Post);
+    HookEvent("witch_killed", Event_WitchKilled, EventHookMode_Post);
+
+    g_hCvarBonus = CreateConVar("sm_simple_witch_bonus", "25", "Bonus points to award for clean witch kills.", FCVAR_PLUGIN, true, 0.0);
+    g_hCvarPrint = CreateConVar("sm_witch_bonus_print", "1", "Should we print when we award points for killing the witch?", FCVAR_PLUGIN, true, 0.0, true, 1.0);
+    g_hCvarBonusAlways = CreateConVar("sm_witch_bonus_always", "0", "Should you receive points when something other than survivors kills witch?", FCVAR_PLUGIN, true, 0.0, true, 1.0);
+
+    g_hWitchTrie = CreateTrie();
+    g_hTrieEntityCreated = CreateTrie();
+    SetTrieValue(g_hTrieEntityCreated, "witch", OEC_WITCH);
+
+    if (g_bLateLoad) {
+        for (new client = 1; client <= MaxClients; client++) {
+            if (IS_VALID_INGAME(client)) {
+                SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamageByWitch);
+            }
+        }
+    }
+}
+
+// player damage tracking
+public OnClientPostAdminCheck(client)
+{
+    SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamageByWitch);
+}
+public OnClientDisconnect(client)
+{
+    SDKUnhook(client, SDKHook_OnTakeDamage, OnTakeDamageByWitch);
+}
+
+// entity destruction
+public OnEntityDestroyed(entity)
+{
+    decl String:witch_key[10];
+    FormatEx(witch_key, sizeof(witch_key), "%x", entity);
+    
+    RemoveFromTrie(g_hWitchTrie, witch_key);
+}
+
+// witch tracking
+public Action: Event_WitchSpawned(Handle:event, const String:name[], bool:dontBroadcast)
+{
+    new witch = GetEventInt(event, "witchid");    
+    decl String:witch_key[10];
+    FormatEx(witch_key, sizeof(witch_key), "%x", witch);
+    SetTrieValue(g_hWitchTrie, witch_key, 0);
+}
+
+// kill tracking
+public Action: Event_WitchKilled(Handle:event, const String:name[], bool:dontBroadcast)
+{
+    new witch = GetEventInt(event, "witchid");
+    new attacker = GetClientOfUserId( GetEventInt(event, "userid") );
+
+    // only award bonus if survivors deal the last blow
+    if ( !IS_VALID_SURVIVOR(attacker) &&  GetConVarBool(g_hCvarBonusAlways) == false ) {
+        return Plugin_Continue;
+    }
+    
+    // only award bonus if witch didn't get a scratch off
+    decl String:witch_key[10];
+    FormatEx(witch_key, sizeof(witch_key), "%x", witch);
+
+    new witch_check;
+    if (!GetTrieValue(g_hWitchTrie, witch_key, witch_check) || !witch_check) {
+        GiveWitchBonus();
+    }
+
+    return Plugin_Continue;
+}
+
+// track witch doing damage to survivors
+public Action: OnTakeDamageByWitch(victim, &attacker, &inflictor, &Float:damage, &damagetype)
+{
+    if (IS_VALID_SURVIVOR(victim) && damage > 0.0) {
+        if (IsWitch(attacker)) {
+            decl String:witch_key[10];
+            FormatEx(witch_key, sizeof(witch_key), "%x", attacker);
+            SetTrieValue(g_hWitchTrie, witch_key, 1);
+        }
+    }
+}
+
+// apply bonus, through PenaltyBonus
+stock GiveWitchBonus()
+{
+    new iBonus = GetConVarInt(g_hCvarBonus);
+    if(GetConVarBool(g_hCvarPrint) == true)
+	{
+        PrintToChatAll("\x01Killing the witch has awarded: \x05%d \x01points!", iBonus);
+    }
+    PBONUS_AddRoundBonus(iBonus);
+}
+
+stock bool: IsWitch(entity)
+{
+    if (!IsValidEntity(entity)) {
+        return false;
+    }
+    
+    decl String: classname[24];
+    new strOEC: classnameOEC;
+    GetEdictClassname(entity, classname, sizeof(classname));
+
+    return !(!GetTrieValue(g_hTrieEntityCreated, classname, classnameOEC) || classnameOEC != OEC_WITCH);
+}

--- a/addons/sourcemod/scripting/simple_witch_bonus.sp
+++ b/addons/sourcemod/scripting/simple_witch_bonus.sp
@@ -34,7 +34,7 @@ public Plugin:myinfo =
     name = "Simple Witch Kill Bonus",
     author = "Tabun",
     description = "Gives bonus for witches getting killed without doing damage to survivors (uses pbonus).",
-    version = "0.9.2",
+    version = "0.9.3",
     url = "none"
 }
 
@@ -137,7 +137,7 @@ stock GiveWitchBonus()
 	{
         PrintToChatAll("\x01Killing the witch has awarded: \x05%d \x01points!", iBonus);
     }
-    PBONUS_AddRoundBonus(iBonus);
+    PBONUS_AddRoundBonus(iBonus, true);
 }
 
 stock bool: IsWitch(entity)

--- a/addons/sourcemod/scripting/slots_vote.sp
+++ b/addons/sourcemod/scripting/slots_vote.sp
@@ -1,0 +1,142 @@
+#pragma semicolon 1
+
+#include <sourcemod>
+#include <builtinvotes>
+#include <colors>
+
+new Handle:g_hVote;
+new String:g_sSlots[32];
+new Handle:hMaxSlots;
+new MaxSlots;
+
+public Plugin:myinfo =
+{
+	name = "Slots?! Voter",
+	description = "Slots Voter",
+	author = "Sir",
+	version = "",
+	url = ""
+};
+
+public OnPluginStart()
+{
+	RegConsoleCmd("sm_slots", SlotsRequest);
+	hMaxSlots = CreateConVar("slots_max_slots", "30", "Maximum amount of slots you wish players to be able to vote for? (DON'T GO HIGHER THAN 30)");
+	MaxSlots = GetConVarInt(hMaxSlots);
+	HookConVarChange(hMaxSlots, CVarChanged);
+}
+
+public Action:SlotsRequest(client, args)
+{
+	if (!client)
+	{
+		return Plugin_Handled;
+	}
+	if (args == 1)
+	{
+		new String:sSlots[64];
+		GetCmdArg(1, sSlots, sizeof(sSlots));
+		new Int = StringToInt(sSlots);
+		if (Int > MaxSlots)
+		{
+			CPrintToChat(client, "{blue}[{default}Slots{blue}] {default}You can't limit slots above {olive}%i {default}on this Server", MaxSlots);
+		}
+		else
+		{
+			if (GetUserAdmin(client) != INVALID_ADMIN_ID)
+			{
+				CPrintToChatAll("{blue}[{default}Slots{blue}] {olive}Admin {default}has limited Slots to {blue}%i", Int);
+				SetConVarInt(FindConVar("sv_maxplayers"), Int);
+			}
+			else if (Int < GetConVarInt(FindConVar("survivor_limit")) + GetConVarInt(FindConVar("z_max_player_zombies")))
+			{
+				CPrintToChat(client, "{blue}[{default}Slots{blue}] {default}You can't limit Slots lower than required Players.");
+			}
+			else if (StartSlotVote(client, sSlots))
+			{
+				strcopy(g_sSlots, sizeof(g_sSlots), sSlots);
+				FakeClientCommand(client, "Vote Yes");
+			}
+		}
+	}
+	else
+	{
+		CPrintToChat(client, "{blue}[{default}Slots{blue}] {default}Usage: {olive}!slots {default}<{olive}number{default}> {blue}| {default}Example: {olive}!slots 8");
+	}
+	return Plugin_Handled;
+}
+
+bool:StartSlotVote(client, String:Slots[])
+{
+	if (GetClientTeam(client) == 1)
+	{
+		PrintToChat(client, "Voting isn't allowed for spectators.");
+		return false;
+	}
+
+	if (IsNewBuiltinVoteAllowed())
+	{
+		new iNumPlayers;
+		decl iPlayers[MaxClients];
+		for (new i=1; i<=MaxClients; i++)
+		{
+			if (!IsClientInGame(i) || IsFakeClient(i) || (GetClientTeam(i) == 1))
+			{
+				continue;
+			}
+			iPlayers[iNumPlayers++] = i;
+		}
+		
+		new String:sBuffer[64];
+		g_hVote = CreateBuiltinVote(VoteActionHandler, BuiltinVoteType_Custom_YesNo, BuiltinVoteAction_Cancel | BuiltinVoteAction_VoteEnd | BuiltinVoteAction_End);
+		Format(sBuffer, sizeof(sBuffer), "Limit Slots to '%s'?", Slots);
+		SetBuiltinVoteArgument(g_hVote, sBuffer);
+		SetBuiltinVoteInitiator(g_hVote, client);
+		SetBuiltinVoteResultCallback(g_hVote, SlotVoteResultHandler);
+		DisplayBuiltinVote(g_hVote, iPlayers, iNumPlayers, 20);
+		return true;
+	}
+
+	PrintToChat(client, "Vote cannot be started now.");
+	return false;
+}
+
+public SlotVoteResultHandler(Handle:vote, num_votes, num_clients, const client_info[][2], num_items, const item_info[][2])
+{
+	for (new i=0; i<num_items; i++)
+	{
+		if (item_info[i][BUILTINVOTEINFO_ITEM_INDEX] == BUILTINVOTES_VOTE_YES)
+		{
+			if (item_info[i][BUILTINVOTEINFO_ITEM_VOTES] > (num_votes / 2))
+			{
+				new Slots = StringToInt(g_sSlots, 10);
+				DisplayBuiltinVotePass(vote, "Limiting Slots...");
+				SetConVarInt(FindConVar("sv_maxplayers"), Slots);
+				return;
+			}
+		}
+	}
+	DisplayBuiltinVoteFail(vote, BuiltinVoteFail_Loses);
+}
+
+public VoteActionHandler(Handle:vote, BuiltinVoteAction:action, param1, param2)
+{
+	switch (action)
+	{
+		case BuiltinVoteAction_End:
+		{
+			g_hVote = INVALID_HANDLE;
+			CloseHandle(vote);
+		}
+		case BuiltinVoteAction_Cancel:
+		{
+			DisplayBuiltinVoteFail(vote, BuiltinVoteFailReason:param1);
+		}
+	}
+}
+
+public CVarChanged(Handle:cvar, String:oldValue[], String:newValue[])
+{
+	MaxSlots = GetConVarInt(hMaxSlots);
+}
+


### PR DESCRIPTION
Final set of plugin reconstructions I could accurately recreate.

* simple_witch_bonus.sp - used older version as base
* l4d2_smoker_drag_damage_interval_zone.sp  - used l4d2_smoker_drag_damage_interval.sp as base

The rest were reconstructed without anything to start with except the lysis decompilations.
* l4d2_antimelee.sp
* l4d2_byedoor.sp
* l4d2_smg_reload_tweak.sp
* changelog.sp
* slots_vote.sp

Lysis decompilations aren't perfect, so I also checked each compiled reconstruction with the [disassembler webtool](https://peace-maker.github.io/sourcepawn-disassembler-web). I compared each disassembled reconstruction to a disassembly of the original smx and adjusted the reconstructed code until I ended up with no significant differences in instructions between the two. The only differences are sometimes the addresses aren't the same, but I think that's due to the environment (compiler version, include code differences, etc) and not the plugin code itself. Aside from that, the instruction count, types, order, and arguments all match.