### PR TITLE
Fixed c5m2 onslaught event warningas

### DIFF
--- a/cfg/stripper/zonemod/maps/c5m2_park.cfg
+++ b/cfg/stripper/zonemod/maps/c5m2_park.cfg
@@ -27,7 +27,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "director,BeginScript,director_onslaught_rework_c5m2.nut,1,-1"
+		"OnStartTouch" "director,BeginScript,director_onslaught_rework_c5m2,1,-1"
 	}
 }
 ; --- Run script to check survivor flow progression
@@ -36,7 +36,7 @@ add:
 	"classname" "logic_timer"
 	"targetname" "OnslaughtFlowChecker"
 	"StartDisabled" "1"
-	"RefireTime" "10"
+	"RefireTime" "1"
 	"vscripts" "director_onslaught_flow_checker"
 	; --- Check survivor flow periodically
 	"OnTimer" "OnslaughtFlowChecker,RunScriptCode,OnslaughtCheckFlow(),0,-1"
@@ -559,6 +559,15 @@ add:
 	"maxs" "45 0.5 25"
 	"initialstate" "1"
 	"BlockType" "0"
+}
+; --- Fix a perma-stuck spot on a ladder before the event that was moved in TLS update
+{
+	"classname" "env_physics_blocker"
+	"origin" "-9295 -5123 -236"
+	"mins" "-9 -9 -20"
+	"maxs" "9 9 20"
+	"initialstate" "1"
+	"BlockType" "2"
 }
 
 ; =====================================================

--- a/scripts/vscripts/director_onslaught_flow_checker.nut
+++ b/scripts/vscripts/director_onslaught_flow_checker.nut
@@ -1,13 +1,17 @@
 Msg("Initiating Onslaught Flow Checker\n");
 
-g_TankSpanwed <- false;
-g_StartingFlow <- 0;
+g_TankSpawned <- false
+g_StartingFlow <- 0
 g_MaxTravelDistance <- Convars.GetFloat("director_tank_bypass_max_flow_travel")
+g_WarnedOnce <- false
+
+// Precache warning sound
+PrecacheSound("Hint.Critical")
 
 function OnslaughtGetStartingFlow()
 {
-	g_TankSpanwed = true
-	g_StartingFlow = Director.GetFurthestSurvivorFlow();
+	g_TankSpawned = true
+	g_StartingFlow = Director.GetFurthestSurvivorFlow()
 	
 	if (developer() > 0)
 	{
@@ -17,15 +21,35 @@ function OnslaughtGetStartingFlow()
 
 function OnslaughtCheckFlow()
 {
-	if (g_TankSpanwed == true)
+	if (g_TankSpawned == true)
 	{
-		local CurrentMaxFlow = Director.GetFurthestSurvivorFlow();
+		local CurrentMaxFlow = Director.GetFurthestSurvivorFlow()
 		
-		// Survivors have travelled past the relax threshold, horde will now spawn regardless of tank state, inform players
-		if (CurrentMaxFlow > g_StartingFlow + g_MaxTravelDistance)
+		// Check furthest survivor flow
+		if (CurrentMaxFlow > g_StartingFlow + (g_MaxTravelDistance * 0.7))
 		{
-			ClientPrint(null, 3, "\x05Horde has resumed due to progression")
-			EntFire("OnslaughtFlowChecker", "Kill")
+			// Survivors have travelled past the relax threshold, horde will now spawn regardless of tank state, inform players
+			if (CurrentMaxFlow > g_StartingFlow + g_MaxTravelDistance)
+			{
+				ClientPrint(null, 3, "\x05Horde has resumed due to progression!")
+				EntFire("OnslaughtFlowChecker", "Disable")
+				
+				// Play sound cue to warn players
+				local players = null;
+				while (players = Entities.FindByClassname(players, "player"))
+				{
+					EmitSoundOnClient("Hint.Critical", players)
+				}
+			}
+			else
+			{
+				// Warn survivors getting close to the bypass point
+				if (g_WarnedOnce == false)
+				{
+					ClientPrint(null, 3, "\x05Survivors are nearing the allowed travel distance...")
+					g_WarnedOnce = true
+				}
+			}
 		}
 		
 		if (developer() > 0)


### PR DESCRIPTION
* Fixed issues with horde warnings during event tanks, which was preventing the horde from relaxing as intended
* Added a sound cue for when the horde is resumed due to progression

Also fixes a perma-stuck spot that should have been included in the current version, I guess it got missed out.