### PR TITLE
Update old Zonemod global_filters

### DIFF
--- a/cfg/stripper/zonemodold/global_filters.cfg
+++ b/cfg/stripper/zonemodold/global_filters.cfg
@@ -2,7 +2,16 @@
 ; ==                  WITCH REMOVAL                  ==
 ; ==           Remove scripted witch spawns          ==
 ; =====================================================
+; --- Uncomment to remove scripted witch spawns
 filter:
+{
+	"classname" "info_zombie_spawn"
+	"population" "witch"
+}
+{
+	"classname" "info_zombie_spawn"
+	"population" "witch_bride"
+}
 {
 	"targetname" "witch_spawn"
 }
@@ -14,10 +23,532 @@ filter:
 }
 
 ; =====================================================
+; ==                 ENTITY TYPE FIX                 ==
+; ==     Fix entities using the wrong class type     ==
+; =====================================================
+; --- Convert prop_physics_multiplayer hittables on custom campaigns into correct class type to prevent issues with plugins
+modify:
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_junk/dumpster.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_junk/dumpster_2.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/cara_69sedan.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/cara_82hatchback.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/cara_82hatchback_wrecked.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/cara_84sedan.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/cara_95sedan.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/cara_95sedan_wrecked.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/police_car.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/police_car.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/police_car_city.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/police_car_lights_on.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/police_car_opentrunk.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/police_car_rural.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/taxi_cab.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/taxi_city.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/taxi_rural.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props/cs_assault/forklift.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics_override"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props/cs_assault/forklift_brokenlift.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics_override"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/airport_baggage_cart2.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_foliage/swamp_fallentree01_bare.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_foliage/tree_trunk_fallen.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_unique/haybails_single.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_fairgrounds/bumpercar.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/generatortrailer01.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props/cs_assault/handtruck.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/utility_truck.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "/.*models/props/cs_militia/militiarock.*/"
+	}
+	replace:
+	{
+		"classname" "prop_physics_override"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_unique/airport/atlas_break_ball.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_interiors/ibeam_breakable01_damaged02.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_vehicles/van.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/props_diescraper/statue_break_ball.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+{
+	match:
+	{
+		"classname" "prop_physics_multiplayer"
+		"model" "models/sblitz/field_equipment_cart.mdl"
+	}
+	replace:
+	{
+		"classname" "prop_physics"
+	}
+}
+
+; =====================================================
 ; ==               T2 WEAPON SPAWN FIX               ==
 ; ==  Prevent director from spawning tier 2 weapons  ==
 ; =====================================================
 modify:
+; --- Convert static weapon spawns into weapon_spawn
+{
+	match:
+	{
+		"classname" "weapon_autoshotgun_spawn"
+	}
+	replace:
+	{
+		"classname" "weapon_spawn"
+	}
+	insert:
+	{
+		"weapon_selection" "tier1_shotgun"
+		"spawn_without_director" "1"
+	}
+}
+{
+	match:
+	{
+		"classname" "weapon_shotgun_spas_spawn"
+	}
+	replace:
+	{
+		"classname" "weapon_spawn"
+	}
+	insert:
+	{
+		"weapon_selection" "tier1_shotgun"
+		"spawn_without_director" "1"
+	}
+}
+{
+	match:
+	{
+		"classname" "weapon_rifle_spawn"
+	}
+	replace:
+	{
+		"classname" "weapon_spawn"
+	}
+	insert:
+	{
+		"weapon_selection" "any_smg"
+		"spawn_without_director" "1"
+	}
+}
+{
+	match:
+	{
+		"classname" "weapon_rifle_ak47_spawn"
+	}
+	replace:
+	{
+		"classname" "weapon_spawn"
+	}
+	insert:
+	{
+		"weapon_selection" "any_smg"
+		"spawn_without_director" "1"
+	}
+}
+{
+	match:
+	{
+		"classname" "weapon_rifle_desert_spawn"
+	}
+	replace:
+	{
+		"classname" "weapon_spawn"
+	}
+	insert:
+	{
+		"weapon_selection" "any_smg"
+		"spawn_without_director" "1"
+	}
+}
+{
+	match:
+	{
+		"classname" "weapon_rifle_sg552_spawn"
+	}
+	replace:
+	{
+		"classname" "weapon_spawn"
+	}
+	insert:
+	{
+		"weapon_selection" "any_smg"
+		"spawn_without_director" "1"
+	}
+}
+{
+	match:
+	{
+		"classname" "weapon_hunting_rifle_spawn"
+	}
+	replace:
+	{
+		"classname" "weapon_spawn"
+	}
+	insert:
+	{
+		"weapon_selection" "tier1_any"
+		"spawn_without_director" "1"
+	}
+}
+{
+	match:
+	{
+		"classname" "weapon_sniper_military_spawn"
+	}
+	replace:
+	{
+		"classname" "weapon_spawn"
+	}
+	insert:
+	{
+		"weapon_selection" "tier1_any"
+		"spawn_without_director" "1"
+	}
+}
+{
+	match:
+	{
+		"classname" "weapon_sniper_scout_spawn"
+	}
+	replace:
+	{
+		"classname" "weapon_spawn"
+	}
+	insert:
+	{
+		"weapon_selection" "tier1_any"
+		"spawn_without_director" "1"
+	}
+}
+{
+	match:
+	{
+		"classname" "weapon_sniper_awp_spawn"
+	}
+	replace:
+	{
+		"classname" "weapon_spawn"
+	}
+	insert:
+	{
+		"weapon_selection" "tier1_any"
+		"spawn_without_director" "1"
+	}
+}
+; --- Convert T2 weapon spawns into T1
 {
 	match:
 	{
@@ -214,6 +745,9 @@ modify:
 filter:
 {
 	"classname" "func_playerinfected_clip"
+}
+{
+	"classname" "func_playerghostinfected_clip"
 }
 ; --- Change ghost hurt triggers into regular hurt triggers
 modify:
@@ -746,28 +1280,19 @@ filter:
 {
 	"classname" "weapon_upgradepack_incendiary_spawn"
 }
+{
+	"classname" "upgrade_laser_sight"
+}
+{
+	"classname" "upgrade_ammo_explosive"
+}
+{
+	"classname" "upgrade_ammo_incendiary"
+}
 ; --- Explosive Fuel Barrels
 filter:
 {
 	"classname" "prop_fuel_barrel"
-}
-
-; =====================================================
-; ==                 ENTITY TYPE FIX                 ==
-; ==     Fix entities using the wrong class type     ==
-; =====================================================
-modify:
-; --- Fix custom campaigns using the wrong physics prop type, which prevents our global fixes from being applied
-; --- prop_physics_multiplayer is essentially a legacy entity that functions identically to prop_physics but serves no purpose in L4D2, it does not affect networking overhead
-{
-	match:
-	{
-		"classname" "prop_physics_multiplayer"
-	}
-	replace:
-	{
-		"classname" "prop_physics"
-	}
 }
 
 ; =====================================================
@@ -776,476 +1301,481 @@ modify:
 ; =====================================================
 filter:
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "/.*props_junk/garbage.*/"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "/.*props_fairgrounds/garbage.*/"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props/cs_office/cardboard_box01.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props/cs_office/cardboard_box02.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props/cs_office/cardboard_box03.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/cardboard_box03.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/cardboard_box04.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/cardboard_box05.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/cardboard_box07.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props/cs_office/coffee_mug.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props/cs_office/file_box.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props/cs_office/paper_towels.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_debris/paintbucket01.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_downtown/notepad.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_downtown/phone_book.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/bottles_shelf.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/dish_soap.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/soap_dispenser.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/styrofoam_cups.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/toiletpaperroll.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/waterbottle.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/food_pile01.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/food_pile02.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/food_pile03.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/metal_paintcan001a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/metal_paintcan001b.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/metalbucket01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/metalbucket02a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/plasticcrate01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/shoe001a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_lab/harddrive01.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_lab/harddrive02.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_misc/rolling_pin-1.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_unique/coffeepot01.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_unique/doll01.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_unique/mopbucket01.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_urban/ashtray_stand001.mdl"
+	"spawnflags" "256"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_urban/plastic_basin001.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_urban/plastic_basin002.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_urban/plastic_bucket001.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_urban/plastic_icechest001.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_urban/plastic_icechest_lid001.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_urban/plastic_water_jug001.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_equipment/tsabin_01.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_lab/binderblue.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_lab/binderbluelabel.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_lab/bindergraylabel01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_lab/bindergreen.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_lab/binderredlabel.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_equipment/sleeping_bag3.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/gibs/hgibs.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_downtown/ironing_board.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/trashcankitchen01.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/furnituremattress001a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/wheebarrow01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_unique/hospital/gurney.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/table_folding.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/table_motel.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/chair_thonet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/tablecafe_square01.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage128_composite001d.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage256_composite001a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage256_composite001b.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage256_composite002a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage256_composite002b.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_beancan01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_beancan01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_beercan01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_beercan01a_crushed.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_beercan01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_cellphone01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_cerealbox01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_cerealbox01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_cerealbox02a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_cerealbox02a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_cleanercan01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_cleanercan01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_coffeecup01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_coffeecup01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_coffeemug001a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_coffeemug001a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_fastfoodcontainer01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_frenchfrycup01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_frenchfrycup01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_glassbottle001a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_glassbottle003a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_hubcap01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_metalcan002a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_milkcarton001a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_milkcarton002a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_milkcarton002a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_newspaper001a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_pizzabox01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_pizzabox01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_plasticbottle001a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_plasticbottle001a_clientside.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_plasticbottle001a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_plasticbottle002a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_plasticbottle002a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_plasticbottle003a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_remotecontrol01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_sixpackbox01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_sixpackbox01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_smallbox01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_smallbox01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_sodacan01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_sodacan01a_crushed.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_sodacan01a_crushed_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_sodacan01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_sodacup01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_sodacup01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_spraypaintcan01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_spraypaintcan01a_fullsheet.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_takeoutbox01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_junk/garbage_tunacan01a.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_fortifications/traffic_barrier001.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_interiors/trashcan01.mdl"
 }
 {
-	"classname" "prop_physics"
+	"classname" "/.*prop_physics.*/"
 	"model" "models/props_street/garbage_can.mdl"
+}
+{
+	"classname" "/.*prop_physics.*/"
+	"model" "models/props_unique/airport/line_post.mdl"
 }
 
 ; =====================================================
@@ -1258,7 +1788,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_fairgrounds/traffic_barrel.mdl"
 	}
 	replace:
@@ -1269,7 +1799,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_assault/barrelwarning.mdl"
 	}
 	replace:
