### PR TITLE
srcds1 "start" command micro-fix

### DIFF
--- a/Dedicated Server Install Guide/srcds1
+++ b/Dedicated Server Install Guide/srcds1
@@ -49,12 +49,12 @@ DESC="L4D2 Dedicated Server #$SVNUM on port $PORT"
 
 case "$1" in
 	start)
-		echo "Starting $DESC: $NAME"
-		if [ -e $DIR ]; then
+		if su $SRCDS_USER -l -c "screen -ls" |grep $NAME; then
+			echo -n "$DESC: $NAME already started!"
+		else
+			echo "Starting $DESC: $NAME"
 			cd $DIR
 			su $SRCDS_USER -l -c "screen -d -m -S $NAME $DAEMON $PARAMS"
-		else
-			echo "No such directory: $DIR!"
 		fi
 		;;
 


### PR DESCRIPTION
Fixed bug, when user might to execute "/etc/init.d/srcds1 start" 2 times or more. This led to the fact that the process was duplicated and thus it was possible to run several servers with the same process name (for example, "L4D2 Dedicated Server 1"), but with different ports. This fix, when you re-enter the command "/etc/init.d/srcds1 start", will give a message that the process has already started and will suspend further execution of the command.