### PR TITLE
Update c8m1_apartment.cfg

### DIFF
--- a/cfg/stripper/zonemod/maps/c6m2_bedlam.cfg
+++ b/cfg/stripper/zonemod/maps/c6m2_bedlam.cfg
@@ -1442,7 +1442,7 @@ add:
 	"origin" "1036 3739 -152"
 	"extent" "140 71 18"
 	"targetname" "barricade_path_navblock1"
-	"teamToBlock" "2"
+	"teamToBlock" "-1"
 	"affectsFlow" "1"
 }
 {
@@ -1450,7 +1450,7 @@ add:
 	"origin" "1055 3816 -152"
 	"extent" "95 24 18"
 	"targetname" "barricade_path_navblock2"
-	"teamToBlock" "2"
+	"teamToBlock" "-1"
 	"affectsFlow" "1"
 }
 {
@@ -1458,7 +1458,7 @@ add:
 	"origin" "868 3688 -152"
 	"extent" "28 24 18"
 	"targetname" "barricade_path_navblock3"
-	"teamToBlock" "2"
+	"teamToBlock" "-1"
 	"affectsFlow" ""
 }
 {
@@ -1466,7 +1466,7 @@ add:
 	"origin" "826 3870 -152"
 	"extent" "24 24 18"
 	"targetname" "barricade_path_navblock4"
-	"teamToBlock" "2"
+	"teamToBlock" "-1"
 	"affectsFlow" "1"
 }
 {
@@ -1474,7 +1474,7 @@ add:
 	"origin" "811 3235 22"
 	"extent" "35 35 18"
 	"targetname" "barricade_path_navblock5"
-	"teamToBlock" "2"
+	"teamToBlock" "-1"
 	"affectsFlow" "1"
 }
 ; --- Plywood on barricades for spawns and ladder visibility

--- a/cfg/stripper/zonemod/maps/c8m1_apartment.cfg
+++ b/cfg/stripper/zonemod/maps/c8m1_apartment.cfg
@@ -1102,7 +1102,7 @@ add:
 	"origin" "2115 3894 20"
 	"extent" "71 10 8"
 	"targetname" "nav_block_street_crash"
-	"teamToBlock" "2"
+	"teamToBlock" "-1"
 	"affectsFlow" "1"
 }
 {
@@ -1110,7 +1110,7 @@ add:
 	"origin" "2743 3774 20"
 	"extent" "71 10 8"
 	"targetname" "nav_block_street_crash"
-	"teamToBlock" "2"
+	"teamToBlock" "-1"
 	"affectsFlow" "1"
 }
 {
@@ -1118,6 +1118,6 @@ add:
 	"origin" "2433 3776 12"
 	"extent" "249 56 8"
 	"targetname" "nav_block_street_crash"
-	"teamToBlock" "2"
+	"teamToBlock" "-1"
 	"affectsFlow" "1"
 }


### PR DESCRIPTION
fixes nav of SI bots not attacking/reaching when survivors are in the opposite side of the new crash area