@@ -1280,7 +1810,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_urban/oil_drum001.mdl"
 	}
 	replace:
@@ -1291,7 +1821,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/oildrum001.mdl"
 	}
 	replace:
@@ -1302,7 +1832,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_industrial/pallet_barrels_water01_single.mdl"
 	}
 	replace:
@@ -1314,7 +1844,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/table_coffee.mdl"
 	}
 	replace:
@@ -1325,7 +1855,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/furnituretable001a.mdl"
 	}
 	replace:
@@ -1336,7 +1866,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_furniture/heavy_table.mdl"
 	}
 	replace:
@@ -1347,7 +1877,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/table_picnic.mdl"
 	}
 	replace:
@@ -1358,7 +1888,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_furniture/desk1.mdl"
 	}
 	replace:
@@ -1369,7 +1899,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/furniture_desk01a.mdl"
 	}
 	replace:
@@ -1381,7 +1911,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_furniture/shelf1.mdl"
 	}
 	replace:
@@ -1392,7 +1922,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_furniture/bathtub1.mdl"
 	}
 	replace:
@@ -1403,7 +1933,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_furniture/drawer1.mdl"
 	}
 	replace:
@@ -1414,7 +1944,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/furnituredresser001a.mdl"
 	}
 	replace:
@@ -1425,7 +1955,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/sink_industrial01.mdl"
 	}
 	replace:
