### PR TITLE
Update l4d2_penalty_bonus.inc

### DIFF
--- a/addons/sourcemod/scripting/include/l4d2_penalty_bonus.inc
+++ b/addons/sourcemod/scripting/include/l4d2_penalty_bonus.inc
@@ -42,7 +42,7 @@ native void PBONUS_SetDefibPenalty(penalty);
 
 public SharedPlugin __pl_l4d2_penalty_bonus =
 {
-    name = "l4d2_penalty_bonus",
+    name = "penaltybonus",
     file = "l4d2_penalty_bonus.smx",
 #if defined REQUIRE_PLUGIN
     required = 1,

--- a/addons/sourcemod/scripting/include/l4d2_penalty_bonus.inc
+++ b/addons/sourcemod/scripting/include/l4d2_penalty_bonus.inc
@@ -1,7 +1,12 @@
 /*
-  Includes for Penalty bonus system (l4d2_penalty_bonus)
-  ------------------------------------------------------
+Includes for Penalty bonus system (l4d2_penalty_bonus)
+------------------------------------------------------
 */
+
+#if defined  _l4d2_penalty_bonus_included_
+#endinput
+#endif
+#define _l4d2_penalty_bonus_included_
 
 /**
  *  Called when a round is about to end. 
@@ -12,25 +17,48 @@
  *  @param  int     update              (by reference) the value of the cumulative update PBonus needs to know
  *  @return int     the update value to add to the round's bonus
  */
-forward OnHoldOutBonusSet( &update );
+forward int PBONUS_RequestFinalUpdate( int &update );
 
 
 // Get the bonus for the current round
 //    returns int
-native PBONUS_GetRoundBonus();
+native int PBONUS_GetRoundBonus();
 
 // Resets the bonus for the current round to 0 (does not do a change-report!)
-native PBONUS_ResetRoundBonus();
+native void PBONUS_ResetRoundBonus();
 
 // Set the bonus for the current round
-native PBONUS_SetRoundBonus(bonus);
+native void PBONUS_SetRoundBonus(int bonus);
 
 // Adds points to the bonus for the current round
-native PBONUS_AddRoundBonus(bonus, bool:bNoReport=false);
+native void PBONUS_AddRoundBonus(int bonus, bool bNoReport=false);
 
 // Get the amount of defibs used in the current round
 //    returns int
-native PBONUS_GetDefibsUsed();
+native int PBONUS_GetDefibsUsed();
 
 // Set the (current) defib penalty
-native PBONUS_SetDefibPenalty(penalty);
+native void PBONUS_SetDefibPenalty(penalty);
+
+public SharedPlugin __pl_l4d2_penalty_bonus =
+{
+    name = "l4d2_penalty_bonus",
+    file = "l4d2_penalty_bonus.smx",
+#if defined REQUIRE_PLUGIN
+    required = 1,
+#else
+    required = 0,
+#endif
+};
+
+#if !defined REQUIRE_PLUGIN
+public void __pl_l4d2_penalty_bonus_SetNTVOptional()
+{
+    MarkNativeAsOptional("PBONUS_GetRoundBonus");
+    MarkNativeAsOptional("PBONUS_ResetRoundBonus");
+    MarkNativeAsOptional("PBONUS_SetRoundBonus");
+    MarkNativeAsOptional("PBONUS_AddRoundBonus");
+    MarkNativeAsOptional("PBONUS_GetDefibsUsed");
+    MarkNativeAsOptional("PBONUS_SetDefibPenalty");
+}
+#endif


### PR DESCRIPTION
1. Update latest syntax

2. Fixed wrong forward function name

[l4d2_penalty_bonus.sp](https://github.com/SirPlease/L4D2-Competitive-Rework/blob/master/addons/sourcemod/scripting/l4d2_penalty_bonus.sp#L71-L78)
