### PR TITLE
Fix incorrect display of ticks in client

### DIFF
--- a/cfg/server.cfg
+++ b/cfg/server.cfg
@@ -65,6 +65,7 @@ sm_cvar sv_client_min_interp_ratio -1         // Minimum value of cl_interp_rati
 sm_cvar sv_client_max_interp_ratio 0          // Maximum value of cl_interp_ratio.
 sm_cvar nb_update_frequency 0.014             // The lower the value, the more often common infected and witches get updated (Pathing, and state), very CPU Intensive. (0.100 is default)
 sm_cvar net_splitpacket_maxrate 50000         // Networking Tweaks.
+sm_cvar net_maxcleartime 0.0001               // Max ? of seconds we can wait for next packets to be sent based on rate setting. Lower values positively affects hit registration and also reduces choke.
 sm_cvar fps_max 0                             // Forces the maximum amount of FPS the CPU has available for the Server.
 
 // Tickrate Fixes


### PR DESCRIPTION
The standard value of 4 can cause significant issues with choke and incorrect tick display on the client side. If this value is reduced to less than 1 tick but not below 0, choke no longer occurs, and hit registration improves due to more frequent packet transmission from the client to the server and vice versa.