@@ -1436,7 +1966,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/stove02.mdl"
 	}
 	replace:
@@ -1447,7 +1977,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/file_cabinet1_group.mdl"
 	}
 	replace:
@@ -1458,7 +1988,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/file_cabinet1_group.mdl"
 	}
 	replace:
@@ -1469,7 +1999,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/sofa.mdl"
 	}
 	replace:
@@ -1480,7 +2010,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/sofa01.mdl"
 	}
 	replace:
@@ -1488,10 +2018,21 @@ modify:
 		"spawnflags" "8"
 	}
 }
+{	
+	match:	
+	{	
+		"classname" "/.*prop_physics.*/"	
+		"model" "models/props_interiors/couch.mdl"	
+	}	
+	insert:	
+	{	
+		"spawnflags" "8"	
+	}	
+}
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_trainstation/trashcan_indoor001b.mdl"
 	}
 	replace:
@@ -1502,7 +2043,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/sawhorse.mdl"
 	}
 	replace:
@@ -1513,7 +2054,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_equipment/cart_utility_01.mdl"
 	}
 	replace:
@@ -1524,7 +2065,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/file_cabinet1.mdl"
 	}
 	replace:
@@ -1535,7 +2076,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/file_cabinet2.mdl"
 	}
 	replace:
@@ -1546,7 +2087,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/file_cabinet3.mdl"
 	}
 	replace:
