### PR TITLE
slots_vote syntax

### DIFF
--- a/addons/sourcemod/scripting/slots_vote.sp
+++ b/addons/sourcemod/scripting/slots_vote.sp
@@ -1,15 +1,17 @@
 #pragma semicolon 1
+#pragma newdecls required
 
 #include <sourcemod>
 #include <builtinvotes>
 #include <colors>
+#include <l4d2util>
 
-new Handle:g_hVote;
-new String:g_sSlots[32];
-new Handle:hMaxSlots;
-new MaxSlots;
+Handle g_hVote;
+char g_sSlots[32];
+ConVar hMaxSlots;
+int MaxSlots;
 
-public Plugin:myinfo =
+public Plugin myinfo =
 {
 	name = "Slots?! Voter",
 	description = "Slots Voter",
@@ -18,34 +20,36 @@ public Plugin:myinfo =
 	url = ""
 };
 
-public OnPluginStart()
+public void OnPluginStart()
 {
 	RegConsoleCmd("sm_slots", SlotsRequest);
 	hMaxSlots = CreateConVar("slots_max_slots", "30", "Maximum amount of slots you wish players to be able to vote for? (DON'T GO HIGHER THAN 30)");
-	MaxSlots = GetConVarInt(hMaxSlots);
+	MaxSlots = hMaxSlots.IntValue;
 	HookConVarChange(hMaxSlots, CVarChanged);
 }
 
