### PR TITLE
More custom map fixes

### DIFF
--- a/cfg/stripper/acemodrv/maps/cwm3_drain.cfg
+++ b/cfg/stripper/acemodrv/maps/cwm3_drain.cfg
@@ -144,6 +144,31 @@ add:
 	"BlockType" "1"
 }
 
+; --- Trigger on pole to activate alarm car to prevent skip
+add:
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "car_alarm_pole_trigger,AddOutput,mins -2 -2 -4,0,-1"
+	"OnMapSpawn" "car_alarm_pole_trigger,AddOutput,maxs 2 2 4,0,-1"
+	"OnMapSpawn" "car_alarm_pole_trigger,AddOutput,boxmins -2 -2 -4,0,-1"
+	"OnMapSpawn" "car_alarm_pole_trigger,AddOutput,boxmaxs 2 2 4,0,-1"
+	"OnMapSpawn" "car_alarm_pole_trigger,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "filter_activator_team"
+	"targetname" "filter_survivor"
+	"Negated" "Allow entities that match criteria"
+	"filterteam" "2"
+}
+{
+	"classname" "trigger_once"
+	"origin" "2192 -752 267"
+	"targetname" "car_alarm_pole_trigger"
+	"filtername" "filter_survivor"
+	"spawnflags" "1"
+	"OnTrigger" "caralarm_car1,SurvivorStandingOnCar,,0,-1"
+}
+
 
 
 ; #############  LADDER CHANGES AND FIXES  ############