@@ -1557,7 +2098,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_wasteland/controlroom_filecabinet001a.mdl"
 	}
 	replace:
@@ -1568,7 +2109,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_wasteland/controlroom_filecabinet002a.mdl"
 	}
 	replace:
@@ -1579,7 +2120,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_office/filecabinet01.mdl"
 	}
 	replace:
@@ -1592,7 +2133,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/sofa_chair.mdl"
 	}
 	replace:
@@ -1603,7 +2144,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/sofa_chair02.mdl"
 	}
 	replace:
@@ -1678,7 +2219,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "/.*deadbodies.*/"
 	}
 	insert:
@@ -1700,7 +2241,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_urban/tire001.mdl"
 	}
 	insert:
@@ -1711,7 +2252,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_vehicles/tire001b_truck.mdl"
 	}
 	insert:
@@ -1722,7 +2263,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_vehicles/tire001c_car.mdl"
 	}
 	insert:
@@ -1733,7 +2274,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_vehicles/carparts_tire01a.mdl"
 	}
 	insert:
@@ -1744,7 +2285,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_vehicles/carparts_wheel01a.mdl"
 	}
 	insert:
@@ -1756,7 +2297,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_fortifications/orange_cone001_clientside.mdl"
 	}
 	insert:
@@ -1767,7 +2308,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_fortifications/orange_cone001_reference.mdl"
 	}
 	insert:
@@ -1778,7 +2319,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_fortifications/traffic_barrier001.mdl"
 	}
 	insert:
@@ -1799,7 +2340,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_wasteland/barricade001a.mdl"
 	}
 	insert:
@@ -1861,6 +2402,17 @@ modify:
 {
 	match:
 	{
+		"classname" "/.*prop_physics.*/"
+		"model" "models/props_lighting/lighthanging.mdl"
+	}
+	insert:
+	{
+		"spawnflags" "4"
+	}
+}
+{
+	match:
+	{
 		"model" "models/props_lighting/lighthanging_animated.mdl"
 	}
 	insert:
@@ -1871,7 +2423,18 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
+		"model" "models/props_lighting/lighthanging_animated.mdl"
+	}
+	insert:
+	{
+		"spawnflags" "4"
+	}
+}
+{
+	match:
+	{
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_equipment/light_floodlight.mdl"
 	}
 	insert:
@@ -1942,7 +2505,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_lighting/airportlight01.mdl"
 	}
 	insert:
