### PR TITLE
[map fix : c4m3] adjust postion of elevt trigger area

### DIFF
--- a/cfg/stripper/zonemod/maps/c4m3_sugarmill_b.cfg
+++ b/cfg/stripper/zonemod/maps/c4m3_sugarmill_b.cfg
@@ -19,6 +19,19 @@ filter:
 	"targetname" "spawn_witch_vskeep"
 }
 
+; adjust postion of trigger area ,avoid svv from being locked out of the elevator the moment it closes
+; 调整检测区域，降低卡出电梯的几率
+modify:
+{
+	match:
+	{
+		"targetname" "trigger_elevator"
+	}
+	replace:
+	{
+		"origin" "-1484 -9546 196"
+	}
+}
 
 ; ################  ITEM SPAWN CHANGES  ###############
 ; =====================================================


### PR DESCRIPTION
avoid svv from being locked out of the elevator the moment it closes,
![c4m3_elev1](https://github.com/user-attachments/assets/06614ed7-bd66-4c92-9c24-c43d1288f736)
![c4m3_elev](https://github.com/user-attachments/assets/574da312-aef1-4ae7-96cb-6eae5e586f2c)

In theory, in this way, it is not guaranteed to solve the problem 100%, but it can also greatly reduce the possibility of problems.
In addition, the Svv bots will stand on the edge of the elevator and you will need to "push" them into the elevator (this only happens if you lack 2+ player teammates).