### PR TITLE
fix a spot (svv cant revive) in c10m2 event

### DIFF
--- a/cfg/stripper/zonemod/maps/c10m2_drainage.cfg
+++ b/cfg/stripper/zonemod/maps/c10m2_drainage.cfg
@@ -112,6 +112,18 @@ add:
 ; ==  Block players getting outside / under the map  ==
 ; =====================================================
 
+add:
+; --- Block pillar top of the bridge
+{
+	"classname" "env_physics_blocker"
+ 	"targetname" "EB_bridge_svv_fix01a"
+  	"origin" "-8128 -8520 -208"
+	"maxs" "14 8 80"
+	"mins" "-8 -4 -80"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+
 ; =====================================================
 ; ==                   STUCK SPOTS                   ==
 ; ==  Prevent players from getting stuck in the map  ==


### PR DESCRIPTION
Block pillar top of the bridge

![_M}TR_PH9B2TO_0{J%3I73K](https://github.com/SirPlease/L4D2-Competitive-Rework/assets/48006618/d134a944-0a66-4498-918b-5218989193b3)
