### PR TITLE
Fix plugin returning a null nav area when based on player origin

### DIFF
--- a/addons/sourcemod/scripting/current.sp
+++ b/addons/sourcemod/scripting/current.sp
@@ -57,8 +57,7 @@ float GetMaxSurvivorCompletion()
 	Address pNavArea;
 	for (int i = 1; i <= MaxClients; i++) {
 		if (IsClientInGame(i) && GetClientTeam(i) == TEAM_SURVIVORS && IsPlayerAlive(i)) {
-			GetClientAbsOrigin(i, origin);
-			pNavArea = L4D2Direct_GetTerrorNavArea(origin);
+			pNavArea = L4D_GetLastKnownArea(i);
 			if (pNavArea != Address_Null) {
 				tmp_flow = L4D2Direct_GetTerrorNavAreaFlow(pNavArea);
 				flow = (flow > tmp_flow) ? flow : tmp_flow;

--- a/addons/sourcemod/scripting/current.sp
+++ b/addons/sourcemod/scripting/current.sp
@@ -53,7 +53,7 @@ float GetBossProximity()
  */
 float GetMaxSurvivorCompletion()
 {
-	float flow = 0.0, tmp_flow = 0.0, origin[3];
+	float flow = 0.0, tmp_flow = 0.0;
 	Address pNavArea;
 	for (int i = 1; i <= MaxClients; i++) {
 		if (IsClientInGame(i) && GetClientTeam(i) == TEAM_SURVIVORS && IsPlayerAlive(i)) {

--- a/addons/sourcemod/scripting/current.sp
+++ b/addons/sourcemod/scripting/current.sp
@@ -14,7 +14,7 @@ public Plugin myinfo =
 	name = "L4D2 Survivor Progress",
 	author = "CanadaRox, Visor",
 	description = "Print survivor progress in flow percents ",
-	version = "2.0.4",
+	version = "2.0.5",
 	url = "https://github.com/SirPlease/L4D2-Competitive-Rework"
 };
 

--- a/addons/sourcemod/scripting/l4d2_tankrage.sp
+++ b/addons/sourcemod/scripting/l4d2_tankrage.sp
@@ -176,8 +176,7 @@ float GetMaxSurvivorCompletion()
     Address pNavArea;
     for (int i = 1; i <= MaxClients; i++) {
         if (IsClientInGame(i) && GetClientTeam(i) == 2 && IsPlayerAlive(i)) {
-            GetClientAbsOrigin(i, origin);
-            pNavArea = L4D2Direct_GetTerrorNavArea(origin);
+            pNavArea = L4D_GetLastKnownArea(i);
             if (pNavArea != Address_Null) {
                 tmp_flow = L4D2Direct_GetTerrorNavAreaFlow(pNavArea);
                 flow = (flow > tmp_flow) ? flow : tmp_flow;

--- a/addons/sourcemod/scripting/l4d2_tankrage.sp
+++ b/addons/sourcemod/scripting/l4d2_tankrage.sp
@@ -23,7 +23,7 @@ public Plugin myinfo =
     name = "L4D2 Tank Rage",
     author = "Sir",
     description = "Manage Tank Rage when Survivors are running back.",
-    version = "1.0.1",
+    version = "1.0.2",
     url = "https://github.com/SirPlease/L4D2-Competitive-Rework"
 };
 

--- a/addons/sourcemod/scripting/l4d2_tankrage.sp
+++ b/addons/sourcemod/scripting/l4d2_tankrage.sp
@@ -172,7 +172,7 @@ int GetBossProximity()
 
 float GetMaxSurvivorCompletion()
 {
-    float flow = 0.0, tmp_flow = 0.0, origin[3];
+    float flow = 0.0, tmp_flow = 0.0;
     Address pNavArea;
     for (int i = 1; i <= MaxClients; i++) {
         if (IsClientInGame(i) && GetClientTeam(i) == 2 && IsPlayerAlive(i)) {


### PR DESCRIPTION
current check sometimes returns a null nav area
example: c1m1_hotel, teleport to the position "300 5683 2893"
the current flow displayed by the plugin outputs "14%" because the "flow" variable is 0, because no nav (pNavArea) was found
using "L4D_GetLastKnownArea" is more accurate since it outputs the same value as the "current_flow_distance" game command