### PR TITLE
Detour Ahead Fixes

### DIFF
--- a/cfg/stripper/zonemod/maps/cdta_01detour.cfg
+++ b/cfg/stripper/zonemod/maps/cdta_01detour.cfg
@@ -35,6 +35,13 @@ filter:
 {
 	"hammerid" "1372313"
 }
+; --- Remove 2 pill spawns outside the map
+{
+	"hammerid" "633541"
+}
+{
+	"hammerid" "1044030"
+}
 ; --- Spawn both T1 guns at the fire barrel
 modify:
 {
@@ -531,6 +538,17 @@ add:
 	"origin" "4061 2535 756"
 	"mins" "-19 -15 -652"
 	"maxs" "19 15 652"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4029 2542 567"
+	"angles" "0 21.5 0"
+	"mins" "-40 -31.4 -456"
+	"maxs" "40 31.4 456"
+	"boxmins" "-40 -31.4 -456"
+	"boxmaxs" "40 31.4 456"
 	"initialstate" "1"
 	"BlockType" "1"
 }

--- a/cfg/stripper/zonemod/maps/cdta_02road.cfg
+++ b/cfg/stripper/zonemod/maps/cdta_02road.cfg
@@ -81,7 +81,17 @@ modify:
 		"spawnflags" "2"
 	}
 }
-
+; --- Remove pill spawns outside the map
+filter:
+{
+	"hammerid" "2487"
+}
+{
+	"hammerid" "2489"
+}
+{
+	"hammerid" "377648"
+}
 ; =====================================================
 ; ==                STATIC AMMO PILES                ==
 ; ==          Add or modify ammo pile spawns         ==
@@ -324,7 +334,18 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-
+; --- Block a big shortcut before the event
+{
+	"classname" "env_physics_blocker"
+	"origin" "-6337 -3922 596"
+	"angles" "0 41 0"
+	"mins" "-340 -24 -155.5"
+	"maxs" "340 24 155.5"
+	"boxmins" "-340 -24 -155.5"
+	"boxmaxs" "340 24 155.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; =====================================================
 ; ==                  OUT OF BOUNDS                  ==
 ; ==  Block players getting outside / under the map  ==

--- a/cfg/stripper/zonemod/maps/cdta_03warehouse.cfg
+++ b/cfg/stripper/zonemod/maps/cdta_03warehouse.cfg
@@ -185,6 +185,10 @@ filter:
 {
 	"hammerid" "2538612"
 }
+; --- Outside the map
+{
+	"hammerid" "2263664"
+}
 ; --- Add some new pill spawns throughout the map
 add:
 ; --- Alley on the right after warehouse one way drop

--- a/cfg/stripper/zonemod/maps/cdta_04onarail.cfg
+++ b/cfg/stripper/zonemod/maps/cdta_04onarail.cfg
@@ -229,6 +229,10 @@ filter:
 {
 	"hammerid" "1212837"
 }
+; --- Outside the map
+{
+	"hammerid" "193482"
+}
 ; --- Add some new pill spawns throughout the map
 add:
 ; --- Next to shack before event trigger
@@ -416,6 +420,27 @@ add:
 	"maxs" "32 120 56"
 	"boxmins" "-32 -120 -56"
 	"boxmaxs" "32 120 56"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Prevent survivors from getting stuck in bushes by the trailer park exit
+{
+	"classname" "env_physics_blocker"
+	"origin" "-5115 1723 1088"
+	"angles" "0 -18 0"
+	"mins" "-8 -250 -576"
+	"maxs" "8 250 576"
+	"boxmins" "-8 -250 -576"
+	"boxmaxs" "8 250 576"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block a perma-stuck spot between bushes and fences in the trailer park
+{
+	"classname" "env_physics_blocker"
+	"origin" "-5386 3050 719"
+	"mins" "-113.5 -36 -70.5"
+	"maxs" "113.5 36 70.5"
 	"initialstate" "1"
 	"BlockType" "0"
 }
@@ -997,6 +1022,18 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
+; --- Infected ladder to prevent a prema-stuck spot in bushes by the trailer park exit
+{
+    "model" "*93"
+    "normal.z" "0.00"
+    "normal.y" "-0.30"
+    "normal.x" "0.95"
+    "team" "2"
+    "classname" "func_simpleladder"
+    "origin" "-864.29 -2301.46 59.69"
+    "angles" "0.00 -18.00 0.00"
+}
+
 ; --- Infected ladders to get over fences by the trailer park exit
 {
 	"classname" "func_simpleladder"


### PR DESCRIPTION
Map 1
1. Remove 2 pill spawns outside the map
2. Block survivors from getting back to saferoom by standing on the edge of a rock by the one-way-drop
![block rock](https://github.com/user-attachments/assets/ddc05332-c0de-49f3-967c-8826e4bfbf6c)

Map 2
1. Remove pill spawns outside the map
2. Block a big shortcut before the event: https://youtu.be/pDNYct34aaE
![20241026114725_1](https://github.com/user-attachments/assets/8afacce7-1de4-47ab-9b39-7dbcb9db9c04)

Map 3
1. Remove a pill spawn outside the map

Map 4
1. Remove a pill spawn outside the map
2. Block stuck spots, add an infected ladder at a stuck spot
![stuck spots](https://github.com/user-attachments/assets/ed1fd4de-d354-4bde-9d91-5aac5d1e09c0)