@@ -1954,7 +2517,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/lamp_table01.mdl"
 	}
 	insert:
@@ -1965,7 +2528,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/lamp_table02.mdl"
 	}
 	insert:
@@ -1976,7 +2539,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_lab/desklamp01.mdl"
 	}
 	insert:
@@ -1987,7 +2550,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_lighting/lampbedside01.mdl"
 	}
 	insert:
@@ -1998,7 +2561,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_misc/lamp-1.mdl"
 	}
 	insert:
@@ -2009,7 +2572,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_urban/hotel_lamp001.mdl"
 	}
 	insert:
@@ -2020,7 +2583,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_furniture/lamp1.mdl"
 	}
 	insert:
@@ -2031,7 +2594,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/furniture_lamp01a.mdl"
 	}
 	insert:
@@ -2042,7 +2605,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/lamp_floor.mdl"
 	}
 	insert:
@@ -2053,7 +2616,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/lamp_floor_arch.mdl"
 	}
 	insert:
@@ -2064,7 +2627,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_waterfront/tattoo_floorlamp.mdl"
 	}
 	insert:
@@ -2076,7 +2639,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/computer_caseb.mdl"
 	}
 	insert:
@@ -2087,7 +2650,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/computer_caseb_p1.mdl"
 	}
 	insert:
@@ -2098,7 +2661,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/phone.mdl"
 	}
 	insert:
@@ -2109,7 +2672,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/phone_p1.mdl"
 	}
 	insert:
@@ -2120,7 +2683,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/phone_p.mdl"
 	}
 	insert:
@@ -2131,7 +2694,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/radio.mdl"
 	}
 	insert:
@@ -2142,7 +2705,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/radio_p1.mdl"
 	}
 	insert:
@@ -2153,7 +2716,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/trash_can.mdl"
 	}
 	insert:
@@ -2164,7 +2727,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/trash_can_p.mdl"
 	}
 	insert:
@@ -2175,7 +2738,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/trash_can_p7.mdl"
 	}
 	insert:
@@ -2186,7 +2749,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/trash_can_p8.mdl"
 	}
 	insert:
@@ -2197,7 +2760,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/computer_keyboard.mdl"
 	}
 	insert:
@@ -2208,7 +2771,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/alarm_clock.mdl"
 	}
 	insert:
@@ -2219,7 +2782,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/coffee_maker.mdl"
 	}
 	insert:
@@ -2230,7 +2793,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/computer_monitor.mdl"
 	}
 	insert:
@@ -2241,7 +2804,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/dvd_player.mdl"
 	}
 	insert:
@@ -2252,7 +2815,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/phone.mdl"
 	}
 	insert:
@@ -2263,7 +2826,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/printer.mdl"
 	}
 	insert:
@@ -2274,7 +2837,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/toaster.mdl"
 	}
 	insert:
@@ -2285,7 +2848,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/vcr.mdl"
 	}
 	insert:
@@ -2296,7 +2859,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_lab/reciever01a.mdl"
 	}
 	insert:
@@ -2307,7 +2870,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_lab/reciever01b.mdl"
 	}
 	insert:
@@ -2318,7 +2881,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_lab/reciever01d.mdl"
 	}
 	insert:
@@ -2329,7 +2892,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_office/computer_monitor_01.mdl"
 	}
 	insert:
@@ -2341,8 +2904,9 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/fire_extinguisher.mdl"
+		"spawnflags" "256"
 	}
 	insert:
 	{
@@ -2352,7 +2916,19 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
+		"model" "models/props/cs_office/fire_extinguisher.mdl"
+		"spawnflags" "264"
+	}
+	insert:
+	{
+		"spawnflags" "12"
+	}
+}
+{
+	match:
+	{
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/microwave.mdl"
 	}
 	insert:
@@ -2363,7 +2939,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/de_inferno/tv_monitor01.mdl"
 	}
 	insert:
@@ -2374,7 +2950,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/consolebox01a.mdl"
 	}
 	insert:
