### PR TITLE
SourceMod 12 fix translation

### DIFF
--- a/addons/sourcemod/translations/annoyance_exploit_fixes.phrases.txt
+++ b/addons/sourcemod/translations/annoyance_exploit_fixes.phrases.txt
@@ -7,6 +7,5 @@
 	"TryAgain"
 	{
 		"en"		"A vote can't be called right now, try again in %is!"
-		"es"		"No se puede solicitar una votación en este momento, ¡inténtalo de nuevo en %is!"
 	}
 }

--- a/addons/sourcemod/translations/es/1v1.phrases.txt
+++ b/addons/sourcemod/translations/es/1v1.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+	"Tag"
+	{
+		"es"		"[{olive}1v1{default}]"
+	}
 	"HealthRemaining"
 	{
 		"#format"   "{1:s},{2:s},{3:d}" // 1:sName 2:L4D2_InfectedNames[iZclass] 3:iRemainingHealth

--- a/addons/sourcemod/translations/es/1v1_skeetstats.phrases.txt
+++ b/addons/sourcemod/translations/es/1v1_skeetstats.phrases.txt
@@ -16,7 +16,7 @@
 	"SI_DMG_CI"
 	{
         "#format"   "{1:d},{2:d},{3:d}" // 1:iDidDamageAll[iClientPlaying] 2:iGotKills[iClientPlaying] 3:iGotCommon[iClientPlaying]
-		"es"		"{olive}{1}{default} daño | {olive}{1}{default} muertes | {olive}{1}{default} comunes\n"
+		"es"		"{olive}{1}{default} daño | {olive}{2}{default} muertes | {olive}{3}{default} comunes\n"
 	}
 	"SI_DMG"
 	{

--- a/addons/sourcemod/translations/es/8ball.phrases.txt
+++ b/addons/sourcemod/translations/es/8ball.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+	"Tag"
+	{
+		"es"		"{default}[{green}8Ball{default}]"
+	}
 	"Usage"
 	{
 		"es"		"Uso: !8ball <pregunta>"

--- a/addons/sourcemod/translations/es/annoyance_exploit_fixes.phrases.txt
+++ b/addons/sourcemod/translations/es/annoyance_exploit_fixes.phrases.txt
@@ -1,0 +1,11 @@
+"Phrases"
+{
+	"Tag"
+	{
+		"es"		"[SM]"
+	}
+	"TryAgain"
+	{
+		"es"		"No se puede solicitar una votación en este momento, ¡inténtalo de nuevo en %is!"
+	}
+}

--- a/addons/sourcemod/translations/es/blocktrolls.phrases.txt
+++ b/addons/sourcemod/translations/es/blocktrolls.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+	"Tag"
+	{
+		"es"    "[{green}!{default}]"
+	}
 	"VotingNotEnabled"
 	{
 		"es"	"La votación no está habilitada hasta los {olive}40s{default} segundos en la ronda."

--- a/addons/sourcemod/translations/es/checkpoint-rage-control.phrases.txt
+++ b/addons/sourcemod/translations/es/checkpoint-rage-control.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+	"Tag"
+	{
+		"es"    "[{green}!{default}]"
+	}
 	"LoseFrustration"
 	{
         "es"	"El {red}Tank{default} {green}aún perderá{default} la frustración mientras los sobrevivientes estén en la {olive}habitación segura{default}."

--- a/addons/sourcemod/translations/es/l4d2_skill_detect.phrases.txt
+++ b/addons/sourcemod/translations/es/l4d2_skill_detect.phrases.txt
@@ -1,14 +1,30 @@
 "Phrases"
 {
+	"Tag+"
+	{
+		"es"	"{green}★{default}"
+	}
+	"Tag++"
+	{
+		"es"	"{green}★★{default}"
+	}
+	"Tag+++"
+	{
+		"es"	"{green}★★★{default}"
+	}
+	"Tag++++"
+	{
+		"es"	"{green}★★★★{default}"
+	}
 	// boomer pop
 	"Popped"
 	{
         "#format"   "{1:N},{2:N}" // 1:attacker 2:victim
-		"es"		"{olive}{2}{default} fue {blue}popped{default} por {olive}{1}{default}."
+		"es"		"{olive}{2}{default} fue {blue}pop{default} por {olive}{1}{default}."
 	}
 	"PoppedBot"
 	{
-		"es"		"Un boomer fue {blue}popped{default} por {olive}%N{default}."
+		"es"		"Un boomer fue {blue}pop{default} por {olive}%N{default}."
 	}
     // charger level
 	"Leveled"
@@ -86,26 +102,26 @@
 	"HurtSkeet"
 	{
         "#format"   "{1:N},{2:i},{3:s}" // 1:victim 2:damage 3:(bOverKill) ? buffer : ""
-		"es"		"{olive}{1}{default} {green}no{default} murio por skeet ({blue}{2}{default} daño).{3}"
+		"es"		"{olive}{1}{default} fue {green}chip-skeet{default} ({blue}{2}{default} daño).{3}"
 	}
 	"HurtSkeetBot"
 	{
         "#format"   "{1:i},{2:s}" // 1:damage 2:(bOverKill) ? buffer : ""
-		"es"		"{olive}Hunter{default} {green}not{default} murio por skeet ({blue}{1}{default} daño).{2}"
+		"es"		"{olive}Hunter{default} fue {green}chip-skeet{default} ({blue}{1}{default} daño).{2}"
 	}
 	"Unchipped"
 	{
-		"es"		"(Hubiera sido skeet, si no estuviera herido)"
+		"es"		""
 	}
     // crown
 	"CrownedWitch"
 	{
         "#format"   "{1:N},{2:i}" // 1:attacker 2:damage
-		"es"		"{olive}{1}{default} realizo un crowned a la witch ({blue}{2}{default} damage)."
+		"es"		"{olive}{1}{default} realizo un crown a la witch ({blue}{2}{default} damage)."
 	}
 	"CrownedWitch2"
 	{
-		"es"		"La witch fue {blue}crowned{default}."
+		"es"		"La witch fue {blue}crown{default}."
 	}
     // drawcrown
 	"DrawCrowned"

--- a/addons/sourcemod/translations/es/l4d2_stats.phrases.txt
+++ b/addons/sourcemod/translations/es/l4d2_stats.phrases.txt
@@ -1,5 +1,17 @@
 "Phrases"
 {
+	"Tag+"
+	{
+		"es"	"{green}★{default}"
+	}
+	"Tag++"
+	{
+		"es"    "{green}★★{default}"
+	}
+	"Tag+++"
+	{
+		"es"	"{green}★★★{default}"
+	}
 	"MeleeSkeeted"
 	{
         "#format"   "{1:N},{2:N}" // 1:victim 2:attacker

--- a/addons/sourcemod/translations/es/l4d2_tank_announce.phrases.txt
+++ b/addons/sourcemod/translations/es/l4d2_tank_announce.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+	"Tag"
+	{
+		"es"	"{red}[{default}!{red}]"
+	}
 	"Spawned"
 	{
     	"es"	"¡Se ha generado un {olive}Tank {default}({red}Control: %s{default})!"

--- a/addons/sourcemod/translations/es/l4d_boss_percent.phrases.txt
+++ b/addons/sourcemod/translations/es/l4d_boss_percent.phrases.txt
@@ -1,5 +1,13 @@
 "Phrases"
 {
+	"TagTank"
+	{
+		"es"	"<{olive}Tank{default}>"
+	}
+	"TagWitch"
+	{
+		"es"	"<{olive}Witch{default}>"
+	}
 	"TankOn"
 	{
 		"es"	"Tank: %d%%"

--- a/addons/sourcemod/translations/es/l4d_boss_vote.phrases.txt
+++ b/addons/sourcemod/translations/es/l4d_boss_vote.phrases.txt
@@ -1,6 +1,10 @@
 "Phrases"
 // RunVoteChecks
 {
+    "Tag"
+    {
+        "es"        "{blue}<{green}BossVote{blue}>{default}"
+    }
     "NotAvailable"
     {
         "es"        "Boss Vote no está disponible en este mapa."

--- a/addons/sourcemod/translations/es/nodeathcamskip.phrases.txt
+++ b/addons/sourcemod/translations/es/nodeathcamskip.phrases.txt
@@ -1,0 +1,8 @@
+"Phrases"
+{
+	"WarnExploiting"
+	{
+		"#format"	"{1:N}"
+		"es"		"{red}[{default}Explotar{red}] {olive}{1} {default}intentó saltarse el temporizador de muerte."
+	}
+}

--- a/addons/sourcemod/translations/es/pause.phrases.txt
+++ b/addons/sourcemod/translations/es/pause.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+	"Tag"
+	{
+		"es"	"{default}[{green}!{default}]"
+	}
 	"ClientFullyLoaded"
 	{
 		"es"	"{olive}%N {default}ha cargado totalmente"

--- a/addons/sourcemod/translations/es/playermanagement.phrases.txt
+++ b/addons/sourcemod/translations/es/playermanagement.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+    "Tag"
+    {
+        "es"    "[{olive}!{default}]"
+    }
     "Usage"
     {
         "es"    "{blue}Uso{default}"

--- a/addons/sourcemod/translations/es/slots_vote.phrases.txt
+++ b/addons/sourcemod/translations/es/slots_vote.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+	"Tag"
+	{
+		"es"    	"{blue}[{default}Slots{blue}]{default}"
+	}
 	"NotConsoleVote"
 	{
 		"es"		"[Slots] Debes estar dentro del juego."

--- a/addons/sourcemod/translations/es/spechud.phrases.txt
+++ b/addons/sourcemod/translations/es/spechud.phrases.txt
@@ -1,0 +1,34 @@
+"Phrases"
+{
+	"on"
+	{
+		"es"		"{blue}on{default}"
+	}
+	
+	"off"
+	{
+		"es"		"{red}off{default}"
+	}
+	
+	"Notify_SpechudState"
+	{
+		"#format"	"{1:t}"
+		"es"		"<{olive}HUD{default}> El HUD de espectador ahora está {1}"
+	}
+	
+	"Notify_TankhudState"
+	{
+		"#format"	"{1:t}"
+		"es"		"<{olive}HUD{default}> El HUD de tanque ahora está {1}"
+	}
+	
+	"Notify_SpechudUsage"
+	{
+		"es"		"<{olive}HUD{default}> Escribe {green}!spechud{default} en el chat para cambiar el {blue}HUD de espectador"
+	}
+	
+	"Notify_TankhudUsage"
+	{
+		"es"		"<{olive}HUD{default}> Escribe {green}!tankhud{default} en el chat para cambiar el {red}HUD de tanque"
+	}
+}

--- a/addons/sourcemod/translations/es/tank_rush.phrases.txt
+++ b/addons/sourcemod/translations/es/tank_rush.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+	"Tag"
+	{
+		"es"		"{red}[{default}NoTankRush{red}]"
+	}
 	"freeze"
 	{
 		"es"		"{red}El Tank {default}ha aparecido. ¡{olive}Congelando {default}el puntaje!"

--- a/addons/sourcemod/translations/es/tpsblock.phrases.txt
+++ b/addons/sourcemod/translations/es/tpsblock.phrases.txt
@@ -1,5 +1,9 @@
 "Phrases"
 {
+	"Tag"
+	{
+		"es"		"[{green}!{default}]"
+	}
 	"Cvar_Invalid"
 	{
 		"es"		"El comando {olive}c_thirdpersonshoulder{default} es inválido o esta protegido."


### PR DESCRIPTION
SourceMod 12 generates an error if a translation does not exist in an optional language. Normally, some translations like "Tag" were only created in the default language, omitting their translation into other languages, which is now considered an error.

+ 1v1_skeetstats: fixed translation error
+ annoyance_exploit_fixes: modified and separated the Spanish translation
+ nodeathcamskip: created the Spanish translation
+ spechud.phrases: created the Spanish translation
+ l4d2_skill_detect.phrases: modified some translation lines to synthesize the message idea.