### PR TITLE
Prevent infected and tank stuck on C2M5

### DIFF
--- a/cfg/stripper/zonemod/maps/c2m5_concert.cfg
+++ b/cfg/stripper/zonemod/maps/c2m5_concert.cfg
@@ -542,3 +542,39 @@ add:
 ; ==                   BLANK HEADER                  ==
 ; ==                Blank description                ==
 ; =====================================================
+
+
+; by harry
+; Prevent infected and tank stuck under the seating large area after final starts
+add:
+{
+    "classname" "trigger_multiple"
+    "origin" "-3548.87 2926.25 -309.876098"
+    "targetname" "final_stuck_warp"
+    "spawnflags" "1"
+    "wait" "1"
+    "StartDisabled" "1"
+    "entireteam" "0"
+    "allowincap" "0"
+    "allowghost" "1"
+
+    "OnStartTouch" "!activator,AddOutput,origin -4079.96 3902.36 66,0,-1"
+}
+{
+    "classname" "logic_auto"
+    "OnMapSpawn" "final_stuck_warp,AddOutput,mins -10 0 0,0,-1"
+    "OnMapSpawn" "final_stuck_warp,AddOutput,maxs 0 200 100,0,-1"
+    "OnMapSpawn" "final_stuck_warp,AddOutput,solid 2,0,-1"
+}
+
+modify:
+{
+    match:
+    {
+        "classname" "trigger_finale"
+    }
+    insert:
+    {
+        "FinaleStart" "final_stuck_warp,Enable,,0,-1"
+    }
+}


### PR DESCRIPTION
(Before)
Sometime Tank could spawn under the seating large area after final starts on C2M5
<img width="2552" height="1201" alt="666" src="https://github.com/user-attachments/assets/e74c9d0b-430f-4d01-a664-eafc85697ac0" />


(After)
warp player outside if trigger
![未命名](https://github.com/user-attachments/assets/f8794a72-c41e-4e95-a007-0f2d86402c3b)
