### PR TITLE
Update l4d2util.inc

### DIFF
--- a/addons/sourcemod/scripting/include/l4d2util.inc
+++ b/addons/sourcemod/scripting/include/l4d2util.inc
@@ -10,3 +10,13 @@
 #include <l4d2util_survivors>
 #include <l4d2util_tanks>
 #include <l4d2util_weapons>
+
+stock void L4D2_GetTeamName(int team, char[] name, int maxlen)
+{
+	strcopy(name, maxlen, L4D2_TeamName[team]);
+}
+
+stock void L4D2_GetSurvivorModelName(int size, char[] name, int maxlen)
+{
+	strcopy(name, maxlen, g_sSurvivorModels[size]);
+}


### PR DESCRIPTION
Using sm1.12 7165 will throw warning which indicates these two variables `L4D2_TeamName` and `g_sSurvivorModels` is never used if a plugin dose not use these when compiling. This change is simply to avoid this warning.