### PR TITLE
Fix `l4d_fix_shove_duration` crashing on windows

### DIFF
--- a/addons/sourcemod/gamedata/l4d_fix_shove_duration.txt
+++ b/addons/sourcemod/gamedata/l4d_fix_shove_duration.txt
@@ -66,7 +66,14 @@
 			"CTerrorPlayer::OnShovedByLunge"
 			{
 				"signature"		"CTerrorPlayer::OnShovedByLunge"
-				"callconv"		"cdecl"
+				"linux"
+				{
+					"callconv"		"cdecl"
+				}
+				"windows"
+				{
+					"callconv"		"stdcall"
+				}
 				"return"		"int"
 				"this"			"ignore"
 				"arguments"


### PR DESCRIPTION
Fix #669 