### PR TITLE
[dbd dc] map3 fix tank spawn stuck

### DIFF
--- a/cfg/stripper/zonemod/maps/l4d_dbd2dc_clean_up.cfg
+++ b/cfg/stripper/zonemod/maps/l4d_dbd2dc_clean_up.cfg
@@ -1263,14 +1263,33 @@ add:
 	"BlockType" "0"
 }
 
-; --- Fix the tank stuck spot at 73% store cant get out 修复73%tank必定卡住的商店
+; --- Block a store would stuck tank spawn at 73% flow 修复73%坦克刷新点会卡住的商店
 {
 	"classname" "env_player_blocker"
-	"origin" "-752 4992 -592"
+	"BlockType" "0"
+	"initialstate" "1"
 	"maxs" "240 186 80"
 	"mins" "-4 -128 -80"
-	"initialstate" "1"
+	"targetname" "eb_fix01a"
+	"origin" "-752 4992 -592"
+}
+{
+	"classname" "env_player_blocker"
 	"BlockType" "0"
+	"initialstate" "1"
+	"maxs" "40 64 80"
+	"mins" "-4 -64 -80"
+	"targetname" "eb_fix01b"
+	"origin" "-792 5112 -592"
+}
+{
+	"classname" "env_player_blocker"
+	"BlockType" "0"
+	"initialstate" "1"
+	"maxs" "40 64 80"
+	"mins" "-4 -64 -80"
+	"targetname" "eb_fix01c"
+	"origin" "-792 4920 -592"
 }
 
 ; =====================================================


### PR DESCRIPTION
Block a store would stuck tank spawn at 73% flow
[
<img width="1920" height="1080" alt="333" src="https://github.com/user-attachments/assets/8e4e5bd8-cd39-4f8e-9d70-2bfcdd18534a" />
](url)