@@ -2385,7 +2961,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_debris/tv_monitor01.mdl"
 	}
 	insert:
@@ -2396,7 +2972,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/tv.mdl"
 	}
 	insert:
@@ -2407,7 +2983,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/prison_heater001a.mdl"
 	}
 	insert:
@@ -2418,7 +2994,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_lab/monitor01a.mdl"
 	}
 	insert:
@@ -2429,7 +3005,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_lab/monitor02.mdl"
 	}
 	insert:
@@ -2440,7 +3016,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_misc/shelf-2.mdl"
 	}
 	insert:
@@ -2453,7 +3029,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/hospital_cart01.mdl"
 	}
 	insert:
@@ -2464,7 +3040,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_assault/ladderaluminium128.mdl"
 	}
 	insert:
@@ -2475,7 +3051,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/de_train/ladderaluminium.mdl"
 	}
 	insert:
@@ -2487,7 +3063,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_office/chair_office.mdl"
 	}
 	insert:
@@ -2498,7 +3074,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_militia/barstool01.mdl"
 	}
 	insert:
@@ -2509,7 +3085,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/de_inferno/chairantique.mdl"
 	}
 	insert:
@@ -2520,7 +3096,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/chair_office01a.mdl"
 	}
 	insert:
@@ -2531,7 +3107,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/chair_stool01a.mdl"
 	}
 	insert:
@@ -2542,7 +3118,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/furniturechair001a.mdl"
 	}
 	insert:
@@ -2553,7 +3129,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_furniture/chair2.mdl"
 	}
 	insert:
@@ -2564,7 +3140,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_furniture/hotel_chair.mdl"
 	}
 	insert:
@@ -2575,7 +3151,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/chair01.mdl"
 	}
 	insert:
@@ -2586,7 +3162,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/chair_cafeteria.mdl"
 	}
 	insert:
@@ -2597,7 +3173,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/chair_cafeteria_atrium.mdl"
 	}
 	insert:
@@ -2608,7 +3184,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/chair_office2.mdl"
 	}
 	insert:
@@ -2619,7 +3195,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/chair_thonet.mdl"
 	}
 	insert:
@@ -2630,7 +3206,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/chairlobby01.mdl"
 	}
 	insert:
@@ -2641,7 +3217,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/foldingchair.mdl"
 	}
 	insert:
@@ -2652,7 +3228,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/foldingchair.mdl"
 	}
 	insert:
@@ -2663,7 +3239,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/patio_chair2_white.mdl"
 	}
 	insert:
@@ -2674,7 +3250,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/wheelchair01.mdl"
 	}
 	insert:
@@ -2685,7 +3261,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_urban/plastic_chair001.mdl"
 	}
 	insert:
@@ -2696,7 +3272,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_urban/plastic_chair001_debris.mdl"
 	}
 	insert:
@@ -2707,7 +3283,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_wasteland/controlroom_chair001a.mdl"
 	}
 	insert:
@@ -2718,7 +3294,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_furniture/cafe_barstool1.mdl"
 	}
 	insert:
@@ -2729,18 +3305,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
-		"model" "models/props_interiors/couch.mdl"
-	}
-	insert:
-	{
-		"spawnflags" "4"
-	}
-}
-{
-	match:
-	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_furniture/piano_bench.mdl"
 	}
 	insert:
@@ -2751,7 +3316,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/bench01a.mdl"
 	}
 	insert:
@@ -2762,7 +3327,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/picnic_bench_toddler.mdl"
 	}
 	insert:
@@ -2774,7 +3339,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/table_folding_folded.mdl"
 	}
 	insert:
@@ -2785,7 +3350,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/table_folding_folded_new.mdl"
 	}
 	insert:
@@ -2797,7 +3362,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_foliage/flower_barrel.mdl"
 	}
 	insert:
@@ -2808,7 +3373,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_foliage/flower_barrel_dead.mdl"
 	}
 	insert:
@@ -2819,7 +3384,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_plants/planthanging01.mdl"
 	}
 	insert:
