### PR TITLE
[OnClientPostAdminCheck] Replacing an unreliable forward.

### DIFF
--- a/addons/sourcemod/scripting/archive/double_getup.sp
+++ b/addons/sourcemod/scripting/archive/double_getup.sp
@@ -125,14 +125,14 @@ public void OnPluginStart()
 	if (lateLoad) {
 		for (int i = 1; i <= MaxClients; i++) {
 			if (IsClientInGame(i)) {
-				OnClientPostAdminCheck(i);
+				OnClientPutInServer(i);
 			}
 		}
 	}
 }
 
 // Used to check for tank rocks and tank punches.
-public void OnClientPostAdminCheck(int client)
+public void OnClientPutInServer(int client)
 {
 	SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamage);
 }

--- a/addons/sourcemod/scripting/archive/modules/FinaleSpawn.sp
+++ b/addons/sourcemod/scripting/archive/modules/FinaleSpawn.sp
@@ -41,7 +41,7 @@ public FS_ConVarChange(Handle:convar, const String:oldValue[], const String:newV
 	FS_bEnabled = GetConVarBool(FS_hEnabled);
 }
 
-public OnClientPostAdminCheck(client)
+public OnClientPutInServer(client)
 {
 	SDKHook(client, SDKHook_PreThinkPost, HookCallback);
 }

--- a/addons/sourcemod/scripting/l4d2_ai_damagefix.sp
+++ b/addons/sourcemod/scripting/l4d2_ai_damagefix.sp
@@ -112,7 +112,7 @@ public void OnPluginStart()
     if (bLateLoad) {
         for (int i = 1; i < MaxClients + 1; i++) {
             if (IsClientAndInGame(i)) {
-                OnClientPostAdminCheck(i);
+                OnClientPutInServer(i);
             }
         }
     }
@@ -129,7 +129,7 @@ void OnPounceInterruptChanged(ConVar convar, const char[] oldValue, const char[]
     iPounceInterrupt = StringToInt(newValue);
 }
 
-public void OnClientPostAdminCheck(int client)
+public void OnClientPutInServer(int client)
 {
     // hook bots spawning
     SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamage);

--- a/addons/sourcemod/scripting/l4d2_playstats.sp
+++ b/addons/sourcemod/scripting/l4d2_playstats.sp
@@ -736,7 +736,7 @@ public void OnConfigsExecuted()
 }
 
 // find a player
-public void OnClientPostAdminCheck(int client)
+public void OnClientPutInServer(int client)
 {
 	GetPlayerIndexForClient(client);
 }

--- a/addons/sourcemod/scripting/l4d2_skill_detect.sp
+++ b/addons/sourcemod/scripting/l4d2_skill_detect.sp
@@ -615,7 +615,7 @@ void CvarChange_PounceInterrupt(Handle convar, const char[] oldValue, const char
 	g_iPounceInterrupt = GetConVarInt(convar);
 }
 
-public void OnClientPostAdminCheck(int client)
+public void OnClientPutInServer(int client)
 {
 	SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamageByWitch);
 }

--- a/addons/sourcemod/scripting/l4d2_spitblock.sp
+++ b/addons/sourcemod/scripting/l4d2_spitblock.sp
@@ -49,7 +49,7 @@ public void OnPluginStart()
 	if (g_bLateLoad) {
 		for (int i = 1; i <= MaxClients; i++) {
 			if (IsClientInGame(i)) {
-				OnClientPostAdminCheck(i);
+				OnClientPutInServer(i);
 			}
 		}
 	}
@@ -125,7 +125,7 @@ public void OnMapStart()
 	g_bIsBlockEnable = false;
 }
 
-public void OnClientPostAdminCheck(int iClient)
+public void OnClientPutInServer(int iClient)
 {
 	SDKHook(iClient, SDKHook_OnTakeDamage, stop_spit_dmg);
 }

--- a/addons/sourcemod/scripting/readyup.sp
+++ b/addons/sourcemod/scripting/readyup.sp
@@ -320,7 +320,7 @@ public void OnMapEnd()
 	}
 }
 
-public void OnClientPostAdminCheck(int client)
+public void OnClientPutInServer(int client)
 {
 	if (inReadyUp && L4D2_IsScavengeMode() && !IsFakeClient(client))
 	{

--- a/addons/sourcemod/scripting/simple_witch_bonus.sp
+++ b/addons/sourcemod/scripting/simple_witch_bonus.sp
@@ -67,7 +67,7 @@ public OnPluginStart()
 }
 
 // player damage tracking
-public OnClientPostAdminCheck(client)
+public OnClientPutInServer(client)
 {
     SDKHook(client, SDKHook_OnTakeDamage, OnTakeDamageByWitch);
 }


### PR DESCRIPTION
This forward does not always work correctly if the client does not complete authorization in time, it is unreliable for hooks, it is better to use 'OnClientPutInServer'.