### PR TITLE
L4D2Lib unbound native fix

### DIFF
--- a/addons/sourcemod/scripting/include/confogl.inc
+++ b/addons/sourcemod/scripting/include/confogl.inc
@@ -152,7 +152,7 @@ public __pl_confogl_SetNTVOptional()
 	MarkNativeAsOptional("LGO_IsMapDataAvailable");
 	MarkNativeAsOptional("LGO_GetMapValueInt");
 	MarkNativeAsOptional("LGO_GetMapValueFloat");
-	MarkNativeAsOptional("LGO__GetMapValueVector");
+	MarkNativeAsOptional("LGO_GetMapValueVector");
 	MarkNativeAsOptional("LGO_GetMapValueString");
 	MarkNativeAsOptional("LGO_CopyMapSubsection");
 	MarkNativeAsOptional("LGO_IsMatchModeLoaded");

--- a/addons/sourcemod/scripting/include/mapinfo.inc
+++ b/addons/sourcemod/scripting/include/mapinfo.inc
@@ -1,7 +1,8 @@
 #include <sourcemod>
 #include <sdktools>
 #include <left4dhooks>
-#include <lgofnoc.inc>
+#undef REQUIRE_PLUGIN
+#include <confogl.inc>
 
 #if defined __mapinfo__
 #endinput

--- a/addons/sourcemod/scripting/l4d2lib.sp
+++ b/addons/sourcemod/scripting/l4d2lib.sp
@@ -60,7 +60,6 @@ public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
 	CreateNative("L4D2_GetMapValueVector", _native_GetMapValueVector);
 	CreateNative("L4D2_GetMapValueString", _native_GetMapValueString);
 	CreateNative("L4D2_CopyMapSubsection", _native_CopyMapSubsection);
-	MarkNativeAsOptional("LGO_BuildConfigPath"); // Prevent loading issues.
 	
 	/* Plugin Forward Declarations */
 	hFwdRoundStart = CreateGlobalForward("L4D2_OnRealRoundStart", ET_Ignore, Param_Cell);

--- a/addons/sourcemod/scripting/l4d2lib.sp
+++ b/addons/sourcemod/scripting/l4d2lib.sp
@@ -8,15 +8,14 @@
 
 #define LIBRARYNAME "l4d2lib"
 
-// Workaround
-new bool:bFirstLoad = true;
+new bool:g_bConfogl = false;
 
 public Plugin:myinfo = 
 {
 	name = "L4D2Lib",
 	author = "Confogl Team",
 	description = "Useful natives and fowards for L4D2 Plugins",
-	version = "1.0",
+	version = "1.0.1",
 	url = "https://bitbucket.org/ProdigySim/misc-sourcemod-plugins"
 }
 
@@ -76,16 +75,30 @@ public APLRes:AskPluginLoad2(Handle:myself, bool:late, String:error[], err_max)
 	return APLRes_Success;
 }
 
+public OnLibraryAdded(const String:name[])
+{
+	if (StrEqual(name, "confogl"))
+	{
+		MapInfo_Init();
+		g_bConfogl = true;
+	}
+}
+
+public OnLibraryRemoved(const String:name[])
+{
+	if (StrEqual(name, "confogl"))
+	{
+		g_bConfogl = false;
+	}
+}
+
 public OnMapStart()
 {
-	if (bFirstLoad) 
+	if (g_bConfogl)
 	{
-		// Little workaround, do it here so that it won't get loaded on OnPluginStart or OnAllPluginsLoaded, or it will fail to use the needed LGO native due to how Confoglcompmod works.
-		MapInfo_Init();
-		bFirstLoad = false;
+		MapInfo_OnMapStart_Update();
+		Tanks_OnMapStart();
 	}
-	MapInfo_OnMapStart_Update();
-	Tanks_OnMapStart();
 }
 
 public OnMapEnd()
@@ -219,6 +232,8 @@ public _native_GetMapEndDist(Handle:plugin, numParams)
 
 public _native_GetMapValueInt(Handle:plugin, numParams)
 {
+	if (!g_bConfogl) return 0;
+
 	decl len, defval;
 	
 	GetNativeStringLength(1, len);
@@ -231,6 +246,8 @@ public _native_GetMapValueInt(Handle:plugin, numParams)
 }
 public _native_GetMapValueFloat(Handle:plugin, numParams)
 {
+	if (!g_bConfogl) return 0;
+
 	decl len, Float:defval;
 	
 	GetNativeStringLength(1, len);
@@ -244,6 +261,8 @@ public _native_GetMapValueFloat(Handle:plugin, numParams)
 
 public _native_GetMapValueVector(Handle:plugin, numParams)
 {
+	if (!g_bConfogl) return;
+
 	decl len, Float:defval[3], Float:value[3];
 	
 	GetNativeStringLength(1, len);
@@ -259,6 +278,8 @@ public _native_GetMapValueVector(Handle:plugin, numParams)
 
 public _native_GetMapValueString(Handle:plugin, numParams)
 {
+	if (!g_bConfogl) return;
+
 	decl len;
 	GetNativeStringLength(1, len);
 	new String:key[len+1];
@@ -278,6 +299,8 @@ public _native_GetMapValueString(Handle:plugin, numParams)
 
 public _native_CopyMapSubsection(Handle:plugin, numParams)
 {
+	if (!g_bConfogl) return;
+
 	decl len, Handle:kv;
 	GetNativeStringLength(2, len);
 	new String:key[len+1];


### PR DESCRIPTION
My attempt at fixing https://github.com/SirPlease/L4D2-Competitive-Rework/issues/103

I found through testing that the confogl natives weren't available OnMapStart (the very first time after the config is loaded but before the map is reloaded) since l4d2lib is loaded before confoglcompmod. so I moved MapInfo_Init from OnMapStart to OnLibraryAdded. This resolves the unbound native error.

Another thing I noticed is that currently kMIData gets initialized before the error is thrown in the next line that calls LGO_BuildConfigPath. https://github.com/SirPlease/L4D2-Competitive-Rework/blob/c20db7a6dd589b5fec364b1ed0d22c89244572e0/addons/sourcemod/scripting/include/mapinfo.inc#L182

Since kMIData is initialized, any calls to `GetMapValueInt` don't currently throw an error. But since this PR now doesn't call MapInfo_Init at all until confogl is ready, kMIData is not initialized and will still be INVALID_HANDLE. So when other plugins call L4D2_GetMapValueInt in their OnMapStart after loading the config it would throw an error. That's why I added additional checks in the l4d2lib natives so they just return if confogl is not loaded yet. Since this only comes up in the OnMapStart event after the config is loaded, I don't think this causes any issues because there is another OnMapStart after the map reload.