@@ -2830,7 +3395,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_plants/pottedplant_tall01.mdl"
 	}
 	insert:
@@ -2841,7 +3406,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/pottery01a.mdl"
 	}
 	insert:
@@ -2852,7 +3417,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/pottery02a.mdl"
 	}
 	insert:
@@ -2863,7 +3428,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/pottery04a.mdl"
 	}
 	insert:
@@ -2874,7 +3439,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/pottery08a.mdl"
 	}
 	insert:
@@ -2885,7 +3450,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_plants/claypot03.mdl"
 	}
 	insert:
@@ -2897,7 +3462,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_fairgrounds/lil'peanut_cutout001.mdl"
 	}
 	insert:
@@ -2908,7 +3473,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_fairgrounds/lil'peanut_sign001.mdl"
 	}
 	insert:
@@ -2919,7 +3484,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_fairgrounds/strongman_moustachio_cutout001.mdl"
 	}
 	insert:
@@ -2930,7 +3495,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/ceda_easel01.mdl"
 	}
 	insert:
@@ -2941,7 +3506,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_signs/sign_horizontal_01.mdl"
 	}
 	insert:
@@ -2952,7 +3517,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_signs/sign_horizontal_02.mdl"
 	}
 	insert:
@@ -2963,7 +3528,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_signs/sign_horizontal_03.mdl"
 	}
 	insert:
@@ -2974,7 +3539,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_signs/sign_horizontal_04.mdl"
 	}
 	insert:
@@ -2985,7 +3550,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_signs/sign_horizontal_05.mdl"
 	}
 	insert:
@@ -2996,7 +3561,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_signs/sign_horizontal_09.mdl"
 	}
 	insert:
@@ -3007,7 +3572,19 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
+		"model" "models/props_signs/sign_horizontal_09.mdl"
+		"spawnflags" "8"
+	}
+	insert:
+	{
+		"spawnflags" "12"
+	}
+}
+{
+	match:
+	{
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_signs/sign_horizontal_10.mdl"
 	}
 	insert:
@@ -3018,7 +3595,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_signs/sign_quarter_02.mdl"
 	}
 	insert:
@@ -3029,7 +3606,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/airport/standup_board.mdl"
 	}
 	insert:
@@ -3040,7 +3617,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_waterfront/sign_underriver_easel01.mdl"
 	}
 	insert:
@@ -3051,7 +3628,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_waterfront/sign_underriver_folding01.mdl"
 	}
 	insert:
@@ -3062,7 +3639,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_waterfront/sign_underriver_linepost.mdl"
 	}
 	insert:
@@ -3073,7 +3650,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_signs/sign_street_05.mdl"
 	}
 	insert:
@@ -3084,7 +3661,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_urban/gas_sign001.mdl"
 	}
 	insert:
@@ -3096,7 +3673,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props/cs_militia/circularsaw01.mdl"
 	}
 	insert:
@@ -3107,7 +3684,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_junk/cinderblock01a.mdl"
 	}
 	insert:
@@ -3118,7 +3695,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_misc/flour_sack-1.mdl"
 	}
 	insert:
@@ -3129,7 +3706,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_misc/pan-1.mdl"
 	}
 	insert:
@@ -3140,7 +3717,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_misc/pan-2.mdl"
 	}
 	insert:
@@ -3151,7 +3728,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_misc/pan-3.mdl"
 	}
 	insert:
@@ -3162,7 +3739,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_misc/saddle-1.mdl"
 	}
 	insert:
@@ -3173,7 +3750,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/luggagecart01.mdl"
 	}
 	insert:
@@ -3184,7 +3761,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_urban/big_wheel001.mdl"
 	}
 	insert:
@@ -3195,7 +3772,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_vehicles/carparts_axel01a.mdl"
 	}
 	insert:
@@ -3206,7 +3783,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_vehicles/carparts_door01a.mdl"
 	}
 	insert:
@@ -3217,7 +3794,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_vehicles/carparts_muffler01a.mdl"
 	}
 	insert:
