### PR TITLE
Passifice Rework

### DIFF
--- a/cfg/cfgogl/acemodrv/mapinfo.txt
+++ b/cfg/cfgogl/acemodrv/mapinfo.txt
@@ -417,6 +417,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -429,9 +437,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -468,7 +481,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/amrv1v1/mapinfo.txt
+++ b/cfg/cfgogl/amrv1v1/mapinfo.txt
@@ -417,6 +417,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -429,9 +437,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -468,7 +481,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/amrv2v2/mapinfo.txt
+++ b/cfg/cfgogl/amrv2v2/mapinfo.txt
@@ -417,6 +417,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -429,9 +437,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -468,7 +481,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/amrv3v3/mapinfo.txt
+++ b/cfg/cfgogl/amrv3v3/mapinfo.txt
@@ -417,6 +417,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -429,9 +437,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -468,7 +481,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/zh1v1/mapinfo.txt
+++ b/cfg/cfgogl/zh1v1/mapinfo.txt
@@ -105,6 +105,14 @@
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"150.000000"
 		"horde_limit"		"120"
+		"tank_ban_flow"
+		{
+			"Alley choke to up top"
+			{
+				"min"		"56"
+				"max"		"68"
+			}
+		}
 		"witch_ban_flow"
 		{
 			"Ladder"
@@ -412,6 +420,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -424,9 +440,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -463,7 +484,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/zh2v2/mapinfo.txt
+++ b/cfg/cfgogl/zh2v2/mapinfo.txt
@@ -105,6 +105,14 @@
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"150.000000"
 		"horde_limit"		"120"
+		"tank_ban_flow"
+		{
+			"Alley choke to up top"
+			{
+				"min"		"56"
+				"max"		"68"
+			}
+		}
 		"witch_ban_flow"
 		{
 			"Ladder"
@@ -412,6 +420,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -424,9 +440,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -463,7 +484,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/zh3v3/mapinfo.txt
+++ b/cfg/cfgogl/zh3v3/mapinfo.txt
@@ -105,6 +105,14 @@
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"150.000000"
 		"horde_limit"		"120"
+		"tank_ban_flow"
+		{
+			"Alley choke to up top"
+			{
+				"min"		"56"
+				"max"		"68"
+			}
+		}
 		"witch_ban_flow"
 		{
 			"Ladder"
@@ -412,6 +420,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -424,9 +440,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -463,7 +484,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/zm1v1/mapinfo.txt
+++ b/cfg/cfgogl/zm1v1/mapinfo.txt
@@ -105,6 +105,14 @@
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"150.000000"
 		"horde_limit"		"120"
+		"tank_ban_flow"
+		{
+			"Alley choke to up top"
+			{
+				"min"		"56"
+				"max"		"68"
+			}
+		}
 		"witch_ban_flow"
 		{
 			"Ladder"
@@ -412,6 +420,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -424,9 +440,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -463,7 +484,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/zm2v2/mapinfo.txt
+++ b/cfg/cfgogl/zm2v2/mapinfo.txt
@@ -420,6 +420,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -432,9 +440,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -458,19 +471,6 @@
 		"start_dist"		"75.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
-		"tank_ban_flow"
-		{
-			"Early to past Event"
-			{
-				"min"		"0"
-				"max"		"64"
-			}
-			"Block End"
-			{
-				"min"		"68"
-				"max"		"100"
-			}
-		}
 	}
 	"c7m2_barge"
 	{
@@ -484,7 +484,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/zm3v3/mapinfo.txt
+++ b/cfg/cfgogl/zm3v3/mapinfo.txt
@@ -420,6 +420,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -432,9 +440,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -458,19 +471,6 @@
 		"start_dist"		"75.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
-		"tank_ban_flow"
-		{
-			"Early to past Event"
-			{
-				"min"		"0"
-				"max"		"64"
-			}
-			"Block End"
-			{
-				"min"		"68"
-				"max"		"100"
-			}
-		}
 	}
 	"c7m2_barge"
 	{
@@ -484,7 +484,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/zonehunters/mapinfo.txt
+++ b/cfg/cfgogl/zonehunters/mapinfo.txt
@@ -105,6 +105,14 @@
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"150.000000"
 		"horde_limit"		"120"
+		"tank_ban_flow"
+		{
+			"Alley choke to up top"
+			{
+				"min"		"56"
+				"max"		"68"
+			}
+		}
 		"witch_ban_flow"
 		{
 			"Ladder"
@@ -412,6 +420,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -424,9 +440,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -463,7 +484,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/zonemod/mapinfo.txt
+++ b/cfg/cfgogl/zonemod/mapinfo.txt
@@ -420,6 +420,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -432,9 +440,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -458,19 +471,6 @@
 		"start_dist"		"75.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
-		"tank_ban_flow"
-		{
-			"Early to past Event"
-			{
-				"min"		"0"
-				"max"		"64"
-			}
-			"Block End"
-			{
-				"min"		"68"
-				"max"		"100"
-			}
-		}
 	}
 	"c7m2_barge"
 	{
@@ -484,7 +484,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/cfgogl/zoneretro/mapinfo.txt
+++ b/cfg/cfgogl/zoneretro/mapinfo.txt
@@ -105,6 +105,14 @@
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"150.000000"
 		"horde_limit"		"120"
+		"tank_ban_flow"
+		{
+			"Alley choke to up top"
+			{
+				"min"		"56"
+				"max"		"68"
+			}
+		}
 		"witch_ban_flow"
 		{
 			"Ladder"
@@ -412,6 +420,14 @@
 		"start_dist"		"50.000000"
 		"start_extra_dist"	"0.000000"
 		"end_dist"			"50.000000"
+		"tank_ban_flow"
+		{
+			"Late Alley"
+			{
+				"min"		"58"
+				"max"		"70"
+			}
+		}
 	}
 	"c6m2_bedlam"
 	{
@@ -424,9 +440,14 @@
 		"horde_limit"		"150"
 		"tank_ban_flow"
 		{
+			"Sewer Drop"
+			{
+				"min"		"56"
+				"max"		"66"
+			}
 			"Event (bugged spawn)"
 			{
-				"min"		"74"
+				"min"		"72"
 				"max"		"100"
 			}
 		}
@@ -463,7 +484,7 @@
 		{
 			"Event (bugged spawn)"
 			{
-				"min"		"72"
+				"min"		"70"
 				"max"		"78"
 			}
 		}

--- a/cfg/stripper/acemodrv/maps/c2m2_fairgrounds.cfg
+++ b/cfg/stripper/acemodrv/maps/c2m2_fairgrounds.cfg
@@ -1321,68 +1321,19 @@ add:
 	"origin" "-2924 -6274 -127"
 	"targetname" "hedge_lighting"
 }
-; --- Open tent by the end saferoom with concert equipment inside
+; --- Tent after the stairs by the end saferoom
 {
 	"classname" "prop_dynamic"
-	"origin" "-3396 -5986 -64"
+	"origin" "-3393 -6050 -64"
 	"angles" "0 0 0"
-	"model" "models/props_misc/fairground_tent_open.mdl"
+	"model" "models/props_misc/fairground_tent_closed.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"rendercolor" "201 162 80"
+	"rendercolor" "83 152 189"
 }
-{
-	"classname" "prop_dynamic"
-	"origin" "-3442 -5958 -64"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/anvil_case_64.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-3442 -5942 -32"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/anvil_case_32.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-3442 -5942 0"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/anvil_case_32.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-3442 -5974 -32"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/anvil_case_32.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-3350 -6014 -64"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/anvil_case_64.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-3349 -6014 -35"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/amp_stack.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Clipping on top of tent
 {
 	"classname" "env_physics_blocker"
-	"origin" "-3396 -5986 421"
+	"origin" "-3393 -6050 421"
 	"mins" "-64 -64 -347.5"
 	"maxs" "64 64 347.5"
 	"initialstate" "1"

--- a/cfg/stripper/acemodrv/maps/c6m1_riverbank.cfg
+++ b/cfg/stripper/acemodrv/maps/c6m1_riverbank.cfg
@@ -35,6 +35,18 @@ add:
 	"spawnflags" "3"
 	"count" "5"
 }
+; --- Make the weapons in the covenience store spawn
+modify:
+{
+	match:
+	{
+		"hammerid" "508847"
+	}
+	insert:
+	{
+		"OnVersus" "ptemplate_tier1_weapons_1,ForceSpawn,,0,-1"
+	}
+}
 ; --- Allow weapon spawns in the apartments to spawn in versus
 filter:
 {
@@ -216,7 +228,7 @@ add:
 	"disableshadows" "1"
 }
 ; --- Car park
-; --- Remaining hittables: caralarm_4-caralarm_car1, car_physics-InstanceAuto48, car_physics-InstanceAuto92
+; --- Remaining hittables: caralarm_4-caralarm_car1
 filter:
 {
 	"targetname" "car_physics-InstanceAuto41"
@@ -242,20 +254,32 @@ filter:
 {
 	"parentname" "car_physics-InstanceAuto51"
 }
+{
+	"targetname" "car_physics-InstanceAuto92"
+}
+{
+	"parentname" "car_physics-InstanceAuto92"
+}
+{
+	"targetname" "car_physics-InstanceAuto48"
+}
+{
+	"parentname" "car_physics-InstanceAuto48"
+}
 add:
 ; --- car_physics-InstanceAuto41
 {
 	"classname" "prop_dynamic"
-	"origin" "3807 3050 30"
-	"angles" "0 156 0"
+	"origin" "3833 3006 31"
+	"angles" "-1.67622 166.969 -2.66401"
 	"model" "models/props_vehicles/cara_69sedan.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "3807 3050 30"
-	"angles" "0 156 0"
+	"origin" "3833 3006 31"
+	"angles" "-1.67622 166.969 -2.66401"
 	"model" "models/props_vehicles/cara_69sedan_glass.mdl"
 	"solid" "6"
 	"disableshadows" "1"
@@ -312,7 +336,6 @@ add:
 	"disableshadows" "1"
 }
 ; --- Bar exit
-; --- Remaining hittables: InstanceAuto24-caralarm_car1
 filter:
 {
 	"targetname" "caralarm_2-caralarm_car1"
@@ -337,6 +360,12 @@ filter:
 }
 {
 	"parentname" "InstanceAuto2-caralarm_car1"
+}
+{
+	"targetname" "InstanceAuto24-caralarm_car1"
+}
+{
+	"parentname" "InstanceAuto24-caralarm_car1"
 }
 add:
 ; --- caralarm_2-caralarm_car1
@@ -507,9 +536,8 @@ add:
 	"disableshadows" "1"
 }
 ; --- Upper alley
-; --- Remaining hittables: InstanceAuto44-caralarm_car1, caralarm_1-caralarm_car1
+; --- Remaining hittables: caralarm_1-caralarm_car1
 filter:
-; --- Removing but not replacing caralarm_3-caralarm_car1 due to weird placement and perma-stuck potential
 {
 	"targetname" "caralarm_3-caralarm_car1"
 }
@@ -521,6 +549,12 @@ filter:
 }
 {
 	"parentname" "caralarm_7-caralarm_car1"
+}
+{
+	"targetname" "InstanceAuto44-caralarm_car1"
+}
+{
+	"parentname" "InstanceAuto44-caralarm_car1"
 }
 add:
 ; --- caralarm_7-caralarm_car1
@@ -536,6 +570,23 @@ add:
 	"classname" "prop_dynamic"
 	"origin" "1438 1207 350"
 	"angles" "-0.499467 180.026 -2.50004"
+	"model" "models/props_vehicles/cara_95sedan_glass.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- InstanceAuto44-caralarm_car1
+{
+	"classname" "prop_dynamic"
+	"origin" "280 1097 348"
+	"angles" "-0.488467 212.879 2.00529"
+	"model" "models/props_vehicles/cara_95sedan.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "280 1097 348"
+	"angles" "-0.488467 212.879 2.00529"
 	"model" "models/props_vehicles/cara_95sedan_glass.mdl"
 	"solid" "6"
 	"disableshadows" "1"
@@ -693,6 +744,14 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+{
+	"classname" "env_physics_blocker"
+	"origin" "2021 1283 273"
+	"mins" "-28 -6 -81"
+	"maxs" "28 6 81"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block survivors from standing on garage doors at the ramp by the apartments
 {
 	"classname" "env_physics_blocker"
@@ -741,26 +800,6 @@ add:
 	"origin" "2224 1608 752"
 	"mins" "-160 -8 -64"
 	"maxs" "160 8 64"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Block survivors from standing on the bus before the park
-{
-	"classname" "env_physics_blocker"
-	"origin" "1057 803 1880"
-	"angles" "0 8 0"
-	"mins" "-239 -56 -1216"
-	"maxs" "239 56 1216"
-	"boxmins" "-239 -56 -1216"
-	"boxmaxs" "239 56 1216"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "1268 889 1862"
-	"mins" "-3 -3 -1234"
-	"maxs" "3 3 1234"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -879,6 +918,16 @@ add:
 ; ==                   STUCK SPOTS                   ==
 ; ==  Prevent players from getting stuck in the map  ==
 ; =====================================================
+add:
+; --- Fix a sliding stuck spot on the bus in the alley
+{
+	"classname" "env_physics_blocker"
+	"origin" "705 1292 314"
+	"mins" "-223 -16 -7"
+	"maxs" "223 16 7"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Prevent players from getting stuck behind the end saferoom
 {
 	"classname" "env_physics_blocker"
@@ -940,6 +989,132 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Clipping on windows and doors in the saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "696 3244 168"
+	"mins" "-8 -28 -48"
+	"maxs" "8 28 48"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "696 3684 168"
+	"mins" "-8 -212 -48"
+	"maxs" "8 212 48"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "690 3376 172"
+	"mins" "-2 -40 -68"
+	"maxs" "2 40 68"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "700 4176 156"
+	"mins" "-4 -24 -52"
+	"maxs" "4 24 52"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Clipping on racecar in the saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "957 3940 135"
+	"angles" "0 0 20"
+	"mins" "-5 -18 -6"
+	"maxs" "5 18 6"
+	"boxmins" "-5 -18 -6"
+	"boxmaxs" "5 18 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "899 3940 135"
+	"angles" "0 0 20"
+	"mins" "-5 -18 -6"
+	"maxs" "5 18 6"
+	"boxmins" "-5 -18 -6"
+	"boxmaxs" "5 18 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "928 3904 144"
+	"angles" "0 0 20"
+	"mins" "-35 -5 -12"
+	"maxs" "35 5 12"
+	"boxmins" "-35 -5 -12"
+	"boxmaxs" "35 5 12"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "884 4083 102"
+	"angles" "0 45 0"
+	"mins" "-3 -4 -15"
+	"maxs" "3 4 15"
+	"boxmins" "-3 -4 -15"
+	"boxmaxs" "3 4 15"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "971 4107 102"
+	"angles" "0 45 0"
+	"mins" "-3 -4 -15"
+	"maxs" "3 4 15"
+	"boxmins" "-3 -4 -15"
+	"boxmaxs" "3 4 15"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "970 4089 102"
+	"mins" "-3 -11 -15"
+	"maxs" "3 11 15"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Stairs on the hedges by the saferoom
+{
+	"classname" "func_brush"
+	"origin" "1260 3262 21"
+	"angles" "0 180 0"
+	"model" "*145"
+	"StartDisabled" "0"
+	"spawnflags" "2"
+	"Solidity" "2"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1188 3298 97.375"
+	"angles" "-0.000552338 89.9751 358.727"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1195 3262 -7.65"
+	"angles" "45 0 0"
+	"mins" "-76 -32 -72"
+	"maxs" "76 32 72"
+	"boxmins" "-76 -32 -72"
+	"boxmaxs" "76 32 72"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Clipping on store entrances to stop players getting stuck on the steps
 {
 	"classname" "env_physics_blocker"
@@ -964,6 +1139,138 @@ add:
 	"maxs" "65 9 4"
 	"initialstate" "1"
 	"BlockType" "0"
+}
+; --- Fix area portal fade out distance in the shop entrance
+modify:
+{
+	match:
+	{
+		"target" "portalbrush_A14"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A20"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A18"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A16"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A21"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A29"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A15"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A19"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+; --- Move filing cabinets away from the door after the stair choke
+modify:
+{
+	match:
+	{
+		"hammerid" "569640"
+	}
+	replace:
+	{
+		"origin" "3650.53 2346.25 201.219"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "569644"
+	}
+	replace:
+	{
+		"origin" "3676 2344 201.219"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "569632"
+	}
+	replace:
+	{
+		"origin" "3653.5 2391.28 201.188"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "569636"
+	}
+	replace:
+	{
+		"origin" "3670.85 2365.75 201.188"
+	}
 }
 ; --- Make plywood in the bar non solid that blocks the door from opening both ways
 modify:
@@ -1015,6 +1322,172 @@ modify:
 ; ==       New props for balance and SI spawns       ==
 ; =====================================================
 add:
+; --- Fences on the wall in the parking lot
+{
+	"classname" "prop_dynamic"
+	"origin" "3715 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "3843 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "3971 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4099 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4227 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4355 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4483 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4611 3736 72"
+	"angles" "0 264 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4163 3741 126"
+	"mins" "-448 -3 -54"
+	"maxs" "448 3 54"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4675 3735 128"
+	"angles" "0 -5 0"
+	"mins" "-64 -3 -54"
+	"maxs" "64 3 54"
+	"boxmins" "-64 -3 -54"
+	"boxmaxs" "64 3 54"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Fences at the front of the parking lot
+{
+	"classname" "prop_dynamic"
+	"origin" "3722 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence002_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "3722 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence_post002.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4122 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence002_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4122 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence_post002.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4270 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence002_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4270 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence_post002.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4418 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence002_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4418 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence_post002.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Van in the parking lot
+{
+	"classname" "prop_dynamic"
+	"origin" "4063 3546 32"
+	"angles" "0 0 0"
+	"model" "models/props_vehicles/van.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4063 3546 32"
+	"angles" "0 0 0"
+	"model" "models/props_vehicles/van_glass.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
 ; --- Van at the ramp by the apartments to help survivors with tank fights there
 {
 	"classname" "prop_dynamic"
@@ -1031,6 +1504,75 @@ add:
 	"model" "models/props_vehicles/van_glass.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+; --- Boxes to get on the bus by the ramp
+{
+	"classname" "prop_dynamic"
+	"origin" "-1067 1172 206"
+	"angles" "0 324 0"
+	"model" "models/props/cs_militia/boxes_garage_lower.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-1043 1186 87"
+	"angles" "0.993572 15.8868 -6.50098"
+	"model" "models/props_wasteland/rockcliff07b.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Boxes to get on the bus before the park
+{
+	"classname" "prop_dynamic"
+	"origin" "970 714 515"
+	"angles" "0 328 0"
+	"model" "models/props/cs_militia/boxes_garage_lower.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1012 700 511"
+	"angles" "0 16 0"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1012 700 512"
+	"angles" "0 14 0"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1013 701 513"
+	"angles" "0 15 0"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1013 702 514"
+	"angles" "0 16 0"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "968 712 581"
+	"angles" "0 28 0"
+	"mins" "-15 -15 -2"
+	"maxs" "15 15 2"
+	"boxmins" "-15 -15 -2"
+	"boxmaxs" "15 15 2"
+	"initialstate" "1"
+	"BlockType" "0"
 }
 ; --- Bus behind tent by the end saferoom
 {
@@ -1260,11 +1802,11 @@ add:
 ; --- Infected ladder to climb over the truck by the bar exit
 {
 	"classname" "func_simpleladder"
-	"origin" "6689.93 6473.32 -50"
-	"angles" "0 201 0"
+	"origin" "6768.93 6434.31 -49"
+	"angles" "0 200 0"
 	"model" "*134"
-	"normal.x" "0.35"
-	"normal.y" "-0.93"
+	"normal.x" "0.34202"
+	"normal.y" "-0.939692"
 	"normal.z" "0.00"
 	"team" "2"
 }
@@ -1338,14 +1880,6 @@ add:
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "1014 1728 512"
-	"angles" "0 270 0"
-	"model" "models/props/cs_militia/boxes_frontroom.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
 	"origin" "1030 2041 512"
 	"angles" "0 0 0"
 	"model" "models/props/de_prodigy/concretebags.mdl"
@@ -1376,105 +1910,4 @@ add:
 	"maxs" "8 19 5"
 	"initialstate" "1"
 	"BlockType" "0"
-}
-; --- Scaffolding
-{
-	"classname" "prop_dynamic"
-	"origin" "886 2134 512"
-	"angles" "0 90 0"
-	"model" "models/props_highway/scaffolding_320_base.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "886 2134 512"
-	"angles" "0 90 0"
-	"model" "models/props_highway/scaffolding_320.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "886 2134 617"
-	"angles" "0 90 0"
-	"model" "models/props_highway/scaffolding_320.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "886 2134 608"
-	"angles" "0 90 0"
-	"model" "models/props_highway/scaffolding_bracing_short.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "646 2038 603"
-	"angles" "0 270 0"
-	"model" "models/props_highway/scaffolding_bracing_medium.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "886 2042 616"
-	"angles" "0 0 0"
-	"model" "models/props_highway/plywood_03.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "763 2074 616"
-	"angles" "0 9 0"
-	"model" "models/props_highway/plywood_03.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "820 2038 718"
-	"angles" "0 270 0"
-	"model" "models/props_highway/plywood_02.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "814 2063 721"
-	"angles" "0 0 0"
-	"model" "models/props_highway/plywood_02.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "660 2038 718"
-	"angles" "0 270 0"
-	"model" "models/props_highway/plywood_02.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Block for survivors
-{
-	"classname" "env_physics_blocker"
-	"origin" "764 2087 728"
-	"mins" "-126 -49 -96"
-	"maxs" "126 49 96"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Infected ladder to climb up scaffolding
-{
-	"classname" "func_simpleladder"
-	"origin" "-254 1237 -74"
-	"angles" "0 90 0"
-	"model" "*132"
-	"normal.x" "1.00"
-	"normal.y" "0.00"
-	"normal.z" "0.00"
-	"team" "2"
 }

--- a/cfg/stripper/acemodrv/maps/c6m2_bedlam.cfg
+++ b/cfg/stripper/acemodrv/maps/c6m2_bedlam.cfg
@@ -181,6 +181,109 @@ add:
 	"spawnflags" "4096"
 	"targetname" "nav_sewer_drop_obscured"
 }
+; --- Force survivors to drop early after the 2nd event gate, and make the button stop the event
+modify:
+{
+	match:
+	{
+		"targetname" "button_bridge"
+	}
+	insert:
+	{
+		"OnPressed" "director,EndScript,,0,-1"
+	}
+}
+add:
+{
+	"classname" "prop_dynamic"
+	"origin" "6143 5448 -988"
+	"angles" "0 0 0"
+	"model" "models/props_wasteland/exterior_fence002b.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "6132 5494 -912"
+	"angles" "0 270 180"
+	"model" "models/props_downtown/balcony_post_base04_154.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "6132 5402 -912"
+	"angles" "0 270 180"
+	"model" "models/props_downtown/balcony_post_base04_154.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "6132 5448 -992"
+	"mins" "-3 -56 -72"
+	"maxs" "3 56 72"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "navblocker_gate_drop,BlockNav,,1,-1"
+}
+{
+	"classname" "script_nav_blocker"
+	"origin" "6128 5448 -1054"
+	"extent" "24 38 12"
+	"targetname" "navblocker_gate_drop"
+	"teamToBlock" "3"
+	"affectsFlow" "0"
+}
+{
+	"origin" "5243.06 5452.03 -928"
+	"targetname" "gate_2_alarm_2"
+	"spawnflags" "48"
+	"radius" "1250"
+	"pitchstart" "100"
+	"pitch" "100"
+	"message" "Churchbell.End"
+	"health" "10"
+	"classname" "ambient_generic"
+	"preset" "15"
+}
+modify:
+{
+	match:
+	{
+		"targetname" "gate_2_alarm"
+	}
+	insert:
+	{
+		"preset" "3"
+	}
+	replace:
+	{
+		"spawnflags" "48"
+	}
+}
+{
+	match:
+	{
+		"targetname" "relay_second_gate"
+	}
+	delete:
+	{
+		"OnTrigger" "gate_spot_2LightOn0-1"
+		"OnTrigger" "gate_2_lightSkin10-1"
+		"_OnTrigger" "gate_2_lightSkin015-1"
+		"_OnTrigger" "gate_spot_2LightOff15-1"
+	}
+	insert:
+	{
+		"OnTrigger" "gate_2_alarm_2,PlaySound,,3.5,-1"
+	}
+}
 ; --- Stop the event once survivors reach the stairs by the saferoom
 add:
 {
@@ -285,6 +388,16 @@ add:
 {
 	"classname" "weapon_ammo_spawn"
 	"origin" "1183 568 18"
+	"angles" "0 90 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+; --- Ammo pile by the cement truck
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "142 1329 -64"
 	"angles" "0 90 0"
 	"model" "models/props/terror/ammo_stack.mdl"
 	"solid" "6"
@@ -619,11 +732,19 @@ add:
 ; ==       New props for balance and SI spawns       ==
 ; =====================================================
 add:
-; --- Additional upturned pool table in the pool room
+; --- Extra upturned pool tables in the pool room
 {
 	"classname" "prop_dynamic"
 	"origin" "1345 723 8"
 	"angles" "75 155 0"
+	"model" "models/props_downtown/pooltable.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "847 1084 8"
+	"angles" "75 335.5 0"
 	"model" "models/props_downtown/pooltable.mdl"
 	"solid" "6"
 	"disableshadows" "1"
@@ -637,6 +758,32 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
+; --- Bricks to climb into the pool room from the construction site
+{
+	"classname" "prop_dynamic"
+	"origin" "1265 1356 -77"
+	"angles" "4.24909 94.4899 0.00738525"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1242 1301 -72"
+	"angles" "-0.370436 359.396 -4.23301"
+	"model" "models/props/de_nuke/cinderblock_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Fence on the bar roof
+{
+	"classname" "prop_dynamic"
+	"origin" "110 1944 336"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence001_256.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
 ; --- Prop to spawn behind on unused fire escape
 {
 	"classname" "prop_dynamic"
@@ -645,6 +792,34 @@ add:
 	"model" "models/props_junk/trashcluster01b_corner.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+; --- Van on the street outside the jazz club
+{
+	"classname" "prop_dynamic"
+	"origin" "-94 3944 -162"
+	"angles" "0 263 0"
+	"model" "models/props_vehicles/van.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-94 3944 -162"
+	"angles" "0 263 0"
+	"model" "models/props_vehicles/van_glass.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "losfix_jazzvan1,AddOutput,mins -108 -2 -13,0,-1"
+	"OnMapSpawn" "losfix_jazzvan1,AddOutput,maxs 108 2 13,0,-1"
+	"OnMapSpawn" "losfix_jazzvan1,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "func_brush"
+	"origin" "-94 3942 -155"
+	"targetname" "losfix_jazzvan1"
 }
 ; --- Sign on jazz club awning
 {
@@ -748,6 +923,91 @@ add:
 	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+; --- Pipe groups with ladders in the room where survivors drop into the sewers
+{
+	"classname" "prop_dynamic"
+	"origin" "486 4497 -1136"
+	"angles" "0 270 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "486 4369 -1096"
+	"angles" "0 270 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "446 4497 -1136"
+	"angles" "0 270 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "446 4369 -1096"
+	"angles" "0 270 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "-341 -487 -186"
+	"angles" "0 0 0"
+	"model" "*80"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1022 5776 -1136"
+	"angles" "0 90 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1022 5904 -1096"
+	"angles" "0 90 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1062 5776 -1136"
+	"angles" "0 90 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1062 5904 -1096"
+	"angles" "0 90 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "1848 10760 -186"
+	"angles" "0 180 0"
+	"model" "*80"
+	"normal.x" "0.00"
+	"normal.y" "-1.00"
+	"normal.z" "0.00"
+	"team" "2"
 }
 ; --- Props in the second sewer room, where the first gate is opened
 {
@@ -874,24 +1134,65 @@ add:
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "6454 5225 -1056"
-	"angles" "-90 0 0"
-	"model" "models/props_pipes/pipeset08d_512_001a.mdl"
+	"origin" "6504 5127 -1031"
+	"angles" "-90 270 0"
+	"model" "models/props_pipes/pipeset32d_bend256u_001a.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+	"lightingorigin" "pipe_bend_lighting"
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "6645 5225 -1056"
-	"angles" "-90 0 0"
-	"model" "models/props_pipes/pipeset08d_512_001a.mdl"
+	"origin" "6504 5256 -1222"
+	"angles" "-90 270 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+	"lightingorigin" "pipe_bend_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "6545 5127 -1031"
+	"angles" "-90 270 0"
+	"model" "models/props_pipes/pipeset32d_bend256u_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipe_bend_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "6545 5256 -1222"
+	"angles" "-90 270 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipe_bend_lighting"
+}
+{
+	"classname" "info_target"
+	"origin" "6525 5129 -1033"
+	"targetname" "pipe_bend_lighting"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "6525.5 5224 -1000"
+	"mins" "-36.5 -48 -80"
+	"maxs" "36.5 48 80"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "6525.5 5120 -964"
+	"mins" "-36.5 -56 -44"
+	"maxs" "36.5 56 44"
+	"initialstate" "1"
+	"BlockType" "1"
 }
 ; --- Props in the tunnel leading to the saferoom
 {
 	"classname" "prop_dynamic"
-	"origin" "7859 5373 -1136"
+	"origin" "8828 5369 -1136"
 	"angles" "90 0 0"
 	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
 	"solid" "6"
@@ -899,11 +1200,28 @@ add:
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "8828 5500 -1136"
+	"origin" "8828 5504 -1136"
 	"angles" "90 0 0"
 	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+; --- Ramp before the ladder after the tunnel
+{
+	"classname" "prop_dynamic"
+	"origin" "9565 5498 -1197"
+	"angles" "-30 0 0"
+	"model" "models/props_urban/metal_plate001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "9623 5498 -1166"
+	"mins" "-1 -36 -2"
+	"maxs" "1 36 2"
+	"initialstate" "1"
+	"BlockType" "0"
 }
 
 ; =====================================================
@@ -939,8 +1257,8 @@ modify:
 	}
 	insert:
 	{
-		"OnTrigger" "gate_2_alarm,FadeOut,5,3,-1"
-		"OnTrigger" "gate_2_alarm,Volume,5,3,-1"
+		"OnTrigger" "gate_2_alarm,FadeOut,2,2,-1"
+		;"OnTrigger" "gate_2_alarm,Volume,5,3,-1"
 		"OnTrigger" "gate_2_alarm,Kill,,10,-1"
 	}
 }
@@ -1054,6 +1372,25 @@ add:
 	"solid" "0"
 	"disableshadows" "1"
 }
+; --- Ladder to climb on the food cart by the cement mixer
+{
+	"classname" "func_simpleladder"
+	"origin" "286 5466 -280"
+	"angles" "0 180 5"
+	"model" "*92"
+	"normal.x" "0.00"
+	"normal.y" "-0.996194"
+	"normal.z" "0.087155"
+	"team" "0"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-384 1807 -1"
+	"angles" "5 90 0"
+	"model" "models/props/cs_assault/ladderaluminium128.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
 ; --- Infected ladder to get to the unused fire escape next to plank crossing
 {
 	"classname" "func_simpleladder"
@@ -1133,9 +1470,9 @@ add:
 ; --- Infected ladder to climb on food cart outside the jazz club
 {
 	"classname" "func_simpleladder"
-	"origin" "-2628.5 5190 -53"
-	"angles" "0 270 0"
-	"model" "*92"
+	"origin" "-281 1656 3"
+	"angles" "0 0 0"
+	"model" "*37"
 	"normal.x" "1.00"
 	"normal.y" "0.00"
 	"normal.z" "0.00"

--- a/cfg/stripper/acemodrv/maps/c7m1_docks.cfg
+++ b/cfg/stripper/acemodrv/maps/c7m1_docks.cfg
@@ -74,19 +74,62 @@ add:
 	"SurvivorName" "Ellis"
 	"Order" "1"
 }
-; --- Automatically open the 2nd train car door 20 seconds after the first one is opened
+; --- Automatically open the 2nd train car door 20 seconds after the tank is spawned
 modify:
 {
 	match:
 	{
-		"targetname" "tankdoorin_button"
+		"targetname" "versus_tank"
 	}
 	insert:
 	{
-		"OnTimeUp" "tankdoorout,Open,,20,-1"
-		"OnTimeUp" "tankdoorout_button,Disable,,20,-1"
-		"OnTimeUp" "tankdoorout_button,Kill,,20.5,-1"
+		"OnTrigger" "tankdoorout,Open,,20,-1"
+		"OnTrigger" "tankdoorout_button,Disable,,20,-1"
+		"OnTrigger" "director,EnableTankFrustration,,20,-1"
+		"OnTrigger" "tankdoorout_button,Kill,,20.5,-1"
 	}
+}
+; --- Remove the fake tank sounds
+filter:
+{
+	"targetname" "tank_sound_timer"
+}
+{
+	"targetname" "tank_sound_picker"
+}
+{
+	"targetname" "tank_shake"
+}
+{
+	"targetname" "tank_sound1"
+}
+{
+	"targetname" "tank_sound2"
+}
+
+{
+	"targetname" "tank_sound3"
+}
+{
+	"targetname" "tank_sound4"
+}
+{
+	"targetname" "tank_sound5"
+}
+{
+	"targetname" "tank_sound6"
+}
+{
+	"targetname" "tank_sound7"
+}
+{
+	"targetname" "tank_sound8"
+}
+{
+	"targetname" "tank_sound9"
+}
+{
+	"targetname" "tank_sound10"
 }
 
 
@@ -95,6 +138,39 @@ modify:
 ; ==           PILL / ITEM / WEAPON SPAWNS           ==
 ; ==   Remove or change pill, item & weapon spawns   ==
 ; =====================================================
+; --- Remove some useless early pill spawns
+filter:
+{
+	"hammerid" "474406"
+}
+{
+	"hammerid" "3441021"
+}
+{
+	"hammerid" "514755"
+}
+{
+	"hammerid" "84931"
+}
+{
+	"hammerid" "523121"
+}
+; --- Remove some useless late pill spawns
+{
+	"hammerid" "85119"
+}
+{
+	"hammerid" "85123"
+}
+{
+	"hammerid" "680768"
+}
+{
+	"hammerid" "681687"
+}
+{
+	"hammerid" "85180"
+}
 
 ; =====================================================
 ; ==                STATIC AMMO PILES                ==
@@ -179,6 +255,287 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Clipping on the underpass rocks
+{
+	"classname" "env_physics_blocker"
+	"origin" "11092 -229 -98"
+	"mins" "-50 -21 -7"
+	"maxs" "50 21 7"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10959 -181 -68"
+	"mins" "-50 -21 -6"
+	"maxs" "50 21 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10915 -189 -58"
+	"mins" "-13 -10 -4"
+	"maxs" "13 10 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10879 -196 -70"
+	"mins" "-41 -21 -6"
+	"maxs" "41 21 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10828 -274 -109"
+	"mins" "-44 -22 -6"
+	"maxs" "44 22 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10781 -256 -96"
+	"mins" "-11 -16 -6"
+	"maxs" "11 16 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10774 -224 -87"
+	"mins" "-10 -24 -6"
+	"maxs" "10 24 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10784 -189 -73"
+	"mins" "-48 -10 -6"
+	"maxs" "48 10 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10784 -182 -63"
+	"mins" "-40 -10 -4"
+	"maxs" "40 10 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10664 -264 -108"
+	"mins" "-16 -26 -6"
+	"maxs" "16 26 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10648 -287 -112"
+	"mins" "-16 -26 -6"
+	"maxs" "16 26 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10475 -319 -123"
+	"mins" "-69 -7 -6"
+	"maxs" "69 7 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10554 -240 -107"
+	"mins" "-38 -24 -6"
+	"maxs" "38 24 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10420 -212 -94"
+	"mins" "-20 -12 -6"
+	"maxs" "20 12 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10664 -264 -108"
+	"mins" "-16 -26 -6"
+	"maxs" "16 26 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10400 -129 -69"
+	"mins" "-40 -12 -6"
+	"maxs" "40 12 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10365 -109 -62"
+	"mins" "-11 -8 -5"
+	"maxs" "11 8 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10333 -105 -73"
+	"mins" "-37 -17 -6"
+	"maxs" "37 17 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10304 -77 -67"
+	"mins" "-32 -17 -6"
+	"maxs" "32 17 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10276 -105 -82"
+	"mins" "-20 -17 -6"
+	"maxs" "20 17 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10252 -40 -73"
+	"mins" "-20 -32	 -6"
+	"maxs" "20 32 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10249 -28 -67"
+	"mins" "-10 -20 -6"
+	"maxs" "10 20 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10208 -171 -122"
+	"mins" "-16 -35 -6"
+	"maxs" "16 35 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10210 -161 -110"
+	"mins" "-14 -25 -6"
+	"maxs" "14 25 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10179 -116 -90"
+	"mins" "-43 -20 -6"
+	"maxs" "43 20 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "11033 -179 -68"
+	"mins" "-24 -19 -6"
+	"maxs" "24 19 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "11029 -174 -58"
+	"mins" "-20 -14 -4"
+	"maxs" "20 14 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10784 -174 -55"
+	"mins" "-32 -10 -4"
+	"maxs" "32 10 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10784 -166 -47"
+	"mins" "-24 -10 -4"
+	"maxs" "24 10 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10940 -196 -64"
+	"mins" "-20 -12 -6"
+	"maxs" "20 12 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10641 -272 -102"
+	"mins" "-17 -24 -4"
+	"maxs" "17 24 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10552 -234 -95"
+	"mins" "-24 -18 -6"
+	"maxs" "24 18 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10572 -277 -109"
+	"mins" "-20 -13 -4"
+	"maxs" "20 13 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10228 -189 -110"
+	"mins" "-20 -12 -6"
+	"maxs" "20 12 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10214 -159 -98"
+	"mins" "-13 -21 -6"
+	"maxs" "13 21 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Add missing glass to vehicles
 {
 	"classname" "prop_dynamic"
@@ -248,6 +605,17 @@ add:
 ; ==              Add or change ladders              ==
 ; =====================================================
 add:
+; --- Infected ladder to climb over the wall outside the saferoom
+{
+	"classname" "func_simpleladder"
+	"origin" "350 0 -96"
+	"angles" "0 0 0"
+	"model" "*249"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
 ; --- Infected ladder to climb on slanted roof by the burning barricade
 {
 	"classname" "func_simpleladder"
@@ -255,6 +623,44 @@ add:
 	"angles" "0 0 0"
 	"model" "*27"
 	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the boat at the back of the tank area
+{
+	"classname" "func_simpleladder"
+	"origin" "8679 9717 -31"
+	"angles" "0 270 0"
+	"model" "*10"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "9114 298 127"
+	"mins" "-16 -3 -6"
+	"maxs" "16 3 6"
+	"initialstate" "1"
+	"BlockType" "3"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "9114 293 136"
+	"mins" "-16 -5 -3"
+	"maxs" "16 5 3"
+	"initialstate" "1"
+	"BlockType" "3"
+}
+; --- Infected ladder on the bricks by the yellow pickup truck
+{
+	"classname" "func_simpleladder"
+	"origin" "0 340 0"
+	"angles" "0 0 0"
+	"model" "*53"
+	"normal.x" "-1.00"
 	"normal.y" "0.00"
 	"normal.z" "0.00"
 	"team" "2"

--- a/cfg/stripper/acemodrv/maps/c7m2_barge.cfg
+++ b/cfg/stripper/acemodrv/maps/c7m2_barge.cfg
@@ -350,6 +350,17 @@ add:
 	"origin" "7449 1507 83"
 	"targetname" "pond_pipe_lighting"
 }
+; --- Infected ladder on the pipes
+{
+	"classname" "func_simpleladder"
+	"origin" "-360 1206 -156"
+	"angles" "0 0 0"
+	"model" "*236"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
 ; --- Extra pole clusters by the sunken fishing boat
 {
 	"classname" "prop_dynamic"

--- a/cfg/stripper/acemodrv/maps/c7m2_barge.cfg
+++ b/cfg/stripper/acemodrv/maps/c7m2_barge.cfg
@@ -98,6 +98,31 @@ filter:
 ; ==                 HITTABLE CHANGES                ==
 ; ==           Add/remove/modify hittables           ==
 ; =====================================================
+; --- Make a car in the fueling area unhittable
+filter:
+{
+	"targetname" "car03"
+}
+{
+	"parentname" "car03"
+}
+add:
+{
+	"classname" "prop_dynamic"
+	"origin" "4256 1776 129"
+	"angles" "0 150 0"
+	"model" "models/props_vehicles/cara_84sedan.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4256 1776 129"
+	"angles" "0 150 0"
+	"model" "models/props_vehicles/cara_84sedan_glass.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
 
 
 ; #############  MAP CLIPPING AND ISSUES  #############
@@ -244,6 +269,256 @@ add:
 ; ==                      PROPS                      ==
 ; ==       New props for balance and SI spawns       ==
 ; =====================================================
+add:
+; --- Tree by the first silo
+{
+	"classname" "prop_dynamic"
+	"origin" "7497 215 254"
+	"angles" "0 0 0"
+	"model" "models/props_foliage/urban_tree_giant01_a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Pipes in the water after the saferoom
+{
+	"classname" "prop_dynamic"
+	"origin" "7836 1508 39"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "7516 1508 78"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_512_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "7132 1508 78"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "7804 1494 4"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "7484 1494 43"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_512_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "7100 1494 43"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "pond_pipe_brush,AddOutput,mins -402 -0.1 -31,0,-1"
+	"OnMapSpawn" "pond_pipe_brush,AddOutput,maxs 402 0.1 31,0,-1"
+	"OnMapSpawn" "pond_pipe_brush,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "func_brush"
+	"origin" "7435 1506 40"
+	"targetname" "pond_pipe_brush"
+}
+{
+	"classname" "info_target"
+	"origin" "7449 1507 83"
+	"targetname" "pond_pipe_lighting"
+}
+; --- Extra pole clusters by the sunken fishing boat
+{
+	"classname" "prop_dynamic"
+	"origin" "186 310 34"
+	"angles" "0 181.5 0"
+	"model" "models/props_docks/dock01_polecluster01d_256.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "180 706 36"
+	"angles" "5.99794 181.508 0.157638"
+	"model" "models/props_docks/dock01_polecluster01d_256.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "142 1562 36"
+	"angles" "0 0 0"
+	"model" "models/props_docks/dock01_polecluster01d_256.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "141 1863 34"
+	"angles" "0 180 0"
+	"model" "models/props_docks/dock01_polecluster01d_256.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Rock by the pole clusters
+{
+	"classname" "prop_dynamic"
+	"origin" "190 354 -93.832"
+	"angles" "0 0 5"
+	"model" "models/lostcoast/props_wasteland/rock_coast01c.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Rock in the open area on the right side by the sunken fishing boat
+{
+	"classname" "prop_dynamic"
+	"origin" "405.28 2155.36 -94.49"
+	"angles" "-4.89735 165.121 -2.83357"
+	"model" "models/lostcoast/props_wasteland/rock_coast01b.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Large rock in the water by the sunken fishing boat
+{
+	"classname" "prop_dynamic"
+	"origin" "780 108 -57"
+	"angles" "0 260 0"
+	"model" "models/props_foliage/rock_coast02f.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "176 337 592"
+	"mins" "-34 -23 -668"
+	"maxs" "34 23 668"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Extra pipes by the sunken fishing boat
+{
+	"classname" "prop_dynamic"
+	"origin" "1556 -304 142.973"
+	"angles" "90 179 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1517.01 -303.319 -44.0267"
+	"angles" "90 179 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1556 -400 142.973"
+	"angles" "90 179 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1517.01 -399.319 -44.0267"
+	"angles" "90 179 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "515 2529 154.97"
+	"angles" "90 269 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipes_right_side_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "514.32 2490.01 -32.03"
+	"angles" "90 269 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipes_right_side_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "611 2529 154.97"
+	"angles" "90 269 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipes_right_side_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "610.32 2490.01 -32.03"
+	"angles" "90 269 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipes_right_side_lighting"
+}
+{
+	"classname" "info_target"
+	"origin" "560 2485 81"
+	"targetname" "pipes_right_side_lighting"
+}
+; --- Boat next to the freighter
+{
+	"classname" "prop_dynamic"
+	"origin" "-5892 -1337 156"
+	"angles" "0 100 0"
+	"model" "models/props_vehicles/boat_fishing02_static.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-5764 -1147 116"
+	"angles" "0 275 -180"
+	"model" "models/props_unique/metalladderbarge.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "-9860.73 -1294 -108.62"
+	"angles" "0 180 0"
+	"model" "*30"
+	"normal.x" "0.087152"
+	"normal.y" "-0.996195"
+	"normal.z" "0.00"
+	"team" "0"
+}
 
 ; =====================================================
 ; ==             LADDER / ELEVATOR NERF              ==
@@ -302,6 +577,17 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
+; --- Infected ladder to climb on the hut by the pond
+{
+	"classname" "func_simpleladder"
+	"origin" "5937 -422 -128"
+	"angles" "0 0 0"
+	"model" "*17"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
 ; --- Infected ladder to climb on the truck on the bridge before the car shop
 {
 	"classname" "func_simpleladder"
@@ -313,7 +599,7 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
-; --- Infected ladder to climb on top of the grounded boat in the open water area
+; --- Infected ladder to climb on top of the sunken boat in the open water area
 {
 	"classname" "func_simpleladder"
 	"origin" "548.83 3927.99 442.87"
@@ -334,6 +620,27 @@ add:
 	"boxmaxs" "28 12 120"
 	"initialstate" "1"
 	"BlockType" "2"
+}
+; --- Infected ladders to climb to climb up the barge by the sunken fishing boat
+{
+	"classname" "func_simpleladder"
+	"origin" "427 -1092 -115"
+	"angles" "0 0 0"
+	"model" "*99"
+	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "431 -447 -78"
+	"angles" "0 0 0"
+	"model" "*99"
+	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
 }
 ; --- Infected ladders to climb up from inside the barge
 {
@@ -390,6 +697,17 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
+; --- Infected ladder to climb up a building opposite the freighter
+{
+	"classname" "func_simpleladder"
+	"origin" "-8209 -6140 41"
+	"angles" "0 270 0"
+	"model" "*31"
+	"normal.x" "0.00"
+	"normal.y" "-1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
 ; --- Infected ladder to get on the higher part of a roof by the end saferoom
 {
 	"classname" "func_simpleladder"
@@ -405,6 +723,196 @@ add:
 
 ; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
 ; =====================================================
-; ==                   BLANK HEADER                  ==
-; ==                Blank description                ==
+; ==              SAFEROOM ONE WAY DROP              ==
+; ==          Prevent easy AI tank runbacks          ==
 ; =====================================================
+add:
+; --- Brick pallets for the one way drop
+{
+	"classname" "prop_dynamic"
+	"origin" "10499 512 126"
+	"angles" "0 0 0"
+	"model" "models/props_industrial/kiln_cart.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10499 512 126"
+	"angles" "0 0 0"
+	"model" "models/props_industrial/kiln_cart_bricks.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10369 512 126"
+	"angles" "0 0 0"
+	"model" "models/props_industrial/kiln_cart.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10369 512 126"
+	"angles" "0 0 0"
+	"model" "models/props_industrial/kiln_cart_bricks.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10531.4 590.636 144.23"
+	"angles" "0.170343 -0.0382243 0.166733"
+	"model" "models/props_industrial/brickpallets_break01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10490.3 594.69 144.412"
+	"angles" "0.0510122 -3.30978 359.797"
+	"model" "models/props_industrial/brickpallets_break04.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10448.7 595.972 145.984"
+	"angles" "5.645 7.5328 0.576767"
+	"model" "models/props_industrial/brickpallets_break03.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10407.8 591.315 149.802"
+	"angles" "5.45881 6.65154 0.638458"
+	"model" "models/props_industrial/brickpallets_break02.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10723 668 129"
+	"angles" "0 150 0"
+	"model" "models/props_equipment/cargo_container01_fixed.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendercolor" "106 64 64"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10434 489 169"
+	"mins" "-127 -39 -41"
+	"maxs" "127 39 41"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block jumping to unintended places from the drop props
+; --- Bricks
+{
+	"classname" "env_physics_blocker"
+	"origin" "10305.5 639.5 769"
+	"mins" "-64.5 -64.5 -511"
+	"maxs" "63.7 64.5 511"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10273.5 543 769"
+	"mins" "-32.5 -32 -511"
+	"maxs" "32.5 32 511"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10178 479 769"
+	"mins" "-64 -32 -511"
+	"maxs" "64 32 511"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Windows
+{
+	"classname" "env_physics_blocker"
+	"origin" "10888 760 400"
+	"mins" "-8 -632 -64"
+	"maxs" "8 632 64"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Truck
+{
+	"classname" "env_physics_blocker"
+	"origin" "10684 978 776"
+	"mins" "-8 -42 -504"
+	"maxs" "8 42 504"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10654 972 776"
+	"mins" "-22 -52 -504"
+	"maxs" "22 52 504"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10610 982 776"
+	"mins" "-22 -54 -504"
+	"maxs" "22 54 504"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10579 975 776"
+	"mins" "-9 -37 -504"
+	"maxs" "9 37 504"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Remove the alarm car
+modify:
+{
+	match:
+	{
+		"targetname" "car_alarm_spawner_versus"
+	}
+	delete:
+	{
+		"OnRandom01" "car_alarm_01ForceSpawn0-1"
+		"OnRandom01" "car_alarm_fake02ForceSpawn0-1"
+		"OnRandom01" "car_alarm_fake03ForceSpawn0-1"
+		"OnRandom01" "car_alarm_fake04ForceSpawn0-1"
+		"OnRandom01" "car_alarm_fake05ForceSpawn0-1"
+	}
+}
+; --- Move the regular car to another spot
+{
+	match:
+	{
+		"targetname" "car31"
+	}
+	replace:
+	{
+		"origin" "9943 1048 130"
+		"angles" "0 336.5 0"
+	}
+}
+{
+	match:
+	{
+		"targetname" "car31_glass"
+	}
+	replace:
+	{
+		"origin" "9943 1048 130"
+		"angles" "0 336.5 0"
+	}
+}

--- a/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
+++ b/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
@@ -1321,68 +1321,19 @@ add:
 	"origin" "-2924 -6274 -127"
 	"targetname" "hedge_lighting"
 }
-; --- Open tent by the end saferoom with concert equipment inside
+; --- Tent after the stairs by the end saferoom
 {
 	"classname" "prop_dynamic"
-	"origin" "-3396 -5986 -64"
+	"origin" "-3393 -6050 -64"
 	"angles" "0 0 0"
-	"model" "models/props_misc/fairground_tent_open.mdl"
+	"model" "models/props_misc/fairground_tent_closed.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"rendercolor" "201 162 80"
+	"rendercolor" "83 152 189"
 }
-{
-	"classname" "prop_dynamic"
-	"origin" "-3442 -5958 -64"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/anvil_case_64.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-3442 -5942 -32"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/anvil_case_32.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-3442 -5942 0"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/anvil_case_32.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-3442 -5974 -32"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/anvil_case_32.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-3350 -6014 -64"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/anvil_case_64.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-3349 -6014 -35"
-	"angles" "0 0 0"
-	"model" "models/props_fairgrounds/amp_stack.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Clipping on top of tent
 {
 	"classname" "env_physics_blocker"
-	"origin" "-3396 -5986 421"
+	"origin" "-3393 -6050 421"
 	"mins" "-64 -64 -347.5"
 	"maxs" "64 64 347.5"
 	"initialstate" "1"

--- a/cfg/stripper/zonemod/maps/c6m1_riverbank.cfg
+++ b/cfg/stripper/zonemod/maps/c6m1_riverbank.cfg
@@ -35,6 +35,18 @@ add:
 	"spawnflags" "3"
 	"count" "5"
 }
+; --- Make the weapons in the covenience store spawn
+modify:
+{
+	match:
+	{
+		"hammerid" "508847"
+	}
+	insert:
+	{
+		"OnVersus" "ptemplate_tier1_weapons_1,ForceSpawn,,0,-1"
+	}
+}
 ; --- Allow weapon spawns in the apartments to spawn in versus
 filter:
 {
@@ -216,7 +228,7 @@ add:
 	"disableshadows" "1"
 }
 ; --- Car park
-; --- Remaining hittables: caralarm_4-caralarm_car1, car_physics-InstanceAuto48, car_physics-InstanceAuto92
+; --- Remaining hittables: caralarm_4-caralarm_car1
 filter:
 {
 	"targetname" "car_physics-InstanceAuto41"
@@ -242,20 +254,32 @@ filter:
 {
 	"parentname" "car_physics-InstanceAuto51"
 }
+{
+	"targetname" "car_physics-InstanceAuto92"
+}
+{
+	"parentname" "car_physics-InstanceAuto92"
+}
+{
+	"targetname" "car_physics-InstanceAuto48"
+}
+{
+	"parentname" "car_physics-InstanceAuto48"
+}
 add:
 ; --- car_physics-InstanceAuto41
 {
 	"classname" "prop_dynamic"
-	"origin" "3807 3050 30"
-	"angles" "0 156 0"
+	"origin" "3833 3006 31"
+	"angles" "-1.67622 166.969 -2.66401"
 	"model" "models/props_vehicles/cara_69sedan.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "3807 3050 30"
-	"angles" "0 156 0"
+	"origin" "3833 3006 31"
+	"angles" "-1.67622 166.969 -2.66401"
 	"model" "models/props_vehicles/cara_69sedan_glass.mdl"
 	"solid" "6"
 	"disableshadows" "1"
@@ -312,7 +336,6 @@ add:
 	"disableshadows" "1"
 }
 ; --- Bar exit
-; --- Remaining hittables: InstanceAuto24-caralarm_car1
 filter:
 {
 	"targetname" "caralarm_2-caralarm_car1"
@@ -337,6 +360,12 @@ filter:
 }
 {
 	"parentname" "InstanceAuto2-caralarm_car1"
+}
+{
+	"targetname" "InstanceAuto24-caralarm_car1"
+}
+{
+	"parentname" "InstanceAuto24-caralarm_car1"
 }
 add:
 ; --- caralarm_2-caralarm_car1
@@ -507,9 +536,8 @@ add:
 	"disableshadows" "1"
 }
 ; --- Upper alley
-; --- Remaining hittables: InstanceAuto44-caralarm_car1, caralarm_1-caralarm_car1
+; --- Remaining hittables: caralarm_1-caralarm_car1
 filter:
-; --- Removing but not replacing caralarm_3-caralarm_car1 due to weird placement and perma-stuck potential
 {
 	"targetname" "caralarm_3-caralarm_car1"
 }
@@ -521,6 +549,12 @@ filter:
 }
 {
 	"parentname" "caralarm_7-caralarm_car1"
+}
+{
+	"targetname" "InstanceAuto44-caralarm_car1"
+}
+{
+	"parentname" "InstanceAuto44-caralarm_car1"
 }
 add:
 ; --- caralarm_7-caralarm_car1
@@ -536,6 +570,23 @@ add:
 	"classname" "prop_dynamic"
 	"origin" "1438 1207 350"
 	"angles" "-0.499467 180.026 -2.50004"
+	"model" "models/props_vehicles/cara_95sedan_glass.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- InstanceAuto44-caralarm_car1
+{
+	"classname" "prop_dynamic"
+	"origin" "280 1097 348"
+	"angles" "-0.488467 212.879 2.00529"
+	"model" "models/props_vehicles/cara_95sedan.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "280 1097 348"
+	"angles" "-0.488467 212.879 2.00529"
 	"model" "models/props_vehicles/cara_95sedan_glass.mdl"
 	"solid" "6"
 	"disableshadows" "1"
@@ -693,6 +744,14 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+{
+	"classname" "env_physics_blocker"
+	"origin" "2021 1283 273"
+	"mins" "-28 -6 -81"
+	"maxs" "28 6 81"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block survivors from standing on garage doors at the ramp by the apartments
 {
 	"classname" "env_physics_blocker"
@@ -741,26 +800,6 @@ add:
 	"origin" "2224 1608 752"
 	"mins" "-160 -8 -64"
 	"maxs" "160 8 64"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Block survivors from standing on the bus before the park
-{
-	"classname" "env_physics_blocker"
-	"origin" "1057 803 1880"
-	"angles" "0 8 0"
-	"mins" "-239 -56 -1216"
-	"maxs" "239 56 1216"
-	"boxmins" "-239 -56 -1216"
-	"boxmaxs" "239 56 1216"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "1268 889 1862"
-	"mins" "-3 -3 -1234"
-	"maxs" "3 3 1234"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -879,6 +918,16 @@ add:
 ; ==                   STUCK SPOTS                   ==
 ; ==  Prevent players from getting stuck in the map  ==
 ; =====================================================
+add:
+; --- Fix a sliding stuck spot on the bus in the alley
+{
+	"classname" "env_physics_blocker"
+	"origin" "705 1292 314"
+	"mins" "-223 -16 -7"
+	"maxs" "223 16 7"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Prevent players from getting stuck behind the end saferoom
 {
 	"classname" "env_physics_blocker"
@@ -940,6 +989,132 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Clipping on windows and doors in the saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "696 3244 168"
+	"mins" "-8 -28 -48"
+	"maxs" "8 28 48"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "696 3684 168"
+	"mins" "-8 -212 -48"
+	"maxs" "8 212 48"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "690 3376 172"
+	"mins" "-2 -40 -68"
+	"maxs" "2 40 68"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "700 4176 156"
+	"mins" "-4 -24 -52"
+	"maxs" "4 24 52"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Clipping on racecar in the saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "957 3940 135"
+	"angles" "0 0 20"
+	"mins" "-5 -18 -6"
+	"maxs" "5 18 6"
+	"boxmins" "-5 -18 -6"
+	"boxmaxs" "5 18 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "899 3940 135"
+	"angles" "0 0 20"
+	"mins" "-5 -18 -6"
+	"maxs" "5 18 6"
+	"boxmins" "-5 -18 -6"
+	"boxmaxs" "5 18 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "928 3904 144"
+	"angles" "0 0 20"
+	"mins" "-35 -5 -12"
+	"maxs" "35 5 12"
+	"boxmins" "-35 -5 -12"
+	"boxmaxs" "35 5 12"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "884 4083 102"
+	"angles" "0 45 0"
+	"mins" "-3 -4 -15"
+	"maxs" "3 4 15"
+	"boxmins" "-3 -4 -15"
+	"boxmaxs" "3 4 15"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "971 4107 102"
+	"angles" "0 45 0"
+	"mins" "-3 -4 -15"
+	"maxs" "3 4 15"
+	"boxmins" "-3 -4 -15"
+	"boxmaxs" "3 4 15"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "970 4089 102"
+	"mins" "-3 -11 -15"
+	"maxs" "3 11 15"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Stairs on the hedges by the saferoom
+{
+	"classname" "func_brush"
+	"origin" "1260 3262 21"
+	"angles" "0 180 0"
+	"model" "*145"
+	"StartDisabled" "0"
+	"spawnflags" "2"
+	"Solidity" "2"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1188 3298 97.375"
+	"angles" "-0.000552338 89.9751 358.727"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1195 3262 -7.65"
+	"angles" "45 0 0"
+	"mins" "-76 -32 -72"
+	"maxs" "76 32 72"
+	"boxmins" "-76 -32 -72"
+	"boxmaxs" "76 32 72"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Clipping on store entrances to stop players getting stuck on the steps
 {
 	"classname" "env_physics_blocker"
@@ -964,6 +1139,138 @@ add:
 	"maxs" "65 9 4"
 	"initialstate" "1"
 	"BlockType" "0"
+}
+; --- Fix area portal fade out distance in the shop entrance
+modify:
+{
+	match:
+	{
+		"target" "portalbrush_A14"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A20"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A18"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A16"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A21"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A29"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A15"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+{
+	match:
+	{
+		"target" "portalbrush_A19"
+	}
+	replace:
+	{
+		"FadeStartDist" "700"
+		"FadeDist" "1400"
+	}
+}
+; --- Move filing cabinets away from the door after the stair choke
+modify:
+{
+	match:
+	{
+		"hammerid" "569640"
+	}
+	replace:
+	{
+		"origin" "3650.53 2346.25 201.219"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "569644"
+	}
+	replace:
+	{
+		"origin" "3676 2344 201.219"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "569632"
+	}
+	replace:
+	{
+		"origin" "3653.5 2391.28 201.188"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "569636"
+	}
+	replace:
+	{
+		"origin" "3670.85 2365.75 201.188"
+	}
 }
 ; --- Make plywood in the bar non solid that blocks the door from opening both ways
 modify:
@@ -1015,6 +1322,172 @@ modify:
 ; ==       New props for balance and SI spawns       ==
 ; =====================================================
 add:
+; --- Fences on the wall in the parking lot
+{
+	"classname" "prop_dynamic"
+	"origin" "3715 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "3843 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "3971 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4099 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4227 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4355 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4483 3736 72"
+	"angles" "0 270 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4611 3736 72"
+	"angles" "0 264 0"
+	"model" "models/props_cemetery/cemetery_gate_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4163 3741 126"
+	"mins" "-448 -3 -54"
+	"maxs" "448 3 54"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4675 3735 128"
+	"angles" "0 -5 0"
+	"mins" "-64 -3 -54"
+	"maxs" "64 3 54"
+	"boxmins" "-64 -3 -54"
+	"boxmaxs" "64 3 54"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Fences at the front of the parking lot
+{
+	"classname" "prop_dynamic"
+	"origin" "3722 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence002_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "3722 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence_post002.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4122 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence002_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4122 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence_post002.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4270 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence002_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4270 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence_post002.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4418 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence002_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4418 3100 32"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence_post002.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Van in the parking lot
+{
+	"classname" "prop_dynamic"
+	"origin" "4063 3546 32"
+	"angles" "0 0 0"
+	"model" "models/props_vehicles/van.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4063 3546 32"
+	"angles" "0 0 0"
+	"model" "models/props_vehicles/van_glass.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
 ; --- Van at the ramp by the apartments to help survivors with tank fights there
 {
 	"classname" "prop_dynamic"
@@ -1031,6 +1504,75 @@ add:
 	"model" "models/props_vehicles/van_glass.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+; --- Boxes to get on the bus by the ramp
+{
+	"classname" "prop_dynamic"
+	"origin" "-1067 1172 206"
+	"angles" "0 324 0"
+	"model" "models/props/cs_militia/boxes_garage_lower.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-1043 1186 87"
+	"angles" "0.993572 15.8868 -6.50098"
+	"model" "models/props_wasteland/rockcliff07b.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Boxes to get on the bus before the park
+{
+	"classname" "prop_dynamic"
+	"origin" "970 714 515"
+	"angles" "0 328 0"
+	"model" "models/props/cs_militia/boxes_garage_lower.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1012 700 511"
+	"angles" "0 16 0"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1012 700 512"
+	"angles" "0 14 0"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1013 701 513"
+	"angles" "0 15 0"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1013 702 514"
+	"angles" "0 16 0"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "968 712 581"
+	"angles" "0 28 0"
+	"mins" "-15 -15 -2"
+	"maxs" "15 15 2"
+	"boxmins" "-15 -15 -2"
+	"boxmaxs" "15 15 2"
+	"initialstate" "1"
+	"BlockType" "0"
 }
 ; --- Bus behind tent by the end saferoom
 {
@@ -1260,11 +1802,11 @@ add:
 ; --- Infected ladder to climb over the truck by the bar exit
 {
 	"classname" "func_simpleladder"
-	"origin" "6689.93 6473.32 -50"
-	"angles" "0 201 0"
+	"origin" "6768.93 6434.31 -49"
+	"angles" "0 200 0"
 	"model" "*134"
-	"normal.x" "0.35"
-	"normal.y" "-0.93"
+	"normal.x" "0.34202"
+	"normal.y" "-0.939692"
 	"normal.z" "0.00"
 	"team" "2"
 }
@@ -1338,14 +1880,6 @@ add:
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "1014 1728 512"
-	"angles" "0 270 0"
-	"model" "models/props/cs_militia/boxes_frontroom.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
 	"origin" "1030 2041 512"
 	"angles" "0 0 0"
 	"model" "models/props/de_prodigy/concretebags.mdl"
@@ -1376,105 +1910,4 @@ add:
 	"maxs" "8 19 5"
 	"initialstate" "1"
 	"BlockType" "0"
-}
-; --- Scaffolding
-{
-	"classname" "prop_dynamic"
-	"origin" "886 2134 512"
-	"angles" "0 90 0"
-	"model" "models/props_highway/scaffolding_320_base.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "886 2134 512"
-	"angles" "0 90 0"
-	"model" "models/props_highway/scaffolding_320.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "886 2134 617"
-	"angles" "0 90 0"
-	"model" "models/props_highway/scaffolding_320.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "886 2134 608"
-	"angles" "0 90 0"
-	"model" "models/props_highway/scaffolding_bracing_short.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "646 2038 603"
-	"angles" "0 270 0"
-	"model" "models/props_highway/scaffolding_bracing_medium.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "886 2042 616"
-	"angles" "0 0 0"
-	"model" "models/props_highway/plywood_03.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "763 2074 616"
-	"angles" "0 9 0"
-	"model" "models/props_highway/plywood_03.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "820 2038 718"
-	"angles" "0 270 0"
-	"model" "models/props_highway/plywood_02.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "814 2063 721"
-	"angles" "0 0 0"
-	"model" "models/props_highway/plywood_02.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "660 2038 718"
-	"angles" "0 270 0"
-	"model" "models/props_highway/plywood_02.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Block for survivors
-{
-	"classname" "env_physics_blocker"
-	"origin" "764 2087 728"
-	"mins" "-126 -49 -96"
-	"maxs" "126 49 96"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Infected ladder to climb up scaffolding
-{
-	"classname" "func_simpleladder"
-	"origin" "-254 1237 -74"
-	"angles" "0 90 0"
-	"model" "*132"
-	"normal.x" "1.00"
-	"normal.y" "0.00"
-	"normal.z" "0.00"
-	"team" "2"
 }

--- a/cfg/stripper/zonemod/maps/c6m2_bedlam.cfg
+++ b/cfg/stripper/zonemod/maps/c6m2_bedlam.cfg
@@ -197,6 +197,109 @@ add:
 	"spawnflags" "4096"
 	"targetname" "nav_sewer_drop_obscured"
 }
+; --- Force survivors to drop early after the 2nd event gate, and make the button stop the event
+modify:
+{
+	match:
+	{
+		"targetname" "button_bridge"
+	}
+	insert:
+	{
+		"OnPressed" "director,EndScript,,0,-1"
+	}
+}
+add:
+{
+	"classname" "prop_dynamic"
+	"origin" "6143 5448 -988"
+	"angles" "0 0 0"
+	"model" "models/props_wasteland/exterior_fence002b.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "6132 5494 -912"
+	"angles" "0 270 180"
+	"model" "models/props_downtown/balcony_post_base04_154.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "6132 5402 -912"
+	"angles" "0 270 180"
+	"model" "models/props_downtown/balcony_post_base04_154.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendermode" "10"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "6132 5448 -992"
+	"mins" "-3 -56 -72"
+	"maxs" "3 56 72"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "navblocker_gate_drop,BlockNav,,1,-1"
+}
+{
+	"classname" "script_nav_blocker"
+	"origin" "6128 5448 -1054"
+	"extent" "24 38 12"
+	"targetname" "navblocker_gate_drop"
+	"teamToBlock" "3"
+	"affectsFlow" "0"
+}
+{
+	"origin" "5243.06 5452.03 -928"
+	"targetname" "gate_2_alarm_2"
+	"spawnflags" "48"
+	"radius" "1250"
+	"pitchstart" "100"
+	"pitch" "100"
+	"message" "Churchbell.End"
+	"health" "10"
+	"classname" "ambient_generic"
+	"preset" "15"
+}
+modify:
+{
+	match:
+	{
+		"targetname" "gate_2_alarm"
+	}
+	insert:
+	{
+		"preset" "3"
+	}
+	replace:
+	{
+		"spawnflags" "48"
+	}
+}
+{
+	match:
+	{
+		"targetname" "relay_second_gate"
+	}
+	delete:
+	{
+		"OnTrigger" "gate_spot_2LightOn0-1"
+		"OnTrigger" "gate_2_lightSkin10-1"
+		"_OnTrigger" "gate_2_lightSkin015-1"
+		"_OnTrigger" "gate_spot_2LightOff15-1"
+	}
+	insert:
+	{
+		"OnTrigger" "gate_2_alarm_2,PlaySound,,3.5,-1"
+	}
+}
 ; --- Stop the event once survivors reach the stairs by the saferoom
 add:
 {
@@ -301,6 +404,16 @@ add:
 {
 	"classname" "weapon_ammo_spawn"
 	"origin" "1183 568 18"
+	"angles" "0 90 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+; --- Ammo pile by the cement truck
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "142 1329 -64"
 	"angles" "0 90 0"
 	"model" "models/props/terror/ammo_stack.mdl"
 	"solid" "6"
@@ -635,11 +748,19 @@ add:
 ; ==       New props for balance and SI spawns       ==
 ; =====================================================
 add:
-; --- Additional upturned pool table in the pool room
+; --- Extra upturned pool tables in the pool room
 {
 	"classname" "prop_dynamic"
 	"origin" "1345 723 8"
 	"angles" "75 155 0"
+	"model" "models/props_downtown/pooltable.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "847 1084 8"
+	"angles" "75 335.5 0"
 	"model" "models/props_downtown/pooltable.mdl"
 	"solid" "6"
 	"disableshadows" "1"
@@ -653,6 +774,32 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
+; --- Bricks to climb into the pool room from the construction site
+{
+	"classname" "prop_dynamic"
+	"origin" "1265 1356 -77"
+	"angles" "4.24909 94.4899 0.00738525"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1242 1301 -72"
+	"angles" "-0.370436 359.396 -4.23301"
+	"model" "models/props/de_nuke/cinderblock_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Fence on the bar roof
+{
+	"classname" "prop_dynamic"
+	"origin" "110 1944 336"
+	"angles" "0 90 0"
+	"model" "models/props_urban/fence001_256.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
 ; --- Prop to spawn behind on unused fire escape
 {
 	"classname" "prop_dynamic"
@@ -661,6 +808,34 @@ add:
 	"model" "models/props_junk/trashcluster01b_corner.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+; --- Van on the street outside the jazz club
+{
+	"classname" "prop_dynamic"
+	"origin" "-94 3944 -162"
+	"angles" "0 263 0"
+	"model" "models/props_vehicles/van.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-94 3944 -162"
+	"angles" "0 263 0"
+	"model" "models/props_vehicles/van_glass.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "losfix_jazzvan1,AddOutput,mins -108 -2 -13,0,-1"
+	"OnMapSpawn" "losfix_jazzvan1,AddOutput,maxs 108 2 13,0,-1"
+	"OnMapSpawn" "losfix_jazzvan1,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "func_brush"
+	"origin" "-94 3942 -155"
+	"targetname" "losfix_jazzvan1"
 }
 ; --- Sign on jazz club awning
 {
@@ -764,6 +939,91 @@ add:
 	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+; --- Pipe groups with ladders in the room where survivors drop into the sewers
+{
+	"classname" "prop_dynamic"
+	"origin" "486 4497 -1136"
+	"angles" "0 270 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "486 4369 -1096"
+	"angles" "0 270 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "446 4497 -1136"
+	"angles" "0 270 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "446 4369 -1096"
+	"angles" "0 270 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "-341 -487 -186"
+	"angles" "0 0 0"
+	"model" "*80"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1022 5776 -1136"
+	"angles" "0 90 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1022 5904 -1096"
+	"angles" "0 90 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1062 5776 -1136"
+	"angles" "0 90 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1062 5904 -1096"
+	"angles" "0 90 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "1848 10760 -186"
+	"angles" "0 180 0"
+	"model" "*80"
+	"normal.x" "0.00"
+	"normal.y" "-1.00"
+	"normal.z" "0.00"
+	"team" "2"
 }
 ; --- Props in the second sewer room, where the first gate is opened
 {
@@ -890,24 +1150,65 @@ add:
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "6454 5225 -1056"
-	"angles" "-90 0 0"
-	"model" "models/props_pipes/pipeset08d_512_001a.mdl"
+	"origin" "6504 5127 -1031"
+	"angles" "-90 270 0"
+	"model" "models/props_pipes/pipeset32d_bend256u_001a.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+	"lightingorigin" "pipe_bend_lighting"
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "6645 5225 -1056"
-	"angles" "-90 0 0"
-	"model" "models/props_pipes/pipeset08d_512_001a.mdl"
+	"origin" "6504 5256 -1222"
+	"angles" "-90 270 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+	"lightingorigin" "pipe_bend_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "6545 5127 -1031"
+	"angles" "-90 270 0"
+	"model" "models/props_pipes/pipeset32d_bend256u_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipe_bend_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "6545 5256 -1222"
+	"angles" "-90 270 0"
+	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipe_bend_lighting"
+}
+{
+	"classname" "info_target"
+	"origin" "6525 5129 -1033"
+	"targetname" "pipe_bend_lighting"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "6525.5 5224 -1000"
+	"mins" "-36.5 -48 -80"
+	"maxs" "36.5 48 80"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "6525.5 5120 -964"
+	"mins" "-36.5 -56 -44"
+	"maxs" "36.5 56 44"
+	"initialstate" "1"
+	"BlockType" "1"
 }
 ; --- Props in the tunnel leading to the saferoom
 {
 	"classname" "prop_dynamic"
-	"origin" "7859 5373 -1136"
+	"origin" "8828 5369 -1136"
 	"angles" "90 0 0"
 	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
 	"solid" "6"
@@ -915,11 +1216,28 @@ add:
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "8828 5500 -1136"
+	"origin" "8828 5504 -1136"
 	"angles" "90 0 0"
 	"model" "models/props_pipes/pipeset32d_128_001a.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+; --- Ramp before the ladder after the tunnel
+{
+	"classname" "prop_dynamic"
+	"origin" "9565 5498 -1197"
+	"angles" "-30 0 0"
+	"model" "models/props_urban/metal_plate001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "9623 5498 -1166"
+	"mins" "-1 -36 -2"
+	"maxs" "1 36 2"
+	"initialstate" "1"
+	"BlockType" "0"
 }
 
 ; =====================================================
@@ -955,8 +1273,8 @@ modify:
 	}
 	insert:
 	{
-		"OnTrigger" "gate_2_alarm,FadeOut,5,3,-1"
-		"OnTrigger" "gate_2_alarm,Volume,5,3,-1"
+		"OnTrigger" "gate_2_alarm,FadeOut,2,2,-1"
+		;"OnTrigger" "gate_2_alarm,Volume,5,3,-1"
 		"OnTrigger" "gate_2_alarm,Kill,,10,-1"
 	}
 }
@@ -1070,6 +1388,25 @@ add:
 	"solid" "0"
 	"disableshadows" "1"
 }
+; --- Ladder to climb on the food cart by the cement mixer
+{
+	"classname" "func_simpleladder"
+	"origin" "286 5466 -280"
+	"angles" "0 180 5"
+	"model" "*92"
+	"normal.x" "0.00"
+	"normal.y" "-0.996194"
+	"normal.z" "0.087155"
+	"team" "0"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-384 1807 -1"
+	"angles" "5 90 0"
+	"model" "models/props/cs_assault/ladderaluminium128.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
 ; --- Infected ladder to get to the unused fire escape next to plank crossing
 {
 	"classname" "func_simpleladder"
@@ -1149,9 +1486,9 @@ add:
 ; --- Infected ladder to climb on food cart outside the jazz club
 {
 	"classname" "func_simpleladder"
-	"origin" "-2628.5 5190 -53"
-	"angles" "0 270 0"
-	"model" "*92"
+	"origin" "-281 1656 3"
+	"angles" "0 0 0"
+	"model" "*37"
 	"normal.x" "1.00"
 	"normal.y" "0.00"
 	"normal.z" "0.00"

--- a/cfg/stripper/zonemod/maps/c7m1_docks.cfg
+++ b/cfg/stripper/zonemod/maps/c7m1_docks.cfg
@@ -74,32 +74,62 @@ add:
 	"SurvivorName" "Ellis"
 	"Order" "1"
 }
-; ------------------------------------------------------------------------------------------
-;  -- Automatically open the 2nd train car door 20 seconds after the first one is touched --
-; ------------------------------------------------------------------------------------------
+; --- Automatically open the 2nd train car door 20 seconds after the tank is spawned
 modify:
 {
 	match:
 	{
-		"hammerid" "188736"
+		"targetname" "versus_tank"
 	}
 	insert:
 	{
-		"OnPressed" "tankdoorout,Open,,20,-1"
-		"OnPressed" "tankdoorout_button,Disable,,20,-1"
-		"OnPressed" "tankdoorout_button,Kill,,20.5,-1"
-		"OnPressed" "directorEnableTankFrustration20-1"
+		"OnTrigger" "tankdoorout,Open,,20,-1"
+		"OnTrigger" "tankdoorout_button,Disable,,20,-1"
+		"OnTrigger" "director,EnableTankFrustration,,20,-1"
+		"OnTrigger" "tankdoorout_button,Kill,,20.5,-1"
 	}
 }
+; --- Remove the fake tank sounds
+filter:
 {
-	match:
-	{
-		"targetname" "minifinale_button_unlocker"
-	}
-	delete:
-	{
-		"OnTrigger" "tank_sound_timerEnable01"
-	}
+	"targetname" "tank_sound_timer"
+}
+{
+	"targetname" "tank_sound_picker"
+}
+{
+	"targetname" "tank_shake"
+}
+{
+	"targetname" "tank_sound1"
+}
+{
+	"targetname" "tank_sound2"
+}
+
+{
+	"targetname" "tank_sound3"
+}
+{
+	"targetname" "tank_sound4"
+}
+{
+	"targetname" "tank_sound5"
+}
+{
+	"targetname" "tank_sound6"
+}
+{
+	"targetname" "tank_sound7"
+}
+{
+	"targetname" "tank_sound8"
+}
+{
+	"targetname" "tank_sound9"
+}
+{
+	"targetname" "tank_sound10"
 }
 
 
@@ -108,6 +138,39 @@ modify:
 ; ==           PILL / ITEM / WEAPON SPAWNS           ==
 ; ==   Remove or change pill, item & weapon spawns   ==
 ; =====================================================
+; --- Remove some useless early pill spawns
+filter:
+{
+	"hammerid" "474406"
+}
+{
+	"hammerid" "3441021"
+}
+{
+	"hammerid" "514755"
+}
+{
+	"hammerid" "84931"
+}
+{
+	"hammerid" "523121"
+}
+; --- Remove some useless late pill spawns
+{
+	"hammerid" "85119"
+}
+{
+	"hammerid" "85123"
+}
+{
+	"hammerid" "680768"
+}
+{
+	"hammerid" "681687"
+}
+{
+	"hammerid" "85180"
+}
 
 ; =====================================================
 ; ==                STATIC AMMO PILES                ==
@@ -192,6 +255,287 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Clipping on the underpass rocks
+{
+	"classname" "env_physics_blocker"
+	"origin" "11092 -229 -98"
+	"mins" "-50 -21 -7"
+	"maxs" "50 21 7"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10959 -181 -68"
+	"mins" "-50 -21 -6"
+	"maxs" "50 21 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10915 -189 -58"
+	"mins" "-13 -10 -4"
+	"maxs" "13 10 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10879 -196 -70"
+	"mins" "-41 -21 -6"
+	"maxs" "41 21 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10828 -274 -109"
+	"mins" "-44 -22 -6"
+	"maxs" "44 22 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10781 -256 -96"
+	"mins" "-11 -16 -6"
+	"maxs" "11 16 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10774 -224 -87"
+	"mins" "-10 -24 -6"
+	"maxs" "10 24 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10784 -189 -73"
+	"mins" "-48 -10 -6"
+	"maxs" "48 10 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10784 -182 -63"
+	"mins" "-40 -10 -4"
+	"maxs" "40 10 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10664 -264 -108"
+	"mins" "-16 -26 -6"
+	"maxs" "16 26 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10648 -287 -112"
+	"mins" "-16 -26 -6"
+	"maxs" "16 26 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10475 -319 -123"
+	"mins" "-69 -7 -6"
+	"maxs" "69 7 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10554 -240 -107"
+	"mins" "-38 -24 -6"
+	"maxs" "38 24 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10420 -212 -94"
+	"mins" "-20 -12 -6"
+	"maxs" "20 12 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10664 -264 -108"
+	"mins" "-16 -26 -6"
+	"maxs" "16 26 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10400 -129 -69"
+	"mins" "-40 -12 -6"
+	"maxs" "40 12 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10365 -109 -62"
+	"mins" "-11 -8 -5"
+	"maxs" "11 8 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10333 -105 -73"
+	"mins" "-37 -17 -6"
+	"maxs" "37 17 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10304 -77 -67"
+	"mins" "-32 -17 -6"
+	"maxs" "32 17 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10276 -105 -82"
+	"mins" "-20 -17 -6"
+	"maxs" "20 17 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10252 -40 -73"
+	"mins" "-20 -32	 -6"
+	"maxs" "20 32 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10249 -28 -67"
+	"mins" "-10 -20 -6"
+	"maxs" "10 20 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10208 -171 -122"
+	"mins" "-16 -35 -6"
+	"maxs" "16 35 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10210 -161 -110"
+	"mins" "-14 -25 -6"
+	"maxs" "14 25 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10179 -116 -90"
+	"mins" "-43 -20 -6"
+	"maxs" "43 20 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "11033 -179 -68"
+	"mins" "-24 -19 -6"
+	"maxs" "24 19 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "11029 -174 -58"
+	"mins" "-20 -14 -4"
+	"maxs" "20 14 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10784 -174 -55"
+	"mins" "-32 -10 -4"
+	"maxs" "32 10 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10784 -166 -47"
+	"mins" "-24 -10 -4"
+	"maxs" "24 10 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10940 -196 -64"
+	"mins" "-20 -12 -6"
+	"maxs" "20 12 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10641 -272 -102"
+	"mins" "-17 -24 -4"
+	"maxs" "17 24 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10552 -234 -95"
+	"mins" "-24 -18 -6"
+	"maxs" "24 18 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10572 -277 -109"
+	"mins" "-20 -13 -4"
+	"maxs" "20 13 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10228 -189 -110"
+	"mins" "-20 -12 -6"
+	"maxs" "20 12 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10214 -159 -98"
+	"mins" "-13 -21 -6"
+	"maxs" "13 21 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Add missing glass to vehicles
 {
 	"classname" "prop_dynamic"
@@ -261,6 +605,17 @@ add:
 ; ==              Add or change ladders              ==
 ; =====================================================
 add:
+; --- Infected ladder to climb over the wall outside the saferoom
+{
+	"classname" "func_simpleladder"
+	"origin" "350 0 -96"
+	"angles" "0 0 0"
+	"model" "*249"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
 ; --- Infected ladder to climb on slanted roof by the burning barricade
 {
 	"classname" "func_simpleladder"
@@ -268,6 +623,44 @@ add:
 	"angles" "0 0 0"
 	"model" "*27"
 	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+; --- Infected ladder to climb on the boat at the back of the tank area
+{
+	"classname" "func_simpleladder"
+	"origin" "8679 9717 -31"
+	"angles" "0 270 0"
+	"model" "*10"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "9114 298 127"
+	"mins" "-16 -3 -6"
+	"maxs" "16 3 6"
+	"initialstate" "1"
+	"BlockType" "3"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "9114 293 136"
+	"mins" "-16 -5 -3"
+	"maxs" "16 5 3"
+	"initialstate" "1"
+	"BlockType" "3"
+}
+; --- Infected ladder on the bricks by the yellow pickup truck
+{
+	"classname" "func_simpleladder"
+	"origin" "0 340 0"
+	"angles" "0 0 0"
+	"model" "*53"
+	"normal.x" "-1.00"
 	"normal.y" "0.00"
 	"normal.z" "0.00"
 	"team" "2"

--- a/cfg/stripper/zonemod/maps/c7m2_barge.cfg
+++ b/cfg/stripper/zonemod/maps/c7m2_barge.cfg
@@ -350,6 +350,17 @@ add:
 	"origin" "7449 1507 83"
 	"targetname" "pond_pipe_lighting"
 }
+; --- Infected ladder on the pipes
+{
+	"classname" "func_simpleladder"
+	"origin" "-360 1206 -156"
+	"angles" "0 0 0"
+	"model" "*236"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
 ; --- Extra pole clusters by the sunken fishing boat
 {
 	"classname" "prop_dynamic"

--- a/cfg/stripper/zonemod/maps/c7m2_barge.cfg
+++ b/cfg/stripper/zonemod/maps/c7m2_barge.cfg
@@ -98,6 +98,31 @@ filter:
 ; ==                 HITTABLE CHANGES                ==
 ; ==           Add/remove/modify hittables           ==
 ; =====================================================
+; --- Make a car in the fueling area unhittable
+filter:
+{
+	"targetname" "car03"
+}
+{
+	"parentname" "car03"
+}
+add:
+{
+	"classname" "prop_dynamic"
+	"origin" "4256 1776 129"
+	"angles" "0 150 0"
+	"model" "models/props_vehicles/cara_84sedan.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4256 1776 129"
+	"angles" "0 150 0"
+	"model" "models/props_vehicles/cara_84sedan_glass.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
 
 
 ; #############  MAP CLIPPING AND ISSUES  #############
@@ -244,6 +269,256 @@ add:
 ; ==                      PROPS                      ==
 ; ==       New props for balance and SI spawns       ==
 ; =====================================================
+add:
+; --- Tree by the first silo
+{
+	"classname" "prop_dynamic"
+	"origin" "7497 215 254"
+	"angles" "0 0 0"
+	"model" "models/props_foliage/urban_tree_giant01_a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Pipes in the water after the saferoom
+{
+	"classname" "prop_dynamic"
+	"origin" "7836 1508 39"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "7516 1508 78"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_512_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "7132 1508 78"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "7804 1494 4"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "7484 1494 43"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_512_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "7100 1494 43"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pond_pipe_lighting"
+}
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "pond_pipe_brush,AddOutput,mins -402 -0.1 -31,0,-1"
+	"OnMapSpawn" "pond_pipe_brush,AddOutput,maxs 402 0.1 31,0,-1"
+	"OnMapSpawn" "pond_pipe_brush,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "func_brush"
+	"origin" "7435 1506 40"
+	"targetname" "pond_pipe_brush"
+}
+{
+	"classname" "info_target"
+	"origin" "7449 1507 83"
+	"targetname" "pond_pipe_lighting"
+}
+; --- Extra pole clusters by the sunken fishing boat
+{
+	"classname" "prop_dynamic"
+	"origin" "186 310 34"
+	"angles" "0 181.5 0"
+	"model" "models/props_docks/dock01_polecluster01d_256.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "180 706 36"
+	"angles" "5.99794 181.508 0.157638"
+	"model" "models/props_docks/dock01_polecluster01d_256.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "142 1562 36"
+	"angles" "0 0 0"
+	"model" "models/props_docks/dock01_polecluster01d_256.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "141 1863 34"
+	"angles" "0 180 0"
+	"model" "models/props_docks/dock01_polecluster01d_256.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Rock by the pole clusters
+{
+	"classname" "prop_dynamic"
+	"origin" "190 354 -93.832"
+	"angles" "0 0 5"
+	"model" "models/lostcoast/props_wasteland/rock_coast01c.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Rock in the open area on the right side by the sunken fishing boat
+{
+	"classname" "prop_dynamic"
+	"origin" "405.28 2155.36 -94.49"
+	"angles" "-4.89735 165.121 -2.83357"
+	"model" "models/lostcoast/props_wasteland/rock_coast01b.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Large rock in the water by the sunken fishing boat
+{
+	"classname" "prop_dynamic"
+	"origin" "780 108 -57"
+	"angles" "0 260 0"
+	"model" "models/props_foliage/rock_coast02f.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "176 337 592"
+	"mins" "-34 -23 -668"
+	"maxs" "34 23 668"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Extra pipes by the sunken fishing boat
+{
+	"classname" "prop_dynamic"
+	"origin" "1556 -304 142.973"
+	"angles" "90 179 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1517.01 -303.319 -44.0267"
+	"angles" "90 179 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1556 -400 142.973"
+	"angles" "90 179 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1517.01 -399.319 -44.0267"
+	"angles" "90 179 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "515 2529 154.97"
+	"angles" "90 269 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipes_right_side_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "514.32 2490.01 -32.03"
+	"angles" "90 269 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipes_right_side_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "611 2529 154.97"
+	"angles" "90 269 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipes_right_side_lighting"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "610.32 2490.01 -32.03"
+	"angles" "90 269 0"
+	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "pipes_right_side_lighting"
+}
+{
+	"classname" "info_target"
+	"origin" "560 2485 81"
+	"targetname" "pipes_right_side_lighting"
+}
+; --- Boat next to the freighter
+{
+	"classname" "prop_dynamic"
+	"origin" "-5892 -1337 156"
+	"angles" "0 100 0"
+	"model" "models/props_vehicles/boat_fishing02_static.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-5764 -1147 116"
+	"angles" "0 275 -180"
+	"model" "models/props_unique/metalladderbarge.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "-9860.73 -1294 -108.62"
+	"angles" "0 180 0"
+	"model" "*30"
+	"normal.x" "0.087152"
+	"normal.y" "-0.996195"
+	"normal.z" "0.00"
+	"team" "0"
+}
 
 ; =====================================================
 ; ==             LADDER / ELEVATOR NERF              ==
@@ -302,6 +577,17 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
+; --- Infected ladder to climb on the hut by the pond
+{
+	"classname" "func_simpleladder"
+	"origin" "5937 -422 -128"
+	"angles" "0 0 0"
+	"model" "*17"
+	"normal.x" "0.00"
+	"normal.y" "1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
 ; --- Infected ladder to climb on the truck on the bridge before the car shop
 {
 	"classname" "func_simpleladder"
@@ -313,7 +599,7 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
-; --- Infected ladder to climb on top of the grounded boat in the open water area
+; --- Infected ladder to climb on top of the sunken boat in the open water area
 {
 	"classname" "func_simpleladder"
 	"origin" "548.83 3927.99 442.87"
@@ -334,6 +620,27 @@ add:
 	"boxmaxs" "28 12 120"
 	"initialstate" "1"
 	"BlockType" "2"
+}
+; --- Infected ladders to climb to climb up the barge by the sunken fishing boat
+{
+	"classname" "func_simpleladder"
+	"origin" "427 -1092 -115"
+	"angles" "0 0 0"
+	"model" "*99"
+	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
+{
+	"classname" "func_simpleladder"
+	"origin" "431 -447 -78"
+	"angles" "0 0 0"
+	"model" "*99"
+	"normal.x" "1.00"
+	"normal.y" "0.00"
+	"normal.z" "0.00"
+	"team" "2"
 }
 ; --- Infected ladders to climb up from inside the barge
 {
@@ -390,6 +697,17 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
+; --- Infected ladder to climb up a building opposite the freighter
+{
+	"classname" "func_simpleladder"
+	"origin" "-8209 -6140 41"
+	"angles" "0 270 0"
+	"model" "*31"
+	"normal.x" "0.00"
+	"normal.y" "-1.00"
+	"normal.z" "0.00"
+	"team" "2"
+}
 ; --- Infected ladder to get on the higher part of a roof by the end saferoom
 {
 	"classname" "func_simpleladder"
@@ -405,6 +723,196 @@ add:
 
 ; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
 ; =====================================================
-; ==                   BLANK HEADER                  ==
-; ==                Blank description                ==
+; ==              SAFEROOM ONE WAY DROP              ==
+; ==          Prevent easy AI tank runbacks          ==
 ; =====================================================
+add:
+; --- Brick pallets for the one way drop
+{
+	"classname" "prop_dynamic"
+	"origin" "10499 512 126"
+	"angles" "0 0 0"
+	"model" "models/props_industrial/kiln_cart.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10499 512 126"
+	"angles" "0 0 0"
+	"model" "models/props_industrial/kiln_cart_bricks.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10369 512 126"
+	"angles" "0 0 0"
+	"model" "models/props_industrial/kiln_cart.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10369 512 126"
+	"angles" "0 0 0"
+	"model" "models/props_industrial/kiln_cart_bricks.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10531.4 590.636 144.23"
+	"angles" "0.170343 -0.0382243 0.166733"
+	"model" "models/props_industrial/brickpallets_break01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10490.3 594.69 144.412"
+	"angles" "0.0510122 -3.30978 359.797"
+	"model" "models/props_industrial/brickpallets_break04.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10448.7 595.972 145.984"
+	"angles" "5.645 7.5328 0.576767"
+	"model" "models/props_industrial/brickpallets_break03.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10407.8 591.315 149.802"
+	"angles" "5.45881 6.65154 0.638458"
+	"model" "models/props_industrial/brickpallets_break02.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "10723 668 129"
+	"angles" "0 150 0"
+	"model" "models/props_equipment/cargo_container01_fixed.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"rendercolor" "106 64 64"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10434 489 169"
+	"mins" "-127 -39 -41"
+	"maxs" "127 39 41"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block jumping to unintended places from the drop props
+; --- Bricks
+{
+	"classname" "env_physics_blocker"
+	"origin" "10305.5 639.5 769"
+	"mins" "-64.5 -64.5 -511"
+	"maxs" "63.7 64.5 511"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10273.5 543 769"
+	"mins" "-32.5 -32 -511"
+	"maxs" "32.5 32 511"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10178 479 769"
+	"mins" "-64 -32 -511"
+	"maxs" "64 32 511"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Windows
+{
+	"classname" "env_physics_blocker"
+	"origin" "10888 760 400"
+	"mins" "-8 -632 -64"
+	"maxs" "8 632 64"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Truck
+{
+	"classname" "env_physics_blocker"
+	"origin" "10684 978 776"
+	"mins" "-8 -42 -504"
+	"maxs" "8 42 504"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10654 972 776"
+	"mins" "-22 -52 -504"
+	"maxs" "22 52 504"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10610 982 776"
+	"mins" "-22 -54 -504"
+	"maxs" "22 54 504"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "10579 975 776"
+	"mins" "-9 -37 -504"
+	"maxs" "9 37 504"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Remove the alarm car
+modify:
+{
+	match:
+	{
+		"targetname" "car_alarm_spawner_versus"
+	}
+	delete:
+	{
+		"OnRandom01" "car_alarm_01ForceSpawn0-1"
+		"OnRandom01" "car_alarm_fake02ForceSpawn0-1"
+		"OnRandom01" "car_alarm_fake03ForceSpawn0-1"
+		"OnRandom01" "car_alarm_fake04ForceSpawn0-1"
+		"OnRandom01" "car_alarm_fake05ForceSpawn0-1"
+	}
+}
+; --- Move the regular car to another spot
+{
+	match:
+	{
+		"targetname" "car31"
+	}
+	replace:
+	{
+		"origin" "9943 1048 130"
+		"angles" "0 336.5 0"
+	}
+}
+{
+	match:
+	{
+		"targetname" "car31_glass"
+	}
+	replace:
+	{
+		"origin" "9943 1048 130"
+		"angles" "0 336.5 0"
+	}
+}

--- a/scripts/vscripts/c6m2_minifinale_rework.nut
+++ b/scripts/vscripts/c6m2_minifinale_rework.nut
@@ -32,7 +32,7 @@ DirectorOptions <-
 	//-----------------------------------------------------
 	PreferredMobDirection = SPAWN_IN_FRONT_OF_SURVIVORS // 7
 
-	ZombieSpawnRange = 2000  // 3000
+	ZombieSpawnRange = 3000
 
 }
 


### PR DESCRIPTION
## Dark Carnival
### Map 2
Replaced open tent by the end saferoom with a regular tent

## The Passing
### Map 1
Blocked tank spawns between 58% - 70% (late alley spawns)
Added stairs to the hedges exiting the saferoom
Added clipping to the windows and doors in the saferoom
Added clipping to the racecar in the saferoom
Fixed area portal fade out distance in the shop entrance
Added fences around the parking lot
Removed 2 hittable cars from the parking lot
Added a van to the parking lot
Allowed the guns in the convenience store spawn
Fixed buggy ladder on truck after the bar
Moved filing cabinets that partially block a doorway after the stairs
Removed a hittable car after the bar, before the alley
Blocked a spot where survivors could climb up the wall in the alley
Fixed a sliding stuck spot on the bus in the alley
Disabled the alarm car on the ramp and made it unhittable
Added boxes to climb on the bus by the ramp
Added boxes to climb on the bus after the apartments
Removed some props from the dark room after the apartments

### Map 2
Blocked tank spawns between 56% - 66% (sewer drop spawns)
Extended event tank ban range to 72% - 100% (was 74% - 100%)
Added brick pile to jump into the pool room from the construction site
Added an extra pool table to the pool room
Added a fence on the bar roof
Added a ladder to climb on the food cart by the cement truck
Added an ammo pile by the cement truck
Added a van on the street outside the jazz club
Fixed a ladder that goes through the floor by the jazz club
Added 2 groups of pipes in the room where survivors drop into the sewers
Opening the second gate now stops the event
Survivors now have to drop down before the end of the walkway after opening the second gate
Replaced some small pipe props with larger pipes before the tunnel
Adjusted pipes in the tunnel
Added a ramp before the ladder after the tunnel
Reverted event horde max spawn range to default (was 2000, now 3000)

## The Sacrifice
### Map 1
Added an extra infected ladder on the wall next to the shipping container by the saferoom
Added clipping to the underpass rocks
Added an infected ladder to climb on a boat at the back of the tank fight area
Added an extra infected ladder on the bricks by the yellow pickup truck
Removed some useless pill spawns at the beginning and end of the map

### Map 2
Extended event tank ban range to 70% - 80% (was 72% - 80%)
Added a one way drop outside the saferoom
Moved the hittable car that was near the broken shipping container to outside the saferoom
Added a tree on the platform by the first silo
Added pipes in the water after the saferoom
Added an infected ladder to climb on the hut by the water after the saferoom
Made a car in the fueling area unhittable
Added various props to the sunken fishing boat area
Added 2 infected ladders to the barge by the sunken fishing boat
Added a boat next to the freighter
Added an infected ladder to climb up a building opposite the freighter