### PR TITLE
Fix stuck survivors in c2m4 saferoom.

### DIFF
--- a/cfg/stripper/zonemod/maps/c2m4_barns.cfg
+++ b/cfg/stripper/zonemod/maps/c2m4_barns.cfg
@@ -312,6 +312,18 @@ add:
 	"classname" "env_physics_blocker"
 }
 
+; --- Teleport trigger to un-stuck survivors that spawn in the newly-added props after ready-up.
+add:
+{
+    "model" "*73"
+    "spawnflags" "1"
+    "angles" "0 45 0"
+    "origin" "3290 3792 37"
+    "classname" "trigger_teleport"
+    "filtername" "filter_survivors"
+    "target" "c2m3_c2m4_landmark"
+}
+
 ; =====================================================
 ; =========  PROMOD HUNTINGRIFLE REPLACEMENT  =========
 ; =====================================================


### PR DESCRIPTION
Added a teleport trigger in fence props - teleports to center of room.
![unknown 1](https://user-images.githubusercontent.com/41553860/97800100-20bc9000-1bf8-11eb-8c2a-9ed4b811f2ff.png)
