### PR TITLE
Block cwm3_drain exploits

### DIFF
--- a/cfg/stripper/zonemod/maps/cwm3_drain.cfg
+++ b/cfg/stripper/zonemod/maps/cwm3_drain.cfg
@@ -43,7 +43,31 @@ add:
 }
 
 
-; --- RBTV Fixes
+; --- Block survivors getting to an unreachable platform in the sewers
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1160 -2240 -312"
+	"mins" "-248 -1 -184"
+	"maxs" "248 1 184"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1344 -1860 -256"
+	"mins" "-32 -628 -128"
+	"maxs" "32 628 128"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1290 -1710 -256"
+	"mins" "-22 -41 -128"
+	"maxs" "22 41 128"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block jumping out of bounds on dirt platforms in sewers
 {
 	"classname" "env_physics_blocker"
@@ -81,7 +105,6 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-
 ; --- Block various skips / props around the bridge event
 ; --- Pipes
 {
@@ -168,7 +191,15 @@ add:
 	"spawnflags" "1"
 	"OnTrigger" "caralarm_car1,SurvivorStandingOnCar,,0,-1"
 }
-
+; --- Block jumping on swing set to skip the alarm car
+{
+	"classname" "env_physics_blocker"
+	"origin" "2192 -575 888"
+	"mins" "-29 -77 -520"
+	"maxs" "29 77 520"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 
 
 ; #############  LADDER CHANGES AND FIXES  ############


### PR DESCRIPTION
Carried Off 3 Fixes
Blocked survivors getting to an unreachable platform in the sewers
Blocked survivors jumping on the swing set to skip the alarm car