### PR TITLE
Remove l4d2_melee_shenanigans from Acemod

### DIFF
--- a/cfg/cfgogl/acemodrv/shared_plugins.cfg
+++ b/cfg/cfgogl/acemodrv/shared_plugins.cfg
@@ -104,7 +104,6 @@ sm plugins load optional/double_getup.smx
 sm plugins load optional/fix_engine.smx
 sm plugins load optional/l4d2_collision_adjustments.smx
 sm plugins load optional/l4d2_stats.smx
-sm plugins load optional/l4d2_melee_shenanigans.smx
 sm plugins load optional/specrates.smx
 sm plugins load optional/l4d2_ladder_rambos.smx
 


### PR DESCRIPTION
Plugin was included by mistake, not used in Acemod, l4d2_tank_charger_m2_fix is used instead.

Double checked all other plugins being loaded in Acemod and all looked ok.