### PR TITLE
Let the plugin check workflow loop continue after the first error

### DIFF
--- a/.github/workflows/check_plugins.yml
+++ b/.github/workflows/check_plugins.yml
@@ -47,9 +47,20 @@ jobs:
 
       - name: Compile plugins
         run: |
+          errors=0
           for file in *.sp
           do
             echo -e "\nCompiling $file..."
-            spcomp -E -w234 -w217 -O2 -v2 -i $SCRIPTS_PATH/include $file
+            spcomp -E -w234 -w217 -O2 -v2 -i $SCRIPTS_PATH/include $file || {
+              errors=$((errors + 1))
+              continue
+            }
           done
+          if [ "$errors" -gt 0 ]; then
+            echo -e "\n$errors plugin(s) failed to compile."
+            exit 1
+          else
+            echo -e "\nAll plugins compiled successfully."
+            exit 0
+          fi
         working-directory: ${{ env.SCRIPTS_PATH }}/


### PR DESCRIPTION
Let the script to compile ALL the plugins, count the failed plugin compilations, and depending on the result produce an adequate exit code.

Currently the script stops on the first failed plugin compilation error.
But in case more plugins fail to compile, we don't exactly know which ones failed except the first one.