### PR TITLE
[Lerpmonitor] Update

### DIFF
--- a/addons/sourcemod/scripting/include/lerpmonitor.inc
+++ b/addons/sourcemod/scripting/include/lerpmonitor.inc
@@ -1,25 +1,35 @@
-#if defined _lerpmonitor
+#if defined __lerpmonitor_included
 	#endinput
 #endif
-#define _lerpmonitor
+#define __lerpmonitor_included
 
- /**
- * @brief				Get the player's saved lerp value
- * @param	client		Client index
+/**
+ * @brief				Get the player's stored lerp time, if the stored value is not found in the array,
+ * 						then the current lerp time will be returned.
+ * @param client		Client index.
  *
- * @return				-1.0 if the current lerp time has not been saved, otherwise current lerp value
+ * @return				The current lerp, if the value was not stored, otherwise the stored value from the array.
  * @error				If the client is not connected or the index is invalid.
- */
+**/
 native float LM_GetLerpTime(int client);
 
- /**
- * @brief				Get the player's current lerp
- * @param	client		Client index
+/**
+ * @brief				Get the player's current lerp time.
+ * @param client		Client index.
  *
- * @return				Current lerp value
+ * @return				Current lerp time.
  * @error				Invalid client index, or client not connected.
- */
+**/
 native float LM_GetCurrentLerpTime(int client);
+
+/**
+ * @brief				Get the player's lerp time stored in the array.
+ * @param client		Client index.
+ *
+ * @return				Return -1.0 if the lerp time has not been saved, otherwise the stored lerp time.
+ * @error				Invalid client index, or client not connected.
+**/
+native float LM_GetStoredLerpTime(int client);
 
 public SharedPlugin __lerpmonitor =
 {
@@ -37,5 +47,6 @@ public void __pl_lerpmonitor_SetNTVOptional()
 {
 	MarkNativeAsOptional("LM_GetLerpTime");
 	MarkNativeAsOptional("LM_GetCurrentLerpTime");
+	MarkNativeAsOptional("LM_GetStoredLerpTime");
 }
 #endif

--- a/addons/sourcemod/scripting/lerpmonitor.sp
+++ b/addons/sourcemod/scripting/lerpmonitor.sp
@@ -17,6 +17,7 @@ ConVar
 	cVarReadyUpLerpChanges = null,
 	cVarAllowedLerpChanges = null,
 	cVarLerpChangeSpec = null,
+	cVarBadLerpAction = null,
 	cVarMinLerp = null,
 	cVarMaxLerp = null,
 	cVarMinUpdateRate = null,
@@ -36,7 +37,7 @@ public Plugin myinfo =
 	name = "LerpMonitor++",
 	author = "ProdigySim, Die Teetasse, vintik, A1m`",
 	description = "Keep track of players' lerp settings",
-	version = "2.4.1",
+	version = "2.4.2",
 	url = "https://github.com/SirPlease/L4D2-Competitive-Rework"
 };
 
@@ -56,6 +57,7 @@ public void OnPluginStart()
 {
 	cVarAllowedLerpChanges = CreateConVar("sm_allowed_lerp_changes", "4", "Allowed number of lerp changes for a half", _, true, 0.0, true, 20.0);
 	cVarLerpChangeSpec = CreateConVar("sm_lerp_change_spec", "1", "Move to spectators on exceeding lerp changes count?", _, true, 0.0, true, 1.0);
+	cVarBadLerpAction = CreateConVar("sm_bad_lerp_action", "1", "What to do with a player if he is out of allowed lerp range? 1 - move to spectators, 0 - kick from server", _, true, 0.0, true, 1.0);
 	cVarReadyUpLerpChanges = CreateConVar("sm_readyup_lerp_changes", "1", "Allow lerp changes during ready-up", _, true, 0.0, true, 1.0);
 	cVarShowLerpTeamChange = CreateConVar("sm_show_lerp_team_changes", "1", "show a message about the player's lerp if he changes the team", _, true, 0.0, true, 1.0);
 	cVarMinLerp = CreateConVar("sm_min_lerp", "0.000", "Minimum allowed lerp value", _, true, 0.000, true, 0.500);
@@ -259,14 +261,23 @@ void ProcessPlayerLerp(int client, bool load = false, bool team = false)
 			float currentLerpTime = 0.0;
 			if (ArrLerpsValue.GetValue(steamID, currentLerpTime)) {
 				if (currentLerpTime == newLerpTime) { // no change?
-					ChangeClientTeam(client, L4D_TEAM_SPECTATE);
+					if (cVarBadLerpAction.IntValue == 1) {
+						ChangeClientTeam(client, L4D_TEAM_SPECTATE); 
+					} else {
+						KickClient(client, "Illegal lerp value (min: %.01f, max: %.01f)", cVarMinLerp.FloatValue * 1000, cVarMaxLerp.FloatValue * 1000);
+					}
 					return;
 				}
 			}
 
-			CPrintToChatAllEx(client, "{default}<{olive}Lerp{default}> {teamcolor}%N {default}was moved to spectators for lerp {teamcolor}%.01f", client, newLerpTime * 1000);
-			ChangeClientTeam(client, L4D_TEAM_SPECTATE);
-			CPrintToChatEx(client, client, "{default}<{olive}Lerp{default}> Illegal lerp value (min: {teamcolor}%.01f{default}, max: {teamcolor}%.01f{default})", cVarMinLerp.FloatValue * 1000, cVarMaxLerp.FloatValue * 1000);
+			if (cVarBadLerpAction.IntValue == 1) {
+				CPrintToChatAllEx(client, "{default}<{olive}Lerp{default}> {teamcolor}%N {default}was moved to spectators for lerp {teamcolor}%.01f", client, newLerpTime * 1000);
+				CPrintToChatEx(client, client, "{default}<{olive}Lerp{default}> Illegal lerp value (min: {teamcolor}%.01f{default}, max: {teamcolor}%.01f{default})", cVarMinLerp.FloatValue * 1000, cVarMaxLerp.FloatValue * 1000);
+				ChangeClientTeam(client, L4D_TEAM_SPECTATE);
+			} else {
+				CPrintToChatAllEx(client, "{default}<{olive}Lerp{default}> {teamcolor}%N {default}was kicked for lerp {teamcolor}%.01f", client, newLerpTime * 1000);
+				KickClient(client, "Illegal lerp value (min: %.01f, max: %.01f)", cVarMinLerp.FloatValue * 1000, cVarMaxLerp.FloatValue * 1000);
+			}
 		}
 
 		// nothing else to do


### PR DESCRIPTION

1) Removed unnecessary checks in native 'LM_GetLerpTime'. 'GetClientAuthId' - will abort the code on error (If the client is not connected or the index is invalid).
2) Removed unnecessary checks in native 'LM_GetCurrentLerpTime'. 'GetClientInfo' - will abort the code on error (If the client is not connected or the index is invalid).
3) Added native 'LM_GetChachedLerpTime'. Native returns the stored lerp time for the player.
4) Changed native 'LM_GetLerpTime'. Native now returns the player's saved interpolation time, if the interpolation value is not found in the array, then it gets and returns the player's current interpolation time.