### PR TITLE
fix handle leak and fix TIMER_FLAG_NO_MAPCHANGE usage

### DIFF
--- a/addons/sourcemod/scripting/fix_engine.sp
+++ b/addons/sourcemod/scripting/fix_engine.sp
@@ -1,4 +1,4 @@
-#define PLUGIN_VERSION "1.1.1"
+#define PLUGIN_VERSION "1.1.2"
 
 #pragma semicolon 1
 
@@ -58,6 +58,18 @@ public OnPluginStart()
 #if debug
 	RegConsoleCmd("debug", CmdDebug);
 #endif
+}
+
+public OnMapEnd()
+{
+	for (new i = 0; i <= MAXPLAYERS; i++)
+	{
+		g_hRestoreTimer[i] = INVALID_HANDLE;
+		g_hFixGlitchTimer[i] = INVALID_HANDLE;
+#if debug
+		g_hDebugTimer[i] = INVALID_HANDLE;
+#endif
+	}
 }
 
 /*                                      +==========================================+

--- a/addons/sourcemod/scripting/l4d2_getupfix.sp
+++ b/addons/sourcemod/scripting/l4d2_getupfix.sp
@@ -12,7 +12,7 @@ public Plugin:myinfo =
     name = "L4D2 Get-Up Fix",
     author = "Blade, ProdigySim, DieTeetasse, Stabby, Jahze",
     description = "Double/no/self-clear get-up fix.",
-    version = "1.7.1",
+    version = "1.7.2",
     url = "http://bitbucket.org/ProdigySim/misc-sourcemod-plugins/"
 }
 
@@ -111,6 +111,7 @@ public Action:Timer_CheckClient(Handle:timer, any:tempStack) {
     decl client, oldSequence, Float:duration;
     PopStackCell(tempStack, oldSequence);
     PopStackCell(tempStack, client);
+    CloseHandle(tempStack);
     
     new SurvivorCharacter:charIndex = IdentifySurvivor(client);    
     if (charIndex == SC_NONE) return;

--- a/addons/sourcemod/scripting/l4d2_nosey_parker.sp
+++ b/addons/sourcemod/scripting/l4d2_nosey_parker.sp
@@ -36,7 +36,7 @@ public Plugin:myinfo =
 {
     name        = "L4D2 Display Infected HP",
     author      = "Visor",
-    version     = "1.2",
+    version     = "1.2.1",
     description = "Survivors receive damage reports after they get capped",
     url         = "https://github.com/Attano/Equilibrium"
 };
@@ -56,6 +56,11 @@ public OnPluginStart()
 public OnConfigsExecuted()
 {
     fGhostDelay = GetConVarFloat(FindConVar("z_ghost_delay_min"));
+}
+
+public OnMapEnd()
+{
+    ClearTimer(hTongueParalyzeTimer);
 }
 
 public Action:Event_PlayerHurt(Handle:event, const String:name[], bool:dontBroadcast)
@@ -117,7 +122,7 @@ public Event_SmokerAttackFirst(Handle:event, const String:name[], bool:dontBroad
     PushStackCell(hEventMembers, checks);
 
     // It takes exactly 1.0s of dragging to get paralyzed, so we'll give the timer additional 0.1s to update
-    hTongueParalyzeTimer = CreateTimer(1.1, CheckSurvivorState, hEventMembers, TIMER_FLAG_NO_MAPCHANGE);
+    hTongueParalyzeTimer = CreateTimer(1.1, CheckSurvivorState, hEventMembers);
 }
 
 public Action:CheckSurvivorState(Handle:timer, any:hEventMembers)
@@ -129,6 +134,7 @@ public Action:CheckSurvivorState(Handle:timer, any:hEventMembers)
         PopStackCell(hEventMembers, victim);
         PopStackCell(hEventMembers, attacker);
     }
+    CloseHandle(hEventMembers);
 
     if (IsSurvivorParalyzed(victim))
     {


### PR DESCRIPTION
Fixed leaked handles in l4d2_nosey_parker.sp and l4d2_getupfix.sp.

Tracked timers should be manually ended OnMapEnd instead of using TIMER_FLAG_NO_MAPCHANGE ([wiki reference](https://wiki.alliedmods.net/SourcePawn_Basics_-_Handles,_DataPacks,_and_Timers#.22Fire_and_Forget.22_vs._.22Tracked.22_Timers)), otherwise the variable will not be set to INVALID_HANDLE. Can also be fixed by setting the variable to INVALID_HANDLE which is the approach I used for fix_engine.sp.
Addresses the issue in https://github.com/SirPlease/L4D2-Competitive-Rework/pull/173