### PR TITLE
Fix Diescraper ball not breaking

### DIFF
--- a/cfg/stripper/zonemod/global_filters.cfg
+++ b/cfg/stripper/zonemod/global_filters.cfg
@@ -36,7 +36,7 @@ modify:
 	}
 	replace:
 	{
-		"classname" "prop_physics_override"
+		"classname" "prop_physics"
 	}
 }
 ; --- Hotfixes for specific props

--- a/cfg/stripper/zonemod/global_filters.cfg
+++ b/cfg/stripper/zonemod/global_filters.cfg
@@ -39,6 +39,19 @@ modify:
 		"classname" "prop_physics_override"
 	}
 }
+; --- Hotfixes for specific props
+; --- Diescraper ball
+{
+	match:
+	{
+		"model" "models/props_diescraper/statue.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+
 
 ; =====================================================
 ; ==                 ITEM DENSITY FIX                ==


### PR DESCRIPTION
Revert change to prop fix for custom campaigns as it causes issues with breakable props.

Fixes the ball on the Diescraper finale not breaking.