-public Action:SlotsRequest(client, args)
+public Action SlotsRequest(int client, int args)
 {
-	if (!client)
-	{
+	if (client == 0) {
 		return Plugin_Handled;
 	}
+
 	if (args == 1)
 	{
-		new String:sSlots[64];
+		char sSlots[64];
 		GetCmdArg(1, sSlots, sizeof(sSlots));
-		new Int = StringToInt(sSlots);
+		int Int = StringToInt(sSlots);
 		if (Int > MaxSlots)
 		{
 			CPrintToChat(client, "{blue}[{default}Slots{blue}] {default}You can't limit slots above {olive}%i {default}on this Server", MaxSlots);
 		}
 		else
 		{
-			if (GetUserAdmin(client) != INVALID_ADMIN_ID)
+			if (GetUserFlagBits(client) & ADMFLAG_GENERIC)
 			{
-				CPrintToChatAll("{blue}[{default}Slots{blue}] {olive}Admin {default}has limited Slots to {blue}%i", Int);
+				char sName[MAX_NAME_LENGTH];
+				GetClientName(client, sName, sizeof(sName));
+				CPrintToChatAll("{blue}[{default}Slots{blue}] {olive}%s {default}has limited Slots to {blue}%i",sName, Int);
 				SetConVarInt(FindConVar("sv_maxplayers"), Int);
 			}
 			else if (Int < GetConVarInt(FindConVar("survivor_limit")) + GetConVarInt(FindConVar("z_max_player_zombies")))
@@ -66,30 +70,31 @@ public Action:SlotsRequest(client, args)
 	return Plugin_Handled;
 }
 
-bool:StartSlotVote(client, String:Slots[])
+bool StartSlotVote(int client, char[] Slots)
 {
-	if (GetClientTeam(client) == 1)
-	{
-		PrintToChat(client, "Voting isn't allowed for spectators.");
+	if (GetClientTeam(client) <= L4D2Team_Spectator) {
+		CPrintToChat(client, "{blue}[{default}Slots{blue}] {default}Voting isn't allowed for spectators.");
 		return false;
 	}
-
-	if (IsNewBuiltinVoteAllowed())
+	
+	if (!IsBuiltinVoteInProgress())
 	{
-		new iNumPlayers;
-		decl iPlayers[MaxClients];
-		for (new i=1; i<=MaxClients; i++)
-		{
-			if (!IsClientInGame(i) || IsFakeClient(i) || (GetClientTeam(i) == 1))
-			{
+		int iNumPlayers = 0;
+		int[] iPlayers = new int[MaxClients];
+	
+		//list of non-spectators players
+		for (int i = 1; i <= MaxClients; i++) {
+			if (!IsClientInGame(i) || IsFakeClient(i) || GetClientTeam(i) <= L4D2Team_Spectator) {
 				continue;
 			}
+
 			iPlayers[iNumPlayers++] = i;
 		}
 		
-		new String:sBuffer[64];
-		g_hVote = CreateBuiltinVote(VoteActionHandler, BuiltinVoteType_Custom_YesNo, BuiltinVoteAction_Cancel | BuiltinVoteAction_VoteEnd | BuiltinVoteAction_End);
+		char sBuffer[64];
 		Format(sBuffer, sizeof(sBuffer), "Limit Slots to '%s'?", Slots);
+		
+		g_hVote = CreateBuiltinVote(VoteActionHandler, BuiltinVoteType_Custom_YesNo, BuiltinVoteAction_Cancel | BuiltinVoteAction_VoteEnd | BuiltinVoteAction_End);
 		SetBuiltinVoteArgument(g_hVote, sBuffer);
 		SetBuiltinVoteInitiator(g_hVote, client);
 		SetBuiltinVoteResultCallback(g_hVote, SlotVoteResultHandler);
@@ -97,19 +102,35 @@ bool:StartSlotVote(client, String:Slots[])
 		return true;
 	}
 
-	PrintToChat(client, "Vote cannot be started now.");
+	CPrintToChat(client, "{blue}[{default}Slots{blue}] {default}Vote cannot be started now.");
 	return false;
+}
+
+public void VoteActionHandler(Handle vote, BuiltinVoteAction action, int param1, int param2)
+{
+	switch (action)
+	{
+		case BuiltinVoteAction_End:
+		{
+			delete vote;
+			g_hVote = null;
+		}
+		case BuiltinVoteAction_Cancel:
+		{
+			DisplayBuiltinVoteFail(vote, view_as<BuiltinVoteFailReason>(param1));
+		}
+	}
 }
 
 public void SlotVoteResultHandler(Handle vote, int num_votes, int num_clients, const int[][] client_info, int num_items, const int[][] item_info)
 {
-	for (new i=0; i<num_items; i++)
+	for (int i = 0; i < num_items; i++)
 	{
 		if (item_info[i][BUILTINVOTEINFO_ITEM_INDEX] == BUILTINVOTES_VOTE_YES)
 		{
 			if (item_info[i][BUILTINVOTEINFO_ITEM_VOTES] > (num_votes / 2))
 			{
-				new Slots = StringToInt(g_sSlots, 10);
+				int Slots = StringToInt(g_sSlots, 10);
 				DisplayBuiltinVotePass(vote, "Limiting Slots...");
 				SetConVarInt(FindConVar("sv_maxplayers"), Slots);
 				return;
@@ -119,23 +140,7 @@ public void SlotVoteResultHandler(Handle vote, int num_votes, int num_clients, c
 	DisplayBuiltinVoteFail(vote, BuiltinVoteFail_Loses);
 }
 
-public VoteActionHandler(Handle:vote, BuiltinVoteAction:action, param1, param2)
-{
-	switch (action)
-	{
-		case BuiltinVoteAction_End:
-		{
-			g_hVote = INVALID_HANDLE;
-			CloseHandle(vote);
-		}
-		case BuiltinVoteAction_Cancel:
-		{
-			DisplayBuiltinVoteFail(vote, BuiltinVoteFailReason:param1);
-		}
-	}
-}
-
-public CVarChanged(Handle:cvar, String:oldValue[], String:newValue[])
+public void CVarChanged(Handle cvar, char[] oldValue, char[] newValue)
 {
 	MaxSlots = GetConVarInt(hMaxSlots);
 }

--- a/addons/sourcemod/scripting/slots_vote.sp
+++ b/addons/sourcemod/scripting/slots_vote.sp
@@ -17,7 +17,7 @@ public Plugin myinfo =
 	description = "Slots Voter",
 	author = "Sir",
 	version = "",
-	url = ""
+	url = "https://github.com/SirPlease/L4D2-Competitive-Rework/"
 };
 
 public void OnPluginStart()


### PR DESCRIPTION
- Code rewritten to new syntax (use matchvote for reference).
- Replace (GetUserAdmin(client) != INVALID_ADMIN_ID) with
(GetUserFlagBits(client) & ADMFLAG_GENERIC), as it allowed users with custom flags to run the command.
- The slot change announcement by an administrator has been modified, now it will say the name of the client.