### PR TITLE
[l4d2_static_shotgun_spread] Restore patch `central pellet` on unload plugin

### DIFF
--- a/addons/sourcemod/scripting/l4d2_static_shotgun_spread.sp
+++ b/addons/sourcemod/scripting/l4d2_static_shotgun_spread.sp
@@ -36,7 +36,7 @@ static const int
 	g_iDegreeOffsets[ePlatform_Size] = {
 		0x3f,	// Windows
 		0x43	// Linux
-	}
+	},
 	g_iFactorOffset[ePlatform_Size] = {
 		0x36,	// Windows
 		0x34	// Linux


### PR DESCRIPTION
- Added deletion of the `central pellet` patch when unloading the plugin. This patch is applied in-game, not in the ASM patch. The value is restored after unloading to prevent logic issues with other server settings.
- Added a check for the `central pellet` patch offset.
- Removed unnecessary type conversions and improved readability.
- Minor plugin refactoring.