### PR TITLE
Small source code fixes/refactor

### DIFF
--- a/addons/sourcemod/scripting/1v1.sp
+++ b/addons/sourcemod/scripting/1v1.sp
@@ -45,7 +45,7 @@ public Plugin:myinfo =
 	name = "1v1 EQ",
 	author = "Blade + Confogl Team, Tabun, Visor",
 	description = "A plugin designed to support 1v1.",
-	version = "0.1",
+	version = "0.1.1",
 	url = "https://github.com/Attano/Equilibrium"
 };
 
@@ -85,7 +85,7 @@ stock GetZombieClass(client) return GetEntProp(client, Prop_Send, "m_zombieClass
 
 stock bool:IsClientAndInGame(index)
 {
-	if (index > 0 && index < MaxClients)
+	if (index > 0 && index <= MaxClients)
 	{
 		return IsClientInGame(index);
 	}

--- a/addons/sourcemod/scripting/eq_finale_tanks.sp
+++ b/addons/sourcemod/scripting/eq_finale_tanks.sp
@@ -45,13 +45,13 @@ public Plugin:myinfo =
 	name = "EQ2 Finale Tank Manager",
 	author = "Visor, Electr0",
 	description = "Either two event tanks or one flow and one (second) event tank",
-	version = "2.5",
+	version = "2.5.1",
 	url = "https://github.com/Attano/Equilibrium"
 };
 
 public OnPluginStart()
 {
-	HookEvent("round_start", OnRoundStart, EventHookMode_PostNoCopy);
+	HookEvent("round_start", RoundStartEvent, EventHookMode_PostNoCopy);
 
 	hFirstTankSpawningScheme = CreateTrie();
 	hSecondTankSpawningScheme = CreateTrie();
@@ -74,7 +74,7 @@ public Action:SetMapSecondTankSpawningScheme(args)
 	SetTrieValue(hSecondTankSpawningScheme, mapname, true);
 }
 
-public Action:OnRoundStart(Handle:event, const String:name[], bool:dontBroadcast)
+public Action:RoundStartEvent(Handle:event, const String:name[], bool:dontBroadcast)
 {
 	CreateTimer(8.0, ProcessTankSpawn);
 }

--- a/addons/sourcemod/scripting/finalefix.sp
+++ b/addons/sourcemod/scripting/finalefix.sp
@@ -6,7 +6,7 @@ public Plugin:myinfo =
 	name = "L4D2 Finale Incap Distance Fixifier",
 	author = "CanadaRox",
 	description = "Kills survivors before the score is calculated so you don't get full distance if you are incapped as the rescue vehicle leaves.",
-	version = "1.0",
+	version = "1.0.1",
 	url = "https://bitbucket.org/CanadaRox/random-sourcemod-stuff"
 };
 