@@ -240,9 +265,19 @@ add:
 }
 {
 	"classname" "func_simpleladder"
-	"origin" "-2 1710 -352"
-	"angles" "0 0 0"
-	"model" "*57"
+	"origin" "-207 -1174 -52"
+	"angles" "0 180 0"
+	"model" "*47"
+	"normal.x" "-1"
+	"normal.y" "0"
+	"normal.z" "0"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "-207 -1174 -232"
+	"angles" "0 180 0"
+	"model" "*47"
 	"normal.x" "-1"
 	"normal.y" "0"
 	"normal.z" "0"

--- a/cfg/stripper/acemodrv/maps/l4d_dbd2dc_new_dawn.cfg
+++ b/cfg/stripper/acemodrv/maps/l4d_dbd2dc_new_dawn.cfg
@@ -369,6 +369,32 @@ add:
 ; ==                  OUT OF BOUNDS                  ==
 ; ==  Block players getting outside / under the map  ==
 ; =====================================================
+; --- Block survivors from going out of bounds through holes in the ceiling
+add:
+{
+	"classname" "env_physics_blocker"
+	"origin" "-306 448 -779"
+	"mins" "-744 -840 -8"
+	"maxs" "744 840 8"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "135 1757 -779"
+	"mins" "-303 -469 -8"
+	"maxs" "303 469 8"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-306 914 -455"
+	"mins" "-744 -1311 -8"
+	"maxs" "744 1311 8"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 
 ; =====================================================
 ; ==                   STUCK SPOTS                   ==

--- a/cfg/stripper/acemodrv/maps/l4d_dbd2dc_the_mall.cfg
+++ b/cfg/stripper/acemodrv/maps/l4d_dbd2dc_the_mall.cfg
@@ -1292,6 +1292,23 @@ add:
 ; ==  Block players getting outside / under the map  ==
 ; =====================================================
 add:
+; --- Block survivors from getting out of bounds over fences by the event
+{
+	"classname" "env_physics_blocker"
+	"origin" "-4 -519 -210"
+	"mins" "-15 -261 -462"
+	"maxs" "15 261 462"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "956 616 -129"
+	"mins" "-4 -864 -393"
+	"maxs" "4 864 393"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block survivors from getting out of bounds on the roof
 {
 	"classname" "env_physics_blocker"

--- a/cfg/stripper/zonemod/maps/cwm3_drain.cfg
+++ b/cfg/stripper/zonemod/maps/cwm3_drain.cfg
@@ -144,6 +144,31 @@ add:
 	"BlockType" "1"
 }
 
+; --- Trigger on pole to activate alarm car to prevent skip
+add:
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "car_alarm_pole_trigger,AddOutput,mins -2 -2 -4,0,-1"
+	"OnMapSpawn" "car_alarm_pole_trigger,AddOutput,maxs 2 2 4,0,-1"
+	"OnMapSpawn" "car_alarm_pole_trigger,AddOutput,boxmins -2 -2 -4,0,-1"
+	"OnMapSpawn" "car_alarm_pole_trigger,AddOutput,boxmaxs 2 2 4,0,-1"
+	"OnMapSpawn" "car_alarm_pole_trigger,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "filter_activator_team"
+	"targetname" "filter_survivor"
+	"Negated" "Allow entities that match criteria"
+	"filterteam" "2"
+}
+{
+	"classname" "trigger_once"
+	"origin" "2192 -752 267"
+	"targetname" "car_alarm_pole_trigger"
+	"filtername" "filter_survivor"
+	"spawnflags" "1"
+	"OnTrigger" "caralarm_car1,SurvivorStandingOnCar,,0,-1"
+}
+
 
 
 ; #############  LADDER CHANGES AND FIXES  ############
@@ -240,9 +265,19 @@ add:
 }
 {
 	"classname" "func_simpleladder"
-	"origin" "-2 1710 -352"
-	"angles" "0 0 0"
-	"model" "*57"
+	"origin" "-207 -1174 -52"
+	"angles" "0 180 0"
+	"model" "*47"
+	"normal.x" "-1"
+	"normal.y" "0"
+	"normal.z" "0"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "-207 -1174 -232"
+	"angles" "0 180 0"
+	"model" "*47"
 	"normal.x" "-1"
 	"normal.y" "0"
 	"normal.z" "0"

--- a/cfg/stripper/zonemod/maps/l4d_dbd2dc_new_dawn.cfg
+++ b/cfg/stripper/zonemod/maps/l4d_dbd2dc_new_dawn.cfg
@@ -369,6 +369,32 @@ add:
 ; ==                  OUT OF BOUNDS                  ==
 ; ==  Block players getting outside / under the map  ==
 ; =====================================================
+; --- Block survivors from going out of bounds through holes in the ceiling
+add:
+{
+	"classname" "env_physics_blocker"
+	"origin" "-306 448 -779"
+	"mins" "-744 -840 -8"
+	"maxs" "744 840 8"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "135 1757 -779"
+	"mins" "-303 -469 -8"
+	"maxs" "303 469 8"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-306 914 -455"
+	"mins" "-744 -1311 -8"
+	"maxs" "744 1311 8"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 
 ; =====================================================
 ; ==                   STUCK SPOTS                   ==

--- a/cfg/stripper/zonemod/maps/l4d_dbd2dc_the_mall.cfg
+++ b/cfg/stripper/zonemod/maps/l4d_dbd2dc_the_mall.cfg
@@ -1292,6 +1292,23 @@ add:
 ; ==  Block players getting outside / under the map  ==
 ; =====================================================
 add:
+; --- Block survivors from getting out of bounds over fences by the event
+{
+	"classname" "env_physics_blocker"
+	"origin" "-4 -519 -210"
+	"mins" "-15 -261 -462"
+	"maxs" "15 261 462"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "956 616 -129"
+	"mins" "-4 -864 -393"
+	"maxs" "4 864 393"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block survivors from getting out of bounds on the roof
 {
 	"classname" "env_physics_blocker"


### PR DESCRIPTION
Carried Off 3
Fixed an infected ladder going into a room below
Fixed survivors being able to skip the alarm car by standing on the pole sticking out of it (hopefully)

Dead Before Dawn 2
Blocked survivors from getting out of bounds over some fences by the event

Dead Before Dawn 5
Blocked survivors from getting into some holes in the ceiling
(There's too many spots on the roof to quickly patch)