@@ -3228,7 +3805,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_vehicles/carparts_muffler02.mdl"
 	}
 	insert:
@@ -3239,7 +3816,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_wasteland/prison_shelf002a.mdl"
 	}
 	insert:
@@ -3250,7 +3827,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_waterfront/tattoo_autoclave.mdl"
 	}
 	insert:
@@ -3261,7 +3838,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/hospital/iv_pole.mdl"
 	}
 	insert:
@@ -3272,7 +3849,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/metalpot001a.mdl"
 	}
 	insert:
@@ -3283,7 +3860,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_c17/metalpot002a.mdl"
 	}
 	insert:
@@ -3294,7 +3871,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/pot01a.mdl"
 	}
 	insert:
@@ -3305,7 +3882,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_misc/pot-1.mdl"
 	}
 	insert:
@@ -3316,7 +3893,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_misc/pot-2.mdl"
 	}
 	insert:
@@ -3327,7 +3904,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_misc/tea_pot-1.mdl"
 	}
 	insert:
@@ -3338,7 +3915,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_mall/mall_mannequin_base.mdl"
 	}
 	insert:
@@ -3349,7 +3926,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_mall/mall_mannequin_female_base.mdl"
 	}
 	insert:
@@ -3360,7 +3937,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/luggagescale.mdl"
 	}
 	insert:
@@ -3371,7 +3948,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/luggagecarthotel01.mdl"
 	}
 	insert:
@@ -3382,7 +3959,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/airport/luggage1.mdl"
 	}
 	insert:
@@ -3393,7 +3970,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/airport/luggage1_floating.mdl"
 	}
 	insert:
@@ -3404,7 +3981,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/airport/luggage2.mdl"
 	}
 	insert:
@@ -3415,7 +3992,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/airport/luggage2_floating.mdl"
 	}
 	insert:
@@ -3426,7 +4003,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/airport/luggage3.mdl"
 	}
 	insert:
@@ -3437,7 +4014,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/airport/luggage3_floating.mdl"
 	}
 	insert:
@@ -3448,7 +4025,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/airport/luggage4.mdl"
 	}
 	insert:
@@ -3459,7 +4036,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_unique/airport/luggage4_floating.mdl"
 	}
 	insert:
@@ -3470,7 +4047,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_crates/supply_crate01.mdl"
 	}
 	insert:
@@ -3481,7 +4058,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_crates/supply_crate01_gib1.mdl"
 	}
 	insert:
@@ -3492,7 +4069,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_crates/supply_crate02.mdl"
 	}
 	insert:
@@ -3503,7 +4080,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_crates/supply_crate02_gib1.mdl"
 	}
 	insert:
@@ -3514,7 +4091,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_foliage/tree_trunk.mdl"
 	}
 	insert:
@@ -3525,7 +4102,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_foliage/tree_trunk_chunk01.mdl"
 	}
 	insert:
@@ -3536,7 +4113,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_foliage/tree_trunk_chunk02.mdl"
 	}
 	insert:
@@ -3547,7 +4124,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_foliage/tree_trunk_chunk03.mdl"
 	}
 	insert:
@@ -3558,7 +4135,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_foliage/tree_trunk_chunk04.mdl"
 	}
 	insert:
@@ -3569,7 +4146,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_foliage/tree_trunk_chunk05.mdl"
 	}
 	insert:
@@ -3580,7 +4157,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_foliage/tree_trunk_chunk06.mdl"
 	}
 	insert:
@@ -3591,7 +4168,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_urban/shopping_cart001.mdl"
 	}
 	insert:
@@ -3602,7 +4179,7 @@ modify:
 {
 	match:
 	{
-		"classname" "prop_physics"
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/paper_tray.mdl"
 	}
 	insert:


### PR DESCRIPTION
The old version of Zonemod was stuck on an old version of global_filters that has some issues with hittables and other props/weapon spawns.
Very minor update to fix that so no issues come from this if it is ever played, not worth moving to a new version number.

Feel free to reject since it is for a legacy version of Zonemod.