@@ -17,7 +17,7 @@ public OnPluginStart()
 
 public FinaleEnd_Event(Handle:event, const String:name[], bool:dontBroadcast)
 {
-	for (new i = 1; i < MaxClients; i++)
+	for (new i = 1; i <= MaxClients; i++)
 	{
 		if (IsClientInGame(i) && GetClientTeam(i) == 2 && IsPlayerIncap(i))
 		{

--- a/addons/sourcemod/scripting/include/mapinfo.inc
+++ b/addons/sourcemod/scripting/include/mapinfo.inc
@@ -24,8 +24,8 @@ static Float:Start_Dist;
 static Float:Start_Extra_Dist;
 static Float:End_Dist;
 
-static iIsInEditMode[MAXPLAYERS];
-static Float:fLocTemp[MAXPLAYERS][3];
+static iIsInEditMode[MAXPLAYERS+1];
+static Float:fLocTemp[MAXPLAYERS+1][3];
 
 MapInfo_Init()
 {
@@ -45,7 +45,7 @@ MapInfo_OnMapEnd_Update()
 {
 	KvRewind(kMIData);
 	MapDataAvailable = false;
-	for (new i; i < MAXPLAYERS; i++) iIsInEditMode[i] = 0;
+	for (new i; i <= MAXPLAYERS; i++) iIsInEditMode[i] = 0;
 }
 
 MapInfo_OnPluginEnd()
@@ -56,7 +56,7 @@ MapInfo_OnPluginEnd()
 MapInfo_PlayerDisconnect_Event(Handle:event)
 {
 	new client = GetClientOfUserId(GetEventInt(event, "userid"));
-	if (client > -1 && client < MAXPLAYERS) iIsInEditMode[client] = 0;
+	if (client > -1 && client <= MAXPLAYERS) iIsInEditMode[client] = 0;
 }
 
 public Action:MI_KV_CmdSave(client, args)

--- a/addons/sourcemod/scripting/include/survivors.inc
+++ b/addons/sourcemod/scripting/include/survivors.inc
@@ -6,7 +6,7 @@
 #define __survs__
 
 /* Global Vars */
-static iSurvivorIndex[MAXPLAYERS];
+static iSurvivorIndex[MAXPLAYERS + 1];
 static iSurvivorCount = 0;
 
 
@@ -25,7 +25,7 @@ Survivors_RebuildArray()
         if (!IsServerProcessing()) return;
         iSurvivorCount = 0;
         
-        for (new i = 0; i < MAXPLAYERS; i++) iSurvivorIndex[i] = 0;
+        for (new i = 0; i <= MAXPLAYERS; i++) iSurvivorIndex[i] = 0;
 
         for (new i = 1; i <= MaxClients; i++)
         {

--- a/addons/sourcemod/scripting/l4d2_blind_infected.sp
+++ b/addons/sourcemod/scripting/l4d2_blind_infected.sp
@@ -13,7 +13,7 @@ public Plugin:myinfo =
 	name = "Blind Infected",
 	author = "CanadaRox, ProdigySim",
 	description = "Hides specified weapons from the infected team until they are (possibly) visible to one of the survivors to prevent SI scouting the map",
-	version = "1.0",
+	version = "1.0.1",
 	url = "https://github.com/CanadaRox/sourcemod-plugins/tree/master/blind_infected_l4d2"
 };
 
@@ -101,7 +101,7 @@ public Action:RoundStartDelay_Timer(Handle:timer)
 	decl WeaponId:weapon;
 	new psychonic = GetEntityCount();
 
-	for (new i = MaxClients; i < psychonic; i++)
+	for (new i = MaxClients+1; i <= psychonic; i++)
 	{
 		weapon = IdentifyWeapon(i);
 		if (weapon)

--- a/addons/sourcemod/scripting/l4d2_drop_secondary.sp
+++ b/addons/sourcemod/scripting/l4d2_drop_secondary.sp
@@ -11,21 +11,21 @@ public Plugin:myinfo =
 {
 	name        = "L4D2 Drop Secondary",
 	author      = "Jahze, Visor",
-	version     = "2.0",
+	version     = "2.0.1",
 	description = "Survivor players will drop their secondary weapon when they die",
 	url         = "https://github.com/Attano/Equilibrium"
 };
 
 public OnPluginStart() 
 {
-	HookEvent("round_start", EventHook:OnRoundStart, EventHookMode_PostNoCopy);
+	HookEvent("round_start", EventHook:RoundStartEvent, EventHookMode_PostNoCopy);
 	HookEvent("player_use", OnPlayerUse, EventHookMode_Post);
 	HookEvent("player_bot_replace", OnBotSwap);
 	HookEvent("bot_player_replace", OnBotSwap);
 	HookEvent("player_death", OnPlayerDeath, EventHookMode_Pre);
 }
 
-public OnRoundStart() 
+public RoundStartEvent()
 {
 	for (new i = 0; i <= MAXPLAYERS; i++) 
 	{

--- a/addons/sourcemod/scripting/l4d2_getupfix.sp
+++ b/addons/sourcemod/scripting/l4d2_getupfix.sp
@@ -12,7 +12,7 @@ public Plugin:myinfo =
     name = "L4D2 Get-Up Fix",
     author = "Blade, ProdigySim, DieTeetasse, Stabby, Jahze",
     description = "Double/no/self-clear get-up fix.",
-    version = "1.7",
+    version = "1.7.1",
     url = "http://bitbucket.org/ProdigySim/misc-sourcemod-plugins/"
 }
 
@@ -147,7 +147,7 @@ public Action:Timer_CheckClient(Handle:timer, any:tempStack) {
 public Action:ChargerKilled(Handle:event, const String:name[], bool:dontBroadcast) {
     new attacker = GetClientOfUserId(GetEventInt(event, "attacker"));
     
-    if (attacker <= 0 || attacker > MaxClients+1) {
+    if (attacker <= 0 || attacker > MaxClients) {
         return;
     }
     

--- a/addons/sourcemod/scripting/l4d2_godframes_control_merge.sp
+++ b/addons/sourcemod/scripting/l4d2_godframes_control_merge.sp
@@ -10,6 +10,7 @@
 #include <sdktools>
 #include <sdkhooks>
 #include <left4dhooks>
+#include <l4d2util>
 
 #define CLASSNAME_LENGTH 64
 #define MIN(%0,%1) (((%0) < (%1)) ? (%0) : (%1))

--- a/addons/sourcemod/scripting/l4d2_godframes_control_merge.sp
+++ b/addons/sourcemod/scripting/l4d2_godframes_control_merge.sp
@@ -97,7 +97,7 @@ new Float: fFakeGodframeEnd[MAXPLAYERS + 1];
 new iLastSI[MAXPLAYERS + 1];
 
 //shotgun ff
-new pelletsShot[MAXPLAYERS][MAXPLAYERS];
+new pelletsShot[MAXPLAYERS + 1][MAXPLAYERS + 1];
 
 //frustration
 new frustrationOffset[MAXPLAYERS + 1];
@@ -117,7 +117,7 @@ public Plugin:myinfo =
 {
 	name = "L4D2 Godframes Control combined with FF Plugins",
 	author = "Stabby, CircleSquared, Tabun, Visor, dcx, Sir, Spoon",
-	version = "0.6",
+	version = "0.6.1",
 	description = "Allows for control of what gets godframed and what doesnt along with integrated FF Support from l4d2_survivor_ff (by dcx and Visor) and l4d2_shotgun_ff (by Visor)"
 };
 
@@ -515,7 +515,7 @@ public Action:OnTakeDamage(victim, &attacker, &inflictor, &Float:damage, &damage
 
 stock IsClientAndInGame(client)
 {
-	if (0 < client && client < MaxClients)
+	if (0 < client && client <= MaxClients)
 	{	
 		return IsClientInGame(client);
 	}

--- a/addons/sourcemod/scripting/l4d2_godframes_control_merge.sp
+++ b/addons/sourcemod/scripting/l4d2_godframes_control_merge.sp
@@ -117,7 +117,7 @@ public Plugin:myinfo =
 {
 	name = "L4D2 Godframes Control combined with FF Plugins",
 	author = "Stabby, CircleSquared, Tabun, Visor, dcx, Sir, Spoon",
-	version = "0.6.1",
+	version = "0.6.2",
 	description = "Allows for control of what gets godframed and what doesnt along with integrated FF Support from l4d2_survivor_ff (by dcx and Visor) and l4d2_shotgun_ff (by Visor)"
 };
 
@@ -989,6 +989,8 @@ void ProcessShot(ArrayStack stack)
 	}
 	
 	bBuckshot[attacker] = false;
+
+	CloseHandle(stack);
 }
 
 bool:IsTankRock(entity)

--- a/addons/sourcemod/scripting/l4d2_health_temp_bonus.sp
+++ b/addons/sourcemod/scripting/l4d2_health_temp_bonus.sp
@@ -104,7 +104,7 @@ public Plugin myinfo =
 	name = "L4D2 Competitive Health Bonus System",
 	author = "Luckylock",
 	description = "Scoring system for l4d2 competitive",
-	version = "3.1",
+	version = "3.1.1",
 	url = "https://github.com/LuckyServ/"
 };
 
@@ -334,7 +334,7 @@ public void copyTableValues(int health[HEALTH_TABLE_SIZE], int healthCopy[HEALTH
 stock bool:IsSurvivor(client)                                                   
 {                                                                               
     return client > 0 
-        && client < MaxClients 
+        && client <= MaxClients
         && IsClientInGame(client) 
         && GetClientTeam(client) == 2; 
 }

--- a/addons/sourcemod/scripting/l4d2_horde_equaliser.sp
+++ b/addons/sourcemod/scripting/l4d2_horde_equaliser.sp
@@ -29,7 +29,7 @@ public Plugin:myinfo =
 	name = "L4D2 Horde Equaliser",
 	author = "Visor (original idea by Sir)",
 	description = "Make certain event hordes finite",
-	version = "3.0.7",
+	version = "3.0.8",
 	url = "https://github.com/Attano/Equilibrium"
 };
 
@@ -50,7 +50,7 @@ public OnPluginStart()
 	hCvarNoEventHordeDuringTanks = CreateConVar("l4d2_heq_no_tank_horde", "0", "Put infinite hordes on a 'hold up' during Tank fights");
 	hCvarHordeCheckpointAnnounce = CreateConVar("l4d2_heq_checkpoint_sound", "1", "Play the incoming mob sound at checkpoints (each 1/4 of total commons killed off) to simulate L4D1 behaviour");
 
-	HookEvent("round_start", EventHook:OnRoundStart, EventHookMode_PostNoCopy);
+	HookEvent("round_start", EventHook:RoundStartEvent, EventHookMode_PostNoCopy);
 }
 
 public OnMapStart()
@@ -61,7 +61,7 @@ public OnMapStart()
 	PrecacheSound(HORDE_SOUND);
 }
 
-public OnRoundStart()
+public RoundStartEvent()
 {
 	commonTotal = 0;
 	lastCheckpoint = 0;

--- a/addons/sourcemod/scripting/l4d2_hunter_no_deadstops.sp
+++ b/addons/sourcemod/scripting/l4d2_hunter_no_deadstops.sp
@@ -17,7 +17,7 @@ public Plugin:myinfo =
 	name = "[L4D2] No Hunter Deadstops",
 	author = "Spoon & Luckylock",
 	description = "Prevents deadstops but allows m2s on standing hunters",
-	version = "1",
+	version = "1.0.1",
 	url = "https://github.com/luckyserv"
 };
 
@@ -170,7 +170,7 @@ public bool:IsGrounded(client)
 
 bool:IsClientAndInGame(index)
 {
-    if (index > 0 && index < MaxClients)
+    if (index > 0 && index <= MaxClients)
     {
         return IsClientInGame(index);
     }

--- a/addons/sourcemod/scripting/l4d2_hybrid_scoremod.sp
+++ b/addons/sourcemod/scripting/l4d2_hybrid_scoremod.sp
@@ -55,7 +55,7 @@ public Plugin:myinfo =
 	name = "L4D2 Scoremod+",
 	author = "Visor",
 	description = "The next generation scoring mod",
-	version = "2.2.2",
+	version = "2.2.4",
 	url = "https://github.com/Attano/L4D2-Competitive-Framework"
 };
 
@@ -167,7 +167,7 @@ public OnClientDisconnect(client)
 
 public OnRoundStart()
 {
-	for (new i = 0; i < MAXPLAYERS; i++)
+	for (new i = 0; i <= MAXPLAYERS; i++)
 	{
 		iTempHealth[i] = 0;
 	}

--- a/addons/sourcemod/scripting/l4d2_hybrid_scoremod.sp
+++ b/addons/sourcemod/scripting/l4d2_hybrid_scoremod.sp
@@ -86,7 +86,7 @@ public OnPluginStart()
 	HookConVarChange(hCvarBonusPerSurvivorMultiplier, CvarChanged);
 	HookConVarChange(hCvarPermanentHealthProportion, CvarChanged);
 
-	HookEvent("round_start", EventHook:OnRoundStart, EventHookMode_PostNoCopy);
+	HookEvent("round_start", EventHook:RoundStartEvent, EventHookMode_PostNoCopy);
 	HookEvent("player_ledge_grab", OnPlayerLedgeGrab);
 	HookEvent("player_hurt", OnPlayerHurt);
 	HookEvent("revive_success", OnPlayerRevived, EventHookMode_Post);
@@ -165,7 +165,7 @@ public OnClientDisconnect(client)
 	SDKUnhook(client, SDKHook_OnTakeDamagePost, OnTakeDamagePost);
 }
 
-public OnRoundStart()
+public RoundStartEvent()
 {
 	for (new i = 0; i <= MAXPLAYERS; i++)
 	{

--- a/addons/sourcemod/scripting/l4d2_hybrid_scoremod_zone.sp
+++ b/addons/sourcemod/scripting/l4d2_hybrid_scoremod_zone.sp
@@ -86,7 +86,7 @@ public OnPluginStart()
 	HookConVarChange(hCvarBonusPerSurvivorMultiplier, CvarChanged);
 	HookConVarChange(hCvarPermanentHealthProportion, CvarChanged);
 
-	HookEvent("round_start", EventHook:OnRoundStart, EventHookMode_PostNoCopy);
+	HookEvent("round_start", EventHook:RoundStartEvent, EventHookMode_PostNoCopy);
 	HookEvent("player_ledge_grab", OnPlayerLedgeGrab);
 	HookEvent("player_incapacitated", OnPlayerIncapped);
 	HookEvent("player_hurt", OnPlayerHurt);
@@ -166,7 +166,7 @@ public OnClientDisconnect(client)
 	SDKUnhook(client, SDKHook_OnTakeDamagePost, OnTakeDamagePost);
 }
 
-public OnRoundStart()
+public RoundStartEvent()
 {
 	for (new i = 0; i <= MAXPLAYERS; i++)
 	{

--- a/addons/sourcemod/scripting/l4d2_hybrid_scoremod_zone.sp
+++ b/addons/sourcemod/scripting/l4d2_hybrid_scoremod_zone.sp
@@ -55,7 +55,7 @@ public Plugin:myinfo =
 	name = "L4D2 Scoremod+",
 	author = "Visor",
 	description = "The next generation scoring mod",
-	version = "2.2.2",
+	version = "2.2.4",
 	url = "https://github.com/Attano/L4D2-Competitive-Framework"
 };
 
@@ -168,7 +168,7 @@ public OnClientDisconnect(client)
 
 public OnRoundStart()
 {
-	for (new i = 0; i < MAXPLAYERS; i++)
+	for (new i = 0; i <= MAXPLAYERS; i++)
 	{
 		iTempHealth[i] = 0;
 	}

--- a/addons/sourcemod/scripting/l4d2_jockey_jumpcap_patch.sp
+++ b/addons/sourcemod/scripting/l4d2_jockey_jumpcap_patch.sp
@@ -14,7 +14,7 @@ public Plugin:myinfo =
 	name = "L4D2 Jockey Jump-Cap Patch",
 	author = "Visor",
 	description = "Prevent Jockeys from being able to land caps with non-ability jumps in unfair situations",
-	version = "1.2",
+	version = "1.2.1",
 	url = "https://github.com/Attano/L4D2-Competitive-Framework"
 };
 
@@ -23,11 +23,11 @@ public OnPluginStart()
 	hCLeap_OnTouch = DHookCreate(CLEAP_ONTOUCH_OFFSET, HookType_Entity, ReturnType_Void, ThisPointer_CBaseEntity, CLeap_OnTouch);
 	DHookAddParam(hCLeap_OnTouch, HookParamType_CBaseEntity);
 	
-	HookEvent("round_start", EventHook:OnRoundStart, EventHookMode_PostNoCopy);
+	HookEvent("round_start", EventHook:RoundStartEvent, EventHookMode_PostNoCopy);
 	HookEvent("player_shoved", OnPlayerShoved);
 }
 
-public OnRoundStart()
+public RoundStartEvent()
 {
 	for (new i = 1; i <= MaxClients; i++)
 	{

--- a/addons/sourcemod/scripting/l4d2_meleecontrol.sp
+++ b/addons/sourcemod/scripting/l4d2_meleecontrol.sp
@@ -24,7 +24,7 @@ public Plugin:myinfo =
 	name = "L4D2 Melee Fatigue Control",
 	description = "Allows players to set custom fatigue levels.",
 	author = "Rotoblin Team & Blade; rebuilt by Visor",
-	version = "0.1",
+	version = "0.1.1",
 	url = "https://github.com/ConfoglTeam/ProMod"
 };
 
@@ -99,7 +99,7 @@ static bool:ShouldPerformCustomFatigueLogic(const String:StrSample[PLATFORM_MAX_
 		return false;	
 
 	// bugfix for some people on L4D2
-	if (entity > MAXPLAYERS) 
+	if (entity > MaxClients)
 		return false; 
 
 	// note 'entity' means 'client' here

--- a/addons/sourcemod/scripting/l4d2_nobackjumps.sp
+++ b/addons/sourcemod/scripting/l4d2_nobackjumps.sp
@@ -10,7 +10,7 @@ public Plugin:myinfo =
     name        = "L4D2 No Backjump",
     author      = "Visor",
     description = "Gah",
-    version     = "1.2",
+    version     = "1.2.1",
     url         = "https://github.com/Attano/Equilibrium"
 }
 
@@ -21,7 +21,7 @@ public OnPluginStart()
     
     hCLunge_ActivateAbility = DHookCreate(LungeActivateAbilityOffset, HookType_Entity, ReturnType_Void, ThisPointer_CBaseEntity, CLunge_ActivateAbility);
 
-    HookEvent("round_start", OnRoundStart, EventHookMode_PostNoCopy);
+    HookEvent("round_start", RoundStartEvent, EventHookMode_PostNoCopy);
     HookEvent("player_jump", OnPlayerJump);
 }
 
@@ -31,7 +31,7 @@ public OnEntityCreated(entity, const String:classname[])
         DHookEntity(hCLunge_ActivateAbility, false, entity); 
 }
 
-public OnRoundStart(Handle:event, const String:name[], bool:bDontBroadcast)
+public RoundStartEvent(Handle:event, const String:name[], bool:bDontBroadcast)
 {
     for (new i = 1; i <= MaxClients; i++)
         fSuspectedBackjump[i] = 0.0;

--- a/addons/sourcemod/scripting/l4d2_saferoom_item_remove.sp
+++ b/addons/sourcemod/scripting/l4d2_saferoom_item_remove.sp
@@ -72,7 +72,7 @@ RemoveEndSaferoomItems()
     new iCountEnd = 0;
     new iCountStart = 0;
     
-    for (new i=1; i < entityCount; i++)
+    for (new i=1; i <= entityCount; i++)
     {
         if (!IsValidEntity(i)) { continue; }
         

--- a/addons/sourcemod/scripting/l4d2_scoremod.sp
+++ b/addons/sourcemod/scripting/l4d2_scoremod.sp
@@ -16,7 +16,7 @@ public Plugin:myinfo =
 	name = "L4D2 Scoremod",
 	author = "CanadaRox, ProdigySim",
 	description = "L4D2 Custom Scoring System (Health Bonus)",
-	version = "1.1b",
+	version = "1.1.1",
 	url = "https://bitbucket.org/CanadaRox/random-sourcemod-stuff"
 };
 
@@ -362,7 +362,7 @@ stock Float:SM_CalculateAvgHealth(&iAliveCount=0)
 	new iSurvCount;
 	iAliveCount =0;
 		
-	for (new index = 1; index < MaxClients; index++)
+	for (new index = 1; index <= MaxClients; index++)
 	{
 		if (IsSurvivor(index))
 		{

--- a/addons/sourcemod/scripting/l4d2_spec_stays_spec.sp
+++ b/addons/sourcemod/scripting/l4d2_spec_stays_spec.sp
@@ -10,7 +10,7 @@
 */
 #define DEBUG_MODE 0
 #define MAX_SPECTATORS 	24
-#define PLUGIN_VERSION 	"1.0"
+#define PLUGIN_VERSION 	"1.0.1"
 #define STEAMID_LENGTH 	32
 
 new Handle:g_hMaxSurvivors            = INVALID_HANDLE;
@@ -96,7 +96,7 @@ public Action:Event_Round_End(Handle:event, const String:name[], bool:dontBroadc
     }
     
     // get steamids
-    for (new i = 1; i < MaxClients; i++) 
+    for (new i = 1; i <= MaxClients; i++)
     {
         if (!IsClientInGame(i)) continue;
         if (GetClientTeam(i) != 1) continue;

--- a/addons/sourcemod/scripting/l4d2_tank_announce.sp
+++ b/addons/sourcemod/scripting/l4d2_tank_announce.sp
@@ -11,7 +11,7 @@ public Plugin:myinfo =
 	name = "L4D2 Tank Announcer",
 	author = "Visor",
 	description = "Announce in chat and via a sound when a Tank has spawned",
-	version = "1.1",
+	version = "1.1.1",
 	url = "https://github.com/SirPlease/L4D2-Competitive-Rework"
 };
 
@@ -23,10 +23,10 @@ public OnMapStart()
 public OnPluginStart()
 {
 	HookEvent("tank_spawn", EventHook:OnTankSpawn, EventHookMode_PostNoCopy);
-	HookEvent("round_start", EventHook:OnRoundStart, EventHookMode_PostNoCopy);
+	HookEvent("round_start", EventHook:RoundStartEvent, EventHookMode_PostNoCopy);
 }
 
-public OnRoundStart()
+public RoundStartEvent()
 {
 	g_bIsTankAlive = false;
 }

--- a/addons/sourcemod/scripting/l4d2_tank_announce.sp
+++ b/addons/sourcemod/scripting/l4d2_tank_announce.sp
@@ -11,7 +11,7 @@ public Plugin:myinfo =
 	name = "L4D2 Tank Announcer",
 	author = "Visor",
 	description = "Announce in chat and via a sound when a Tank has spawned",
-	version = "1.1.1",
+	version = "1.1.2",
 	url = "https://github.com/SirPlease/L4D2-Competitive-Rework"
 };
 
@@ -22,7 +22,7 @@ public OnMapStart()
 
 public OnPluginStart()
 {
-	HookEvent("tank_spawn", EventHook:OnTankSpawn, EventHookMode_PostNoCopy);
+	HookEvent("tank_spawn", EventHook:TankSpawnEvent, EventHookMode_PostNoCopy);
 	HookEvent("round_start", EventHook:RoundStartEvent, EventHookMode_PostNoCopy);
 }
 
@@ -31,7 +31,7 @@ public RoundStartEvent()
 	g_bIsTankAlive = false;
 }
 
-public OnTankSpawn()
+public TankSpawnEvent()
 {
 	if (!g_bIsTankAlive)
 	{

--- a/addons/sourcemod/scripting/l4d2_tank_attack_control.sp
+++ b/addons/sourcemod/scripting/l4d2_tank_attack_control.sp
@@ -21,7 +21,7 @@ public Plugin:myinfo =
 	name = "Tank Attack Control", 
 	author = "vintik, CanadaRox, Jacob, Visor",
 	description = "",
-	version = "0.7",
+	version = "0.7.1",
 	url = "https://github.com/Attano/L4D2-Competitive-Framework"
 }
 
@@ -39,11 +39,11 @@ public OnPluginStart()
 	g_hBlockJumpRock = CreateConVar("l4d2_block_jump_rock", "0", "Block tanks from jumping and throwing a rock at the same time");
 	hOverhandOnly = CreateConVar("tank_overhand_only", "0", "Force tank to only throw overhand rocks.");
 
-	HookEvent("round_start", EventHook:OnRoundStart, EventHookMode_PostNoCopy);
+	HookEvent("round_start", EventHook:RoundStartEvent, EventHookMode_PostNoCopy);
 	HookEvent("tank_spawn", TankSpawn_Event);
 }
 
-public OnRoundStart()
+public RoundStartEvent()
 {
 	for (new i = 1; i <= MaxClients; i++)
 	{

--- a/addons/sourcemod/scripting/l4d2_tank_attack_control_nextmod.sp
+++ b/addons/sourcemod/scripting/l4d2_tank_attack_control_nextmod.sp
@@ -7,7 +7,7 @@ public Plugin:myinfo =
 	name = "[L4D2] Tank Attack Control / Jump Rock Cooldown Hybrid", 
 	author = "Spoon",
 	description = "Remake of https://github.com/Stabbath/ProMod/blob/master/addons/sourcemod/scripting/l4d_tank_control.sp.",
-	version = "0.8",
+	version = "0.8.1",
 	url = "https://github.com/spoon-l4d2"
 }
 
@@ -37,12 +37,12 @@ public OnPluginStart()
 	g_hJumpRockCooldown = CreateConVar("l4d2_jump_rock_cooldown", "20", "Sets cooldown for jump rock ability");
 	hOverhandOnly = CreateConVar("tank_overhand_only", "0", "Force tank to only throw overhand rocks.");
 
-	HookEvent("round_start", EventHook:OnRoundStart, EventHookMode_PostNoCopy);
+	HookEvent("round_start", EventHook:RoundStartEvent, EventHookMode_PostNoCopy);
 	HookEvent("tank_spawn", TankSpawn_Event);
 }
 
 
-public OnRoundStart()
+public RoundStartEvent()
 {
 	for (new i = 1; i <= MaxClients; i++)
 	{

--- a/addons/sourcemod/scripting/l4d2_weapon_attributes.sp
+++ b/addons/sourcemod/scripting/l4d2_weapon_attributes.sp
@@ -13,7 +13,7 @@ public Plugin:myinfo =
 {
     name        = "L4D2 Weapon Attributes",
     author      = "Jahze",
-    version     = "1.4",
+    version     = "1.4.1",
     description = "Allowing tweaking of the attributes of all weapons"
 };
 
@@ -331,7 +331,7 @@ public Action:WeaponAttributes( client, args ) {
 
  
 public Action:DamageBuffVsTank( victim, &attacker, &inflictor, &Float:damage, &damageType, &weapon, Float:damageForce[3], Float:damagePosition[3] ) {
-    if (attacker <= 0 || attacker > MaxClients+1) {
+    if (attacker <= 0 || attacker > MaxClients) {
         return Plugin_Continue;
     }
 
@@ -360,7 +360,7 @@ public Action:DamageBuffVsTank( victim, &attacker, &inflictor, &Float:damage, &d
  
 bool:IsTank( client ) {
     if ( client <= 0
-    || client > MaxClients+1
+    || client > MaxClients
     || !IsClientInGame(client)
     || GetClientTeam(client) != 3
     || !IsPlayerAlive(client) ) {

--- a/addons/sourcemod/scripting/l4d2_weaponrules.sp
+++ b/addons/sourcemod/scripting/l4d2_weaponrules.sp
@@ -30,6 +30,15 @@ new g_GlobalWeaponRules[WeaponId]={-1, ...};
 new g_bRoundStartHit;
 new g_bConfigsExecuted;
 
+public Plugin:myinfo =
+{
+	name = "L4D2 Weapon Rules",
+	author = "ProdigySim",
+	version = "1.0.1",
+	description = "^",
+	url = "https://github.com/SirPlease/L4D2-Competitive-Rework"
+};
+
 public OnPluginStart()
 {
 	RegServerCmd("l4d2_addweaponrule", AddWeaponRuleCb);
@@ -112,7 +121,7 @@ AddWeaponRule(WeaponId:match, to)
 WeaponSearchLoop()
 {
 	new entcnt = GetEntityCount();
-	for(new ent=1; ent < entcnt; ent++)
+	for(new ent=1; ent <= entcnt; ent++)
 	{
 		new WeaponId:source=IdentifyWeapon(ent);
 		if(source > WEPID_NONE && g_GlobalWeaponRules[source] != -1)

--- a/addons/sourcemod/scripting/l4d_stuckzombiemeleefix.sp
+++ b/addons/sourcemod/scripting/l4d_stuckzombiemeleefix.sp
@@ -2,7 +2,7 @@
 #include <sdktools>
 #define DEBUG 0
 
-#define PLUGIN_VERSION "1.0.4"
+#define PLUGIN_VERSION "1.0.5"
 
 public Plugin:myinfo = 
 {
@@ -29,7 +29,7 @@ public Action:HookSound_Callback(Clients[64], &NumClients, String:StrSample[PLAT
 	if (StrContains(StrSample, "Swish", false) == -1) return Plugin_Continue;
 	//so the client has the melee sound playing. OMG HES MELEEING!
 	
-	if (Entity > MAXPLAYERS) return Plugin_Continue; // bugfix for some people on L4D2
+	if (Entity > MaxClients) return Plugin_Continue; // bugfix for some people on L4D2
 	
 	//add in a 1 second delay so this doesnt fire every frame
 	if (MeleeDelay[Entity]) return Plugin_Continue; //note 'Entity' means 'client' here

--- a/addons/sourcemod/scripting/l4d_tank_control_eq.sp
+++ b/addons/sourcemod/scripting/l4d_tank_control_eq.sp
@@ -280,7 +280,8 @@ public Action:GiveTank_Cmd(client, args)
 public chooseTank()
 {
     // Create our pool of players to choose from
-    new Handle:infectedPool = teamSteamIds(L4D2Team_Infected);
+    new Handle:infectedPool = CreateArray(64);
+    addTeamSteamIdsToArray(infectedPool, L4D2Team_Infected);
     
     // If there is nobody on the infected team, return (otherwise we'd be stuck trying to select forever)
     if (GetArraySize(infectedPool) == 0)
@@ -295,7 +296,8 @@ public chooseTank()
     // If the infected pool is empty, remove infected players from pool
     if (GetArraySize(infectedPool) == 0) // (when nobody on infected ,error)
     {
-        new Handle:infectedTeam = teamSteamIds(L4D2Team_Infected);
+        new Handle:infectedTeam = CreateArray(64);
+        addTeamSteamIdsToArray(infectedTeam, L4D2Team_Infected);
         if (GetArraySize(infectedTeam) > 1)
         {
             h_whosHadTank = removeTanksFromPool(h_whosHadTank, infectedTeam);
@@ -419,18 +421,16 @@ stock PrintToInfected(const String:Message[], any:... )
     }
 }
 /**
- * Returns an array of steam ids for a particular team.
+ * Adds steam ids for a particular team to an array.
  * 
+ * @ param Handle:steamIds
+ *     The array steam ids will be added to.
  * @param L4D2Team:team
- *     The team which to return steam ids for.
- * 
- * @return
- *     An array of steam ids.
+ *     The team to get steam ids for.
  */
  
-public Handle:teamSteamIds(L4D2Team:team)
+public Handle:addTeamSteamIdsToArray(Handle:steamIds, L4D2Team:team)
 {
-    new Handle:steamIds = CreateArray(64);
     decl String:steamId[64];
 
     for (new i = 1; i <= MaxClients; i++)
@@ -446,8 +446,6 @@ public Handle:teamSteamIds(L4D2Team:team)
             PushArrayString(steamIds, steamId);
         }
     }
-    
-    return steamIds;
 }
 
 /**

--- a/addons/sourcemod/scripting/l4d_tank_control_eq.sp
+++ b/addons/sourcemod/scripting/l4d_tank_control_eq.sp
@@ -283,8 +283,11 @@ public chooseTank()
     
     // If there is nobody on the infected team, return (otherwise we'd be stuck trying to select forever)
     if (GetArraySize(infectedPool) == 0)
+    {
+        CloseHandle(infectedPool);
         return;
-    
+    }
+
     // Remove players who've already had tank from the pool.
     infectedPool = removeTanksFromPool(infectedPool, h_whosHadTank);
     
@@ -302,6 +305,8 @@ public chooseTank()
             queuedTankSteamId = "";
         }
         
+        CloseHandle(infectedTeam);
+        CloseHandle(infectedPool);
         return;
     }
     

--- a/addons/sourcemod/scripting/l4d_tank_control_eq.sp
+++ b/addons/sourcemod/scripting/l4d_tank_control_eq.sp
@@ -298,7 +298,7 @@ public chooseTank()
         new Handle:infectedTeam = teamSteamIds(L4D2Team_Infected);
         if (GetArraySize(infectedTeam) > 1)
         {
-            h_whosHadTank = removeTanksFromPool(h_whosHadTank, teamSteamIds(L4D2Team_Infected));
+            h_whosHadTank = removeTanksFromPool(h_whosHadTank, infectedTeam);
             chooseTank();
         }
         else

--- a/addons/sourcemod/scripting/l4d_tank_control_eq.sp
+++ b/addons/sourcemod/scripting/l4d_tank_control_eq.sp
@@ -5,6 +5,7 @@
 #include <left4dhooks>
 #include <colors>
 #include <readyup>
+#include <l4d2util>
 
 #define IS_VALID_CLIENT(%1)     (%1 > 0 && %1 <= MaxClients)
 #define IS_INFECTED(%1)         (GetClientTeam(%1) == 3)

--- a/addons/sourcemod/scripting/l4d_tank_control_eq.sp
+++ b/addons/sourcemod/scripting/l4d_tank_control_eq.sp
@@ -5,7 +5,6 @@
 #include <left4dhooks>
 #include <colors>
 #include <readyup>
-#include <l4d2util>
 
 #define IS_VALID_CLIENT(%1)     (%1 > 0 && %1 <= MaxClients)
 #define IS_INFECTED(%1)         (GetClientTeam(%1) == 3)
@@ -54,6 +53,7 @@ public OnPluginStart()
     
     // Event hooks
     HookEvent("player_left_start_area", EventHook:PlayerLeftStartArea_Event, EventHookMode_PostNoCopy);
+    HookEvent("round_start", EventHook:RoundStart_Event, EventHookMode_PostNoCopy);
     HookEvent("round_end", EventHook:RoundEnd_Event, EventHookMode_PostNoCopy);
     HookEvent("player_team", EventHook:PlayerTeam_Event, EventHookMode_PostNoCopy);
     HookEvent("tank_killed", EventHook:TankKilled_Event, EventHookMode_PostNoCopy);
@@ -95,7 +95,7 @@ public OnClientDisconnect(client)
  * When a new game starts, reset the tank pool.
  */
  
-public OnRoundStart()
+public RoundStart_Event()
 {
     CreateTimer(10.0, newGame);
 }

--- a/addons/sourcemod/scripting/l4d_weapon_limits.sp
+++ b/addons/sourcemod/scripting/l4d_weapon_limits.sp
@@ -14,7 +14,7 @@ public Plugin:myinfo =
 	name = "L4D Weapon Limits",
 	author = "CanadaRox, Stabby",
 	description = "Restrict weapons individually or together",
-	version = "1.3.1",
+	version = "1.3.2",
 	url = "https://www.github.com/CanadaRox/sourcemod-plugins/tree/master/weapon_limits"
 }
 
@@ -59,10 +59,10 @@ public OnPluginStart()
 
 	HookEvent("player_incapacitated_start", OnIncap);
 	HookEvent("revive_success", OnRevive);
-	HookEvent("round_end", OnRoundEnd);
+	HookEvent("round_end", RoundEndEvent);
 }
 
-public OnRoundEnd(Handle:event, const String:name[], bool:dontBroadcast)
+public RoundEndEvent(Handle:event, const String:name[], bool:dontBroadcast)
 {
 	for (new i = 1; i <= MaxClients; i++)
 	{

--- a/addons/sourcemod/scripting/l4d_weapon_limits.sp
+++ b/addons/sourcemod/scripting/l4d_weapon_limits.sp
@@ -14,7 +14,7 @@ public Plugin:myinfo =
 	name = "L4D Weapon Limits",
 	author = "CanadaRox, Stabby",
 	description = "Restrict weapons individually or together",
-	version = "1.3",
+	version = "1.3.1",
 	url = "https://www.github.com/CanadaRox/sourcemod-plugins/tree/master/weapon_limits"
 }
 
@@ -239,7 +239,7 @@ stock FindAmmoSpawn()
 {
 	new psychonic = GetEntityCount();
 	decl String:classname[64];
-	for (new i = MaxClients; i < psychonic; ++i)
+	for (new i = MaxClients+1; i <= psychonic; ++i)
 	{
 		if (IsValidEntity(i))
 		{

--- a/addons/sourcemod/scripting/readyup.sp
+++ b/addons/sourcemod/scripting/readyup.sp
@@ -20,7 +20,7 @@ public Plugin:myinfo =
 	name = "L4D2 Ready-Up",
 	author = "CanadaRox, (Lazy unoptimized additions by Sir)",
 	description = "New and improved ready-up plugin.",
-	version = "9.2",
+	version = "9.2.1",
 	url = ""
 };
 
@@ -97,7 +97,7 @@ public OnPluginStart()
 	l4d_ready_cfg_name = CreateConVar("l4d_ready_cfg_name", "", "Configname to display on the ready-up panel", FCVAR_PRINTABLEONLY);
 	l4d_ready_disable_spawns = CreateConVar("l4d_ready_disable_spawns", "0", "Prevent SI from having spawns during ready-up", 0, true, 0.0, true, 1.0);
 	l4d_ready_survivor_freeze = CreateConVar("l4d_ready_survivor_freeze", "1", "Freeze the survivors during ready-up.  When unfrozen they are unable to leave the saferoom but can move freely inside", 0, true, 0.0, true, 1.0);
-	l4d_ready_max_players = CreateConVar("l4d_ready_max_players", "12", "Maximum number of players to show on the ready-up panel.", 0, true, 0.0, true, MAXPLAYERS+1.0);
+	l4d_ready_max_players = CreateConVar("l4d_ready_max_players", "12", "Maximum number of players to show on the ready-up panel.", 0, true, 0.0, true, MAXPLAYERS);
 	l4d_ready_delay = CreateConVar("l4d_ready_delay", "3", "Number of seconds to count down before the round goes live.", 0, true, 0.0);
 	l4d_ready_enable_sound = CreateConVar("l4d_ready_enable_sound", "1", "Enable sound during countdown & on live");
 	l4d_ready_chuckle = CreateConVar("l4d_ready_chuckle", "1", "Enable chuckle during countdown");

--- a/addons/sourcemod/scripting/tankdoorfix.sp
+++ b/addons/sourcemod/scripting/tankdoorfix.sp
@@ -7,7 +7,7 @@
 #include <sdkhooks>
 #include <entity_prop_stocks>
 
-#define VERSION "1.4"
+#define VERSION "1.4.1"
 
 //Found ent 'prop_door_rotating', id: 163
 
@@ -27,7 +27,7 @@
 
 new tankCount;
 
-new Float:nextTankPunchAllowed[19];
+new Float:nextTankPunchAllowed[MAXPLAYERS+1];
 
 new tankClassIndex;
 


### PR DESCRIPTION
* Corrected errors with MaxClients and MAXPLAYERS.
* Corrected a couple instances of unclosed handles
* Renamed event handlers whose names conflict with l4d2util global forwards (OnRoundStart, OnRoundEnd, OnTankSpawn) in plugins that don't include l4d2util and hook the events themselves, otherwise they fire twice (from plugin's own hook + l4d2util global forward).
* Added l4d2util include to plugins that rely on its OnRoundStart global forward because they don't hook round_start themselves. This just makes the dependency on l4d2util explicit.