### PR TITLE
l4d2_nobhaps rework

### DIFF
--- a/addons/sourcemod/scripting/l4d2_nobhaps.sp
+++ b/addons/sourcemod/scripting/l4d2_nobhaps.sp
@@ -4,103 +4,117 @@
 public Plugin:myinfo =
 {
 	name = "Simple Anti-Bunnyhop",
-	author = "CanadaRox, ProdigySim, blodia, CircleSquared",
-	description = "Stops bunnyhops by restricting speed when a player lands on the ground to their MaxSpeed",
-	version = "0.2",
-	url = "https://bitbucket.org/CanadaRox/random-sourcemod-stuff/"
+	author = "CanadaRox, ProdigySim, blodia, CircleSquared, robex",
+	description = "Stops bunnyhops by restricting speed when a player lands a perfect bhop",
+	version = "1.0",
+	url = "https://github.com/SirPlease/L4D2-Competitive-Rework"
 };
 
 
 #define DEBUG 0
 
-#define L4DBUILD 1
+#define MIN_JUMP_TIME 0.500
 
 new Handle:hCvarEnable;
-#if defined(L4DBUILD)
 new Handle:hCvarSIExcept;
 new Handle:hCvarSurvivorExcept;
-#endif
+new Handle:hCvarConsecutiveHopsSI;
+
+int consecutiveBhops = 0;
 
 public OnPluginStart()
 {
 	hCvarEnable = CreateConVar("simple_antibhop_enable", "1", "Enable or disable the Simple Anti-Bhop plugin");
-#if defined(L4DBUILD)
-	hCvarSIExcept = CreateConVar("bhop_except_si_flags", "0", 
-		"Bitfield for exempting SI in anti-bhop functionality. From least significant: Smoker, Boomer, Hunter, Spitter, Jockey, Charger, Tank");
+	hCvarSIExcept = CreateConVar("bhop_except_si_flags", "0", "Bitfield for exempting SI in anti-bhop functionality. From least significant: Smoker, Boomer, Hunter, Spitter, Jockey, Charger, Tank");
 	hCvarSurvivorExcept = CreateConVar("bhop_allow_survivor", "0", "Allow Survivors to bhop while plugin is enabled");
-#endif
-
+	hCvarConsecutiveHopsSI = CreateConVar("bhop_consecutive_hops_si", "0", "How many consecutive bhops to allow for non-exempt SI");
 }
 
 public Action:OnPlayerRunCmd(client, &buttons, &impulse, Float:vel[3], Float:angles[3], &weapon)
 {
-	if (!IsValidClient(client) || IsFakeClient(client)) return Plugin_Continue;
+	if (!IsValidClient(client) || IsFakeClient(client))
+		return Plugin_Continue;
 
-	static Float:LeftGroundMaxSpeed[MAXPLAYERS + 1];
-	
-	if(!GetConVarBool(hCvarEnable)) return Plugin_Continue;
-	
-	if (IsPlayerAlive(client))
-	{
-		#if defined(L4DBUILD)
-		if(GetClientTeam(client) == 3)
-		{
-			new class = GetEntProp(client, Prop_Send, "m_zombieClass");
-			if(class == 8) // tank
-			{
-				--class;
-			}
+	if (!GetConVarBool(hCvarEnable))
+		return Plugin_Continue;
+
+	if (!IsPlayerAlive(client))
+		return Plugin_Continue;
+
+	if (GetClientTeam(client) == 3) {
+		new class = GetEntProp(client, Prop_Send, "m_zombieClass");
+		// tank is class 8 but we want to make it 7 to match bitfield
+		if (class == 8) {
 			class--;
-			new except = GetConVarInt(hCvarSIExcept);
-			if(class >=0 && class <=6 && ((1 << class) & except))
-			{
-				// Skipping calculation for This SI based on exception rules
-				return Plugin_Continue;
-			}
 		}
-		if(GetClientTeam(client) == 2)
-        {
-            if(GetConVarBool(hCvarSurvivorExcept))
-            {
-                return Plugin_Continue;
-            }
-        }
-		#endif
-		
-		new ClientFlags = GetEntityFlags(client);
-		if (ClientFlags & FL_ONGROUND)
-		{
-			if (LeftGroundMaxSpeed[client] != -1.0)
-			{
-				
-				new Float:CurVelVec[3];
-				GetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", CurVelVec);
-				
-				if (GetVectorLength(CurVelVec) > LeftGroundMaxSpeed[client])
-				{
-					#if DEBUG
-					PrintToChat(client, "Speed: %f {%.02f, %.02f, %.02f}, MaxSpeed: %f", GetVectorLength(CurVelVec), CurVelVec[0], CurVelVec[1], CurVelVec[2], LeftGroundMaxSpeed[client]);
-					#endif
-					NormalizeVector(CurVelVec, CurVelVec);
-					ScaleVector(CurVelVec, LeftGroundMaxSpeed[client]);
-					TeleportEntity(client, NULL_VECTOR, NULL_VECTOR, CurVelVec);
-				}
-				LeftGroundMaxSpeed[client] = -1.0;
-			}
-		}
-		else if(LeftGroundMaxSpeed[client] == -1.0)
-		{
-			LeftGroundMaxSpeed[client] = GetEntPropFloat(client, Prop_Data, "m_flMaxspeed");
+		class--;
+		new except = GetConVarInt(hCvarSIExcept);
+		if (class >= 0 && class <= 6 && ((1 << class) & except)) {
+			// Skipping calculation for This SI based on exception rules
+			return Plugin_Continue;
 		}
 	}
-	
+	if (GetClientTeam(client) == 2) {
+		if (GetConVarBool(hCvarSurvivorExcept)) {
+			return Plugin_Continue;
+		}
+	}
+
+	static int iPrevButtons[MAXPLAYERS + 1];
+	static float fCheckTime[MAXPLAYERS + 1];
+
+	bool bhopDetected = false;
+	new ClientFlags = GetEntityFlags(client);
+
+	if (!(buttons & IN_JUMP) && (ClientFlags & FL_ONGROUND) && fCheckTime[client] > 0.0) {
+		fCheckTime[client] = 0.0;
+	}
+
+	if ((buttons & IN_JUMP) && !(iPrevButtons[client] & IN_JUMP)) {
+		if (ClientFlags & FL_ONGROUND) {
+			float fGameTime = GetGameTime();
+
+			if (fCheckTime[client] > 0.0 && fGameTime > fCheckTime[client]) {
+				consecutiveBhops++;
+#if DEBUG
+				PrintToChat(client, "Bhop detected, consecutive hops: %d", consecutiveBhops);
+#endif
+				bhopDetected = true;
+			} else {
+				consecutiveBhops = 0;
+				fCheckTime[client] = fGameTime + MIN_JUMP_TIME;
+			}
+		} else {
+			consecutiveBhops = 0;
+			fCheckTime[client] = 0.0;
+		}
+	}
+
+	iPrevButtons[client] = buttons;
+
+	int allowedConsecHops = GetConVarInt(hCvarConsecutiveHopsSI);
+	if (bhopDetected && consecutiveBhops > allowedConsecHops) {
+		float CurVelVec[3];
+		float maxSpeed = GetEntPropFloat(client, Prop_Data, "m_flMaxspeed");
+
+		GetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", CurVelVec);
+
+		if (GetVectorLength(CurVelVec) > maxSpeed) {
+#if DEBUG
+			PrintToChat(client, "Speed: %f {%.02f, %.02f, %.02f}, MaxSpeed: %f", GetVectorLength(CurVelVec), CurVelVec[0], CurVelVec[1], CurVelVec[2], maxSpeed);
+#endif
+			NormalizeVector(CurVelVec, CurVelVec);
+			ScaleVector(CurVelVec, maxSpeed);
+			SetEntPropVector(client, Prop_Data, "m_vecAbsVelocity", CurVelVec);
+		}
+	}
+
 	return Plugin_Continue;
 } 
 
 stock bool:IsValidClient(client)
 { 
-	if (client <= 0 || client > MaxClients || !IsClientConnected(client))
-	{
+	if (client <= 0 || client > MaxClients || !IsClientConnected(client)) {
 		return false; 
 	}
 	return IsClientInGame(client); 


### PR DESCRIPTION
- check for perfect bhops instead of landing speed
- use `SetEntProp` instead of `TeleportEntity` for capping speed
- add extra convar `bhop_consecutive_hops_si` to allow for a certain number of hops on non-exempt SI (in case keeping old 1-bhop allowed behavior is desired)

[FIXED] ~~Known issue (was already present before and on every jump, not just perfect bhops):~~

~~- If you land a perfect hop while holding crouch, speed will be limited to crouch speed instead of max running speed, because the EntProp `m_flMaxspeed` is dependent on whether you're crouching or not. If someone knows a way to get max running speed it would be an easy fix, just replace the variable.~~

I've tested the plugin on as many scenarios as I could think of with no issues but further testing may be required.