### PR TITLE
April 2026 Map Update

### DIFF
--- a/cfg/stripper/zonemod/global_filters.cfg
+++ b/cfg/stripper/zonemod/global_filters.cfg
@@ -434,11 +434,11 @@ modify:
 ; ==                   WEAPON SKINS                  ==
 ; ==  Use random skins, see weapon_skin_enabler.nut  ==
 ; =====================================================
-add:
-{
-	"classname" "logic_auto"
-	"OnMapSpawn" "!self,RunScriptFile,weapon_skin_enabler,5,-1"
-}
+;add:
+;{
+;	"classname" "logic_auto"
+;	"OnMapSpawn" "!self,RunScriptFile,weapon_skin_enabler,5,-1"
+;}
 
 ; =====================================================
 ; ==               T2 WEAPON SPAWN FIX               ==
@@ -1577,7 +1577,7 @@ filter:
 {
 	"classname" "prop_mounted_machine_gun"
 }
-; --- Gas Cans & First Aid Kits
+; --- Gas Cans
 modify:
 {
 	match:
@@ -1587,7 +1587,6 @@ modify:
 	replace:
 	{
 		"item8" "0"
-		"item2" "0"
 	}
 }
 filter:
@@ -1731,6 +1730,18 @@ filter:
 {
 	"classname" "weapon_defibrillator"
 }
+; --- First Aid Kits
+modify:
+{
+	match:
+	{
+		"classname" "weapon_item_spawn"
+	}
+	replace:
+	{
+		"item2" "0"
+	}
+}
 ; --- Adrenaline
 modify:
 {
@@ -1839,62 +1850,6 @@ filter:
 ; =====================================================
 ; --- Spawnflags = 8 (Motion disabled)
 modify:
-; --- Barrels
-{
-	match:
-	{
-		"classname" "/.*prop_physics.*/"
-		"model" "models/props_fairgrounds/traffic_barrel.mdl"
-	}
-	replace:
-	{
-		"spawnflags" "8"
-	}
-}
-{
-	match:
-	{
-		"classname" "/.*prop_physics.*/"
-		"model" "models/props/cs_assault/barrelwarning.mdl"
-	}
-	replace:
-	{
-		"spawnflags" "8"
-	}
-}
-{
-	match:
-	{
-		"classname" "/.*prop_physics.*/"
-		"model" "models/props_urban/oil_drum001.mdl"
-	}
-	replace:
-	{
-		"spawnflags" "8"
-	}
-}
-{
-	match:
-	{
-		"classname" "/.*prop_physics.*/"
-		"model" "models/props_c17/oildrum001.mdl"
-	}
-	replace:
-	{
-		"spawnflags" "8"
-	}
-}
-{
-	match:
-	{
-		"classname" "/.*prop_physics.*/"
-		"model" "models/props_industrial/pallet_barrels_water01_single.mdl"
-	}
-	replace:
-	{
-		"spawnflags" "8"
-	}
-}
 ; --- Tables
 {
 	match:
@@ -2084,39 +2039,7 @@ modify:
 		"spawnflags" "8"
 	}
 }
-{
-	match:
-	{
-		"classname" "/.*prop_physics.*/"
-		"model" "models/props_trainstation/trashcan_indoor001b.mdl"
-	}
-	replace:
-	{
-		"spawnflags" "8"
-	}
-}
-{
-	match:
-	{
-		"classname" "/.*prop_physics.*/"
-		"model" "models/props_interiors/sawhorse.mdl"
-	}
-	replace:
-	{
-		"spawnflags" "8"
-	}
-}
-{
-	match:
-	{
-		"classname" "/.*prop_physics.*/"
-		"model" "models/props_equipment/cart_utility_01.mdl"
-	}
-	replace:
-	{
-		"spawnflags" "8"
-	}
-}
+; --- Generic cabinets across multiple maps
 {
 	match:
 	{
@@ -2150,17 +2073,7 @@ modify:
 		"spawnflags" "8"
 	}
 }
-{
-	match:
-	{
-		"classname" "/.*prop_physics.*/"
-		"model" "models/props_wasteland/controlroom_filecabinet001a.mdl"
-	}
-	replace:
-	{
-		"spawnflags" "8"
-	}
-}
+; --- Green file cabinets
 {
 	match:
 	{
@@ -2172,6 +2085,7 @@ modify:
 		"spawnflags" "8"
 	}
 }
+; --- Blue file cabinets
 {
 	match:
 	{
@@ -2183,7 +2097,6 @@ modify:
 		"spawnflags" "8"
 	}
 }
-
 ; --- Chairs
 {
 	match:
@@ -2686,6 +2599,35 @@ filter:
 	"classname" "/.*prop_physics.*/"
 	"model" "models/props_unique/airport/line_post.mdl"
 }
+; --- Nuisance props that are too big to be debris without causing confusing
+{
+	"classname" "/.*prop_physics.*/"
+	"model" "models/props_fairgrounds/traffic_barrel.mdl"
+}
+{
+	"classname" "/.*prop_physics.*/"
+	"model" "models/props_urban/oil_drum001.mdl"
+}
+{
+	"classname" "/.*prop_physics.*/"
+	"model" "models/props_c17/oildrum001.mdl"
+}
+{
+	"classname" "/.*prop_physics.*/"
+	"model" "models/props_industrial/pallet_barrels_water01_single.mdl"
+}
+{
+	"classname" "/.*prop_physics.*/"
+	"model" "models/props/cs_assault/barrelwarning.mdl"
+}
+{
+	"classname" "/.*prop_physics.*/"
+	"model" "models/props_trainstation/trashcan_indoor001b.mdl"
+}
+{
+	"classname" "/.*prop_physics.*/"
+	"model" "models/props_equipment/cart_utility_01.mdl"
+}
 
 ; =====================================================
 ; ==                PROP COLLISION FIX               ==
@@ -2694,6 +2636,18 @@ filter:
 ; --- Physics Props: Spawnflags = 4 (Debris)
 ; --- Dynamic Props: Solid = 0 (No collision)
 modify:
+; --- File cabinets
+{
+	match:
+	{
+		"classname" "/.*prop_physics.*/"
+		"model" "models/props_wasteland/controlroom_filecabinet001a.mdl"
+	}
+	replace:
+	{
+		"spawnflags" "4"
+	}
+}
 ; --- Dead bodies
 {
 	match:
@@ -3848,6 +3802,17 @@ modify:
 		"model" "models/props_interiors/table_folding_folded_new.mdl"
 	}
 	insert:
+	{
+		"spawnflags" "4"
+	}
+}
+{
+	match:
+	{
+		"classname" "/.*prop_physics.*/"
+		"model" "models/props_interiors/sawhorse.mdl"
+	}
+	replace:
 	{
 		"spawnflags" "4"
 	}

--- a/cfg/stripper/zonemod/maps/c10m1_caves.cfg
+++ b/cfg/stripper/zonemod/maps/c10m1_caves.cfg
@@ -719,16 +719,37 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
-; --- Clipping on some cracks in the wall at the end of the tunnel to stop survivors from getting stuck
+; --- Clipping on some cracks in the wall at the end of the tunnel to stop players from getting stuck
 {
 	"classname" "env_physics_blocker"
-	"origin" "-12768 -5940 40"
-	"mins" "-1 -103 -88"
-	"maxs" "1 103 88"
+	"origin" "-12768.5 -6000.5 40"
+	"mins" "-1.5 -162.5 -88"
+	"maxs" "1.5 162.5 88"
 	"initialstate" "1"
-	"BlockType" "1"
+	"BlockType" "0"
 }
-
+{
+	"classname" "env_physics_blocker"
+	"origin" "-12767.1 -6163 40"
+	"angles" "0 45 0"
+	"mins" "-2 -2 -88"
+	"maxs" "2 2 88"
+	"boxmins" "-2 -2 -88"
+	"boxmaxs" "2 2 88"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-12767.1 -5838 40"
+	"angles" "0 45 0"
+	"mins" "-2 -2 -88"
+	"maxs" "2 2 88"
+	"boxmins" "-2 -2 -88"
+	"boxmaxs" "2 2 88"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 
 ; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
 ; =====================================================

--- a/cfg/stripper/zonemod/maps/c10m2_drainage.cfg
+++ b/cfg/stripper/zonemod/maps/c10m2_drainage.cfg
@@ -97,6 +97,31 @@ modify:
 ; ==      Block intentionally performed exploits     ==
 ; =====================================================
 add:
+; --- Block standing on bridge supports at the event
+{
+	"classname" "env_physics_blocker"
+	"origin" "-8448 -8518 -152"
+	"mins" "-10 -6 -38"
+	"maxs" "10 6 38"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-8360 -8520 -152"
+	"mins" "-10 -6 -38"
+	"maxs" "10 6 38"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-8125 -8518 -165.5"
+	"mins" "-11 -6 -51.5"
+	"maxs" "11 6 51.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block standing on the pipe under the walkway after the bridge
 {
 	"classname" "env_physics_blocker"
@@ -111,18 +136,6 @@ add:
 ; ==                  OUT OF BOUNDS                  ==
 ; ==  Block players getting outside / under the map  ==
 ; =====================================================
-
-add:
-; --- Block pillar top of the bridge
-{
-	"classname" "env_physics_blocker"
- 	"targetname" "EB_bridge_svv_fix01a"
-  	"origin" "-8128 -8520 -208"
-	"maxs" "14 8 80"
-	"mins" "-8 -4 -80"
-	"initialstate" "1"
-	"BlockType" "1"
-}
 
 ; =====================================================
 ; ==                   STUCK SPOTS                   ==
@@ -210,6 +223,11 @@ filter:
 ; --- Remove fallen oil barrel in tunnel after the event
 {
 	"hammerid" "988448"
+}
+; --- Remove file cabinets on the ground by the end saferoom
+{
+	"classname" "prop_physics"
+	"model" "models/props_wasteland/controlroom_filecabinet002a.mdl"
 }
 
 

--- a/cfg/stripper/zonemod/maps/c10m3_ranchhouse.cfg
+++ b/cfg/stripper/zonemod/maps/c10m3_ranchhouse.cfg
@@ -445,18 +445,6 @@ modify:
 ;		"OnBreak" "break_rescue_window_01,SetDamageFilter,,0,1"
 ;	}
 ;}
-; --- Make the gravestones only breakable by tanks
-modify:
-{
-	match:
-	{
-		"damagefilter" "filter_no_burn"
-	}
-	replace:
-	{
-		"damagefilter" "filter_tank"
-	}
-}
 ; --- Block LOS in church window behind the map
 add:
 {

--- a/cfg/stripper/zonemod/maps/c10m4_mainstreet.cfg
+++ b/cfg/stripper/zonemod/maps/c10m4_mainstreet.cfg
@@ -1057,7 +1057,7 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Block LOS under the cement truck
+; --- Block LOS under the ambulance
 {
 	"classname" "logic_auto"
 	"OnMapSpawn" "los_ambulance_a,AddOutput,mins -1 -62 -10,0,-1"
@@ -1139,7 +1139,7 @@ add:
 	; --- Clip on added delivery van
 	"OnMapSpawn" "anv_mapfixes_losblocker_deliveryclip,Kill,,30,-1"
 	; --- Clip on truck after florist (can be re-enabled if angled blockers get fixed) (#34)
-	"OnMapSpawn" "anv_mapfixes_cliprework_trucknuke,Kill,,30,-1"
+	;"OnMapSpawn" "anv_mapfixes_cliprework_trucknuke,Kill,,30,-1"
 	; --- Clip above office roof
 	"OnMapSpawn" "anv_mapfixes_meticulous_funcinfclip03,Kill,,30,-1"
 	"OnMapSpawn" "anv_mapfixes_stainedroof_wrongway1,Kill,,30,-1"

--- a/cfg/stripper/zonemod/maps/c10m4_mainstreet.cfg
+++ b/cfg/stripper/zonemod/maps/c10m4_mainstreet.cfg
@@ -657,6 +657,40 @@ add:
 	"origin" "-787 -942 -50"
 	"targetname" "losfix_bus_street_2e"
 }
+; --- Clipping on sleeping bags in florist shop
+{
+	"classname" "env_physics_blocker"
+	"origin" "-301.69 -1905.25 -44"
+	"angles" "0 -15 0"
+	"mins" "-24 -43 -4"
+	"maxs" "24 43 4"
+	"boxmins" "-24 -43 -4"
+	"boxmaxs" "24 43 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-248 -1980 -43"
+	"angles" "0 25 0"
+	"mins" "-15 -19 -5"
+	"maxs" "15 19 5"
+	"boxmins" "-15 -19 -5"
+	"boxmaxs" "15 19 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-248 -1980 -34.5"
+	"angles" "0 25 0"
+	"mins" "-13 -17 -3.5"
+	"maxs" "13 17 3.5"
+	"boxmins" "-13 -17 -3.5"
+	"boxmaxs" "13 17 3.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Clipping on car stoppers after the florist shop
 {
 	"classname" "env_physics_blocker"

--- a/cfg/stripper/zonemod/maps/c11m5_runway.cfg
+++ b/cfg/stripper/zonemod/maps/c11m5_runway.cfg
@@ -75,7 +75,7 @@ add:
 	"classname" "logic_auto"
 	; --- Remove TLS hittable
 	"OnMapSpawn" "anv_mapfixes_replacement_baggagecart,Kill,,15,-1"
-	; --- Spawn new bumper car
+	; --- Spawn new baggage cart
 	"OnMapSpawn" "original_baggagecart_template,ForceSpawn,,16,-1"
 }
 {
@@ -383,13 +383,6 @@ filter:
 ; ==                   CLIP REMOVAL                  ==
 ; ==      Remove miscellaneous clips and brushes     ==
 ; =====================================================
-; --- Remove TLS clips
-add:
-{
-	"classname" "logic_auto"
-	; --- Angled survivor clip over boarding gate (can be re-enabled if angled blockers get fixed) (#34)
-	"OnMapSpawn" "anv_mapfixes_nav_skybridge,Kill,,30,-1"
-}
 
 ; =====================================================
 ; ==              TRIGGER REMOVAL / FIX              ==

--- a/cfg/stripper/zonemod/maps/c12m5_cornfield.cfg
+++ b/cfg/stripper/zonemod/maps/c12m5_cornfield.cfg
@@ -167,6 +167,15 @@ add:
 ; ==  Block players getting outside / under the map  ==
 ; =====================================================
 add:
+; --- Block out of bounds stuck spot in cliffs behind the saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "7136 -1264 -922"
+	"mins" "-32 -80 -1126"
+	"maxs" "32 80 1126"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Prevent infected from going behind tree cards right of the saferoom
 {
 	"classname" "env_physics_blocker"

--- a/cfg/stripper/zonemod/maps/c13m2_southpinestream.cfg
+++ b/cfg/stripper/zonemod/maps/c13m2_southpinestream.cfg
@@ -233,6 +233,15 @@ add:
 ; ==  Prevent players from getting stuck in the map  ==
 ; =====================================================
 add:
+; --- Block a stuck spot behind the barricade below the static tank spawn
+{
+	"classname" "env_physics_blocker"
+	"origin" "6453 3716 950"
+	"mins" "-167 -80 -138"
+	"maxs" "167 80 138"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Prevent a stuck spot on the ambulance one way drop fence
 {
 	"classname" "env_physics_blocker"

--- a/cfg/stripper/zonemod/maps/c14m1_junkyard.cfg
+++ b/cfg/stripper/zonemod/maps/c14m1_junkyard.cfg
@@ -164,6 +164,28 @@ add:
 ; ==                  SOUND REMOVAL                  ==
 ; ==    Remove or adjust sounds played by the map    ==
 ; =====================================================
+; --- Remove plane sounds at the start of the map
+filter:
+{
+	"targetname" "b_plane01_sound"
+}
+{
+	"targetname" "b_plane01_sound2"
+}
+{
+	"targetname" "b_plane01_sound3"
+}
+modify:
+{
+	match:
+	{
+		"hammerid" "5312564"
+	}
+	delete:
+	{
+		"OnStartTouch" "!activatorSpeakResponseConceptC14M1PlaneFlyBy1.5-1"
+	}
+}
 
 ; =====================================================
 ; ==             GFX / PARTICLES REMOVAL             ==

--- a/cfg/stripper/zonemod/maps/c14m2_lighthouse.cfg
+++ b/cfg/stripper/zonemod/maps/c14m2_lighthouse.cfg
@@ -135,6 +135,17 @@ add:
 	"spawnflags" "2"
 	"count" "5"
 }
+; --- Ammo pile on the beach
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "-2368.99 4838.92 -56.2947"
+	"angles" "-1.01178 -45.1634 356.849"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+	"count" "5"
+}
 
 ; =====================================================
 ; ==                 HITTABLE CHANGES                ==

--- a/cfg/stripper/zonemod/maps/c1m1_hotel.cfg
+++ b/cfg/stripper/zonemod/maps/c1m1_hotel.cfg
@@ -3,128 +3,6 @@
 ; ==          DIRECTOR & EVENT MODIFICATION          ==
 ; ==       Modify director behaviour and events      ==
 ; =====================================================
-; --- Make survivors have to call the elevator to the top before going to the ground floor
-; --- Fake the elevator moving with visuals and sounds
-; --- Remove logic_auto that opens the elevator doors on map spawn
-filter:
-{
-	"hammerid" "1227763"
-}
-; --- Remove existing button as there are 2 buttons with the same targetname
-{
-	"hammerid" "329945"
-	"targetname" "elevbuttonoutsidefront"
-}
-; --- Create the new elevator button
-add:
-{
-	"classname" "prop_dynamic"
-	"origin" "2048 5696 2516.17"
-	"angles" "0 270 0"
-	"model" "models/props_equipment/elevator_buttons.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"targetname" "call_elevator_button_prop"
-	"fadescale" "0"
-	"glowrange" "1000"
-	"glowrangemin" "128"
-}
-{
-	"classname" "func_button"
-	"origin" "2048 5706 2884.89"
-	"model" "*5"
-	"spawnflags" "1025"
-	"targetname" "call_elevator_button"
-	"glow" "call_elevator_button_prop"
-	"wait" "-1"
-	"sounds" "32"
-	; --- Disable glow
-	"OnPressed" "call_elevator_button_prop,StopGlowing,,0,-1"
-	; --- Button and elevator lights
-	"OnPressed" "call_elevator_button_prop,Skin,1,0,-1"
-	"OnPressed" "call_elevator_button_prop,Skin,0,0.3,-1"
-	"OnPressed" "call_elevator_lights,Skin,1,0.5,-1"
-	; --- Elevator moving sound
-	"OnPressed" "elevator_movement_sound,PlaySound,,2,-1"
-	; --- Survivors call out pressing the button
-	"OnPressed" "!activator,SpeakResponseConcept,c4m2_elevator_top_button,0,-1"
-	; --- Start panic event
-	"OnPressed" "director,ForcePanicEvent,,3,-1"
-	; --- Elevator opens after ~30 seconds
-	"OnPressed" "call_elevator_relay,Trigger,,34,-1"
-}
-; --- Create a relay for handling elevator arrival
-{
-	"classname" "logic_relay"
-	"origin" "2035 5661 2473"
-	"targetname" "call_elevator_relay"
-	; --- Button and elevator lights
-	"OnTrigger" "call_elevator_lights,Skin,0,4,-1"
-	; --- Stop elevator moving sound
-	"OnTrigger" "elevator_movement_sound,StopSound,,0,-1"
-	; --- Elevator arrival sounds and dialogue
-	"OnTrigger" "elevator_stop_sound,PlaySound,,2,-1"
-	"OnTrigger" "sound_elevator_arrived,PlaySound,,4,-1"
-	"OnTrigger" "sound_elevator_arrived,StopSound,,10,-1"
-	; --- Survivors call out the elevator arriving
-	"OnTrigger" "!activator,SpeakResponseConcept,PlayerMoveOn,5,-1"
-	; --- Open the doors
-	"OnTrigger" "elevator_1_door1,Open,,5,-1"
-	"OnTrigger" "elevator_1_door2,Open,,5,-1"
-	; --- Unblock nav
-	"OnTrigger" "elevator_event_nav_block_a,UnblockNav,,5,-1"
-	"OnTrigger" "elevator_event_nav_block_b,UnblockNav,,5,-1"
-}
-; --- Give a unique name to the relevant elevator arrow lights so we only change this one
-modify:
-{
-	match:
-	{
-		"hammerid" "330225"
-	}
-	replace:
-	{
-		"targetname" "call_elevator_lights"
-	}
-}
-; --- Add a glow to the button when hitting a trigger just before the elevator room, and limit trigger to survivors
-{
-	match:
-	{
-		"hammerid" "4029721"
-		"origin" "1728 5736 2528"
-	}
-	insert:
-	{
-		"filtername" "filter_survivor"
-		"OnStartTouch" "call_elevator_button_prop,StartGlowing,,0,-1"
-	}
-}
-; --- Block elevator nav until doors open
-add:
-{
-	"classname" "logic_auto"
-	"OnMapSpawn" "elevator_event_nav_block_a,AddOutput,mins -104 -100 -96,0,-1"
-	"OnMapSpawn" "elevator_event_nav_block_a,AddOutput,maxs 104 100 96,0,-1"
-	"OnMapSpawn" "elevator_event_nav_block_a,AddOutput,solid 2,0,-1"
-	"OnMapSpawn" "elevator_event_nav_block_a,BlockNav,,1,-1"
-	"OnMapSpawn" "elevator_event_nav_block_b,AddOutput,mins -44 -12 -96,0,-1"
-	"OnMapSpawn" "elevator_event_nav_block_b,AddOutput,maxs 44 12 96,0,-1"
-	"OnMapSpawn" "elevator_event_nav_block_b,AddOutput,solid 2,0,-1"
-	"OnMapSpawn" "elevator_event_nav_block_b,BlockNav,,1,-1"
-}
-{
-	"classname" "func_nav_blocker"
-	"origin" "2168 5813 2560"
-	"targetname" "elevator_event_nav_block_a"
-	"teamToBlock" "-1"
-}
-{
-	"classname" "func_nav_blocker"
-	"origin" "2164 5701 2560"
-	"targetname" "elevator_event_nav_block_b"
-	"teamToBlock" "-1"
-}
 ; --- Remove scripted zombie spawns that fall through the windows by the end saferoom
 filter:
 {
@@ -144,14 +22,14 @@ add:
 ; --- Single pickup tier 1 weapons in saferoom
 {
 	"classname" "weapon_smg_silenced"
-	"origin" "429 5579 2850"
+	"origin" "429 5573 2850"
 	"angles" "0 254 84"
 	"ammo" "650"
 	"spawnflags" "1"
 }
 {
 	"classname" "weapon_shotgun_chrome"
-	"origin" "430 5545 2850"
+	"origin" "430 5531 2850"
 	"angles" "0 254 84"
 	"ammo" "96"
 	"spawnflags" "1"
@@ -168,28 +46,20 @@ add:
 	"spawnflags" "2"
 	"count" "1"
 }
-; --- Single pickup T1s on table by cleaning cart around the corner in the first hallway
+; --- Additional single pickup T1s at the corner in the first hallway
 {
 	"classname" "weapon_smg"
-	"origin" "1684 5926 2692"
-	"angles" "0 270 90"
+	"origin" "1771 5781 2657"
+	"angles" "0 316 -90"
 	"ammo" "650"
 	"spawnflags" "1"
 }
 {
 	"classname" "weapon_pumpshotgun"
-	"origin" "1687 5894 2692"
-	"angles" "0 255 90"
+	"origin" "1775 5742 2657"
+	"angles" "0 276.5 -90"
 	"ammo" "72"
 	"spawnflags" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "1684 5901 2656"
-	"angles" "0 0 0"
-	"model" "models/props_interiors/table_kitchen.mdl"
-	"solid" "6"
-	"disableshadows" "1"
 }
 ; --- Make the melee in the map room always spawn
 modify:
@@ -215,29 +85,6 @@ add:
 	"disableshadows" "1"
 	"spawnflags" "2"
 	"count" "1"
-}
-; --- Guns in the room by the elevator
-{
-	"classname" "weapon_spawn"
-	"origin" "2155 5367 2487"
-	"angles" "0 270 -90"
-	"weapon_selection" "any_smg"
-	"spawn_without_director" "1"
-	"solid" "6"
-	"disableshadows" "1"
-	"spawnflags" "2"
-	"count" "5"
-}
-{
-	"classname" "weapon_spawn"
-	"origin" "2141 5413 2465"
-	"angles" "0 223 -90"
-	"weapon_selection" "tier1_shotgun"
-	"spawn_without_director" "1"
-	"solid" "6"
-	"disableshadows" "1"
-	"spawnflags" "2"
-	"count" "5"
 }
 
 ; =====================================================
@@ -343,20 +190,53 @@ add:
 	"BlockType" "1"
 	"targetname" "lower_ledge_block"
 }
-; --- Remove the block once survivors have opened the stairwell door
+; --- Remove the block once survivors hit a trigger after the stairwell to the lower floor
 modify:
 {
 	match:
 	{
-		"hammerid" "570190"
+		"hammerid" "4545120"
+		"origin" "1727.75 7589.71 2523.5"
 	}
 	insert:
 	{
-		"OnBreak" "lower_ledge_block,Kill,,0,-1"
-		"OnOpen" "lower_ledge_block,Kill,,0,-1"
+		"OnStartTouch" "lower_ledge_block,Kill,,0,-1"
 	}
 }
 add:
+; --- Block survivors from standing on clips in the hospital bed room
+{
+	"classname" "env_physics_blocker"
+	"origin" "364 5064 1412"
+	"mins" "-68 -128 -44"
+	"maxs" "68 128 44"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-156 4696 1412"
+	"mins" "-132 -72 -44"
+	"maxs" "132 72 44"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-644 5040 1412"
+	"mins" "-68 -176 -44"
+	"maxs" "68 176 44"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-636 5560 1412"
+	"mins" "-68 -128 -44"
+	"maxs" "68 128 44"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block survivors from standing on the awning above the check-in desk
 {
 	"classname" "env_physics_blocker"
@@ -404,7 +284,15 @@ add:
 ; ==  Prevent players from getting stuck in the map  ==
 ; =====================================================
 add:
-; --- Block getting stuck on top of the suitcase pile just before the kitchen
+; --- Block getting stuck on top of suitcase piles just before the kitchen
+{
+	"classname" "env_physics_blocker"
+	"origin" "990 5418 1264"
+	"mins" "-46 -42 -80"
+	"maxs" "38 42 80"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 {
 	"classname" "env_physics_blocker"
 	"origin" "494 5436 1264"
@@ -444,6 +332,7 @@ add:
 	"angles" "0 0 0"
 	"extent" "8.5 84 350"
 	"StartDisabled" "0"
+	"targetname" "weapon_grief_protector"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -451,6 +340,7 @@ add:
 	"angles" "0 0 0"
 	"extent" "191.5 8.5 350"
 	"StartDisabled" "0"
+	"targetname" "weapon_grief_protector"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -458,6 +348,7 @@ add:
 	"angles" "0 0 0"
 	"extent" "8.5 417.5 350"
 	"StartDisabled" "0"
+	"targetname" "weapon_grief_protector"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -465,6 +356,7 @@ add:
 	"angles" "0 0 0"
 	"extent" "191.5 8.5 350"
 	"StartDisabled" "0"
+	"targetname" "weapon_grief_protector"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -472,6 +364,7 @@ add:
 	"angles" "0 0 0"
 	"extent" "8.5 125.5 350"
 	"StartDisabled" "0"
+	"targetname" "weapon_grief_protector"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -479,6 +372,7 @@ add:
 	"angles" "0 0 0"
 	"extent" "8.5 208 296"
 	"StartDisabled" "0"
+	"targetname" "weapon_grief_protector"
 }
 ; --- Remove window by elevator that prevents death charges and ledge hangs
 filter:
@@ -569,11 +463,12 @@ add:
 ; --- Props in the Banquet Hall A area for spawns
 {
 	"classname" "prop_dynamic"
-	"origin" "-358 5271 1184"
+	"origin" "-367 5285 1184"
 	"angles" "0 81.5 0"
-	"model" "models/props_office/vending_machine01.mdl"
+	"model" "models/props/cs_office/vending_machine.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+	"skin" "1"
 }
 {
 	"classname" "prop_dynamic"
@@ -598,11 +493,12 @@ add:
 ; --- Drinks machines behind the check-in desk by the end saferoom
 {
 	"classname" "prop_dynamic"
-	"origin" "546 4942 1184"
+	"origin" "531 4944 1184"
 	"angles" "0 90 0"
-	"model" "models/props_office/vending_machine01.mdl"
+	"model" "models/props/cs_office/vending_machine.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+	"skin" "1"
 }
 {
 	"classname" "prop_dynamic"
@@ -612,109 +508,48 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Dressers by the end saferoom
+; --- Drinks machine by the end saferoom
 {
 	"classname" "prop_dynamic"
-	"origin" "1344 4908 1183"
-	"angles" "0 270 90"
+	"origin" "1325 4923 1184"
+	"angles" "0 270 0"
+	"model" "models/props/cs_office/vending_machine.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"skin" "1"
+}
+; --- Pile of dressers, chairs and plants by the end saferoom
+{
+	"classname" "prop_dynamic"
+	"origin" "1400 4421 1184"
+	"angles" "0 185 0"
 	"model" "models/props_downtown/dresser.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "1301 4908 1182"
-	"angles" "0 270 83.5"
-	"model" "models/props_downtown/dresser.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Baggage cart by the end saferoom
-{
-	"classname" "prop_dynamic_override"
-	"origin" "1152 4914 1184"
-	"angles" "0 0 0"
-	"model" "models/props_interiors/luggagecarthotel01.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic_override"
-	"origin" "1143 4915 1185"
-	"angles" "0 0 0"
-	"model" "models/props_unique/airport/luggage1.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic_override"
-	"origin" "1155 4904 1207"
-	"angles" "0 0 -90"
-	"model" "models/props_unique/airport/luggage2.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic_override"
-	"origin" "1166 4923 1205"
-	"angles" "0 0 90"
-	"model" "models/props_unique/airport/luggage4.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic_override"
-	"origin" "1152 4927 1226"
-	"angles" "-83 0 90"
-	"model" "models/props_unique/airport/luggage3.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic_override"
-	"origin" "1177 4915 1236"
-	"angles" "-83 0 0"
-	"model" "models/props_unique/airport/luggage1.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Block LOS under baggage cart
-{
-	"classname" "logic_auto"
-	"OnMapSpawn" "los_baggage_cart,AddOutput,mins -20 -1 -3,0,-1"
-	"OnMapSpawn" "los_baggage_cart,AddOutput,maxs 20 1 3,0,-1"
-	"OnMapSpawn" "los_baggage_cart,AddOutput,solid 2,0,-1"
-}
-{
-	"classname" "func_brush"
-	"origin" "1152 4914 1187"
-	"targetname" "los_baggage_cart"
-}
-; --- Chair by the end saferoom
-{
-	"classname" "prop_dynamic"
-	"origin" "1275 4399 1184"
-	"angles" "0 90 0"
+	"origin" "1367 4350 1241"
+	"angles" "1.02272 89.47 86.6526"
 	"model" "models/props_urban/hotel_chair001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Luggage pile by the end saferoom
 {
 	"classname" "prop_dynamic"
-	"origin" "1583 4165 1183"
-	"angles" "0 197.5 0"
-	"model" "models/props_unique/airport/luggage_pile1.mdl"
+	"origin" "1331.22 4344 1184"
+	"angles" "0 0 0"
+	"model" "models/props_foliage/mall_pot_square02.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
 {
-	"classname" "env_physics_blocker"
-	"origin" "1583 4173 1288"
-	"mins" "-69 -51 -104"
-	"maxs" "69 51 104"
-	"initialstate" "1"
-	"BlockType" "1"
+	"classname" "prop_dynamic"
+	"origin" "1331 4346 1216"
+	"angles" "0 180 0"
+	"model" "models/props_foliage/mall_small_palm01_cluster_medium.mdl"
+	"solid" "0"
+	"disableshadows" "1"
 }
 
 ; =====================================================
@@ -967,6 +802,169 @@ modify:
 
 ; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
 ; =====================================================
-; ==                   BLANK HEADER                  ==
-; ==                Blank description                ==
+; ==                 ELEVATOR HOLDOUT                ==
+; ==     Short holdout to access the elevator        ==
 ; =====================================================
+; --- Make survivors have to call the elevator to the top before going to the ground floor
+; --- Fake the elevator moving with visuals and sounds
+; --- Remove logic_auto that opens the elevator doors on map spawn
+filter:
+{
+	"hammerid" "1227763"
+}
+; --- Remove existing button as there are 2 buttons with the same targetname
+{
+	"hammerid" "329945"
+	"targetname" "elevbuttonoutsidefront"
+}
+; --- Create the new elevator button
+add:
+{
+	"classname" "prop_dynamic"
+	"origin" "2048 5696 2516.17"
+	"angles" "0 270 0"
+	"model" "models/props_equipment/elevator_buttons.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"targetname" "call_elevator_button_prop"
+	"fadescale" "0"
+	"glowrange" "1000"
+	"glowrangemin" "128"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "2048 5695.5 2516.17"
+	"angles" "0 90 0"
+	"model" "models/props_equipment/elevator_buttons.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+	"rendermode" "10"
+	"targetname" "call_elevator_button_prop_glow"
+	"fadescale" "0"
+	"glowrange" "1000"
+	"glowrangemin" "128"
+}
+{
+	"classname" "func_button"
+	"origin" "2048 5706 2884.89"
+	"model" "*5"
+	"spawnflags" "1025"
+	"targetname" "call_elevator_button"
+	"glow" "call_elevator_button_prop"
+	"wait" "-1"
+	"sounds" "32"
+	; --- Disable glow
+	"OnPressed" "call_elevator_button_prop*,StopGlowing,,0,-1"
+	; --- Button and elevator lights
+	"OnPressed" "call_elevator_button_prop,Skin,1,0,-1"
+	"OnPressed" "call_elevator_button_prop,Skin,0,0.3,-1"
+	"OnPressed" "call_elevator_lights,Skin,1,0.5,-1"
+	; --- Elevator moving sound
+	"OnPressed" "elevator_movement_sound,PlaySound,,2,-1"
+	; --- Survivors call out pressing the button
+	"OnPressed" "!activator,SpeakResponseConcept,c4m2_elevator_top_button,0,-1"
+	; --- Start panic event
+	"OnPressed" "director,ForcePanicEvent,,3,-1"
+	; --- Elevator opens after ~30 seconds
+	"OnPressed" "call_elevator_relay,Trigger,,34,-1"
+}
+; --- Create a relay for handling elevator arrival
+{
+	"classname" "logic_relay"
+	"origin" "2035 5661 2473"
+	"targetname" "call_elevator_relay"
+	; --- Button and elevator lights
+	"OnTrigger" "call_elevator_lights,Skin,0,4,-1"
+	; --- Stop elevator moving sound
+	"OnTrigger" "elevator_movement_sound,StopSound,,0,-1"
+	; --- Elevator arrival sounds and dialogue
+	"OnTrigger" "elevator_stop_sound,PlaySound,,2,-1"
+	"OnTrigger" "sound_elevator_arrived,PlaySound,,4,-1"
+	"OnTrigger" "sound_elevator_arrived,StopSound,,10,-1"
+	; --- Survivors call out the elevator arriving
+	"OnTrigger" "!activator,SpeakResponseConcept,PlayerMoveOn,5,-1"
+	; --- Open the doors
+	"OnTrigger" "elevator_1_door1,Open,,5,-1"
+	"OnTrigger" "elevator_1_door2,Open,,5,-1"
+	; --- Unblock nav
+	"OnTrigger" "elevator_event_nav_block_a,UnblockNav,,5,-1"
+	"OnTrigger" "elevator_event_nav_block_b,UnblockNav,,5,-1"
+}
+; --- Give a unique name to the relevant elevator arrow lights so we only change this one
+modify:
+{
+	match:
+	{
+		"hammerid" "330225"
+	}
+	replace:
+	{
+		"targetname" "call_elevator_lights"
+	}
+}
+; --- Add a glow to the button when hitting a trigger just before the elevator room, and limit trigger to survivors
+{
+	match:
+	{
+		"hammerid" "4029721"
+		"origin" "1728 5736 2528"
+	}
+	insert:
+	{
+		"filtername" "filter_survivor"
+		"OnStartTouch" "call_elevator_button_prop*,StartGlowing,,0,-1"
+	}
+	replace:
+	{
+		"origin" "1728 5904 2528"
+	}
+}
+; --- Block elevator nav until doors open
+add:
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "elevator_event_nav_block_a,AddOutput,mins -104 -100 -96,0,-1"
+	"OnMapSpawn" "elevator_event_nav_block_a,AddOutput,maxs 104 100 96,0,-1"
+	"OnMapSpawn" "elevator_event_nav_block_a,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "elevator_event_nav_block_a,BlockNav,,1,-1"
+	"OnMapSpawn" "elevator_event_nav_block_b,AddOutput,mins -44 -12 -96,0,-1"
+	"OnMapSpawn" "elevator_event_nav_block_b,AddOutput,maxs 44 12 96,0,-1"
+	"OnMapSpawn" "elevator_event_nav_block_b,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "elevator_event_nav_block_b,BlockNav,,1,-1"
+}
+{
+	"classname" "func_nav_blocker"
+	"origin" "2168 5813 2560"
+	"targetname" "elevator_event_nav_block_a"
+	"teamToBlock" "-1"
+}
+{
+	"classname" "func_nav_blocker"
+	"origin" "2164 5701 2560"
+	"targetname" "elevator_event_nav_block_b"
+	"teamToBlock" "-1"
+}
+; --- Guns in the room by the elevator
+add:
+{
+	"classname" "weapon_spawn"
+	"origin" "2155 5367 2487"
+	"angles" "0 270 -90"
+	"weapon_selection" "any_smg"
+	"spawn_without_director" "1"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+	"count" "5"
+}
+{
+	"classname" "weapon_spawn"
+	"origin" "2141 5413 2465"
+	"angles" "0 223 -90"
+	"weapon_selection" "tier1_shotgun"
+	"spawn_without_director" "1"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+	"count" "5"
+}

--- a/cfg/stripper/zonemod/maps/c1m2_streets.cfg
+++ b/cfg/stripper/zonemod/maps/c1m2_streets.cfg
@@ -93,28 +93,6 @@ add:
 	"HDRColorScale" ".7"
 	"GlowProxySize" "8"
 }
-; --- Enable the 2 alarm cars after the event
-modify:
-{
-	match:
-	{
-		"targetname" "branch_caralarm-car1_alarm"
-	}
-	replace:
-	{
-		"OnTrue" "relay_caralarm_on-car1_alarmTrigger0-1"
-	}
-}
-{
-	match:
-	{
-		"targetname" "branch_caralarm-car2_alarm"
-	}
-	replace:
-	{
-		"OnTrue" "relay_caralarm_on-car2_alarmTrigger0-1"
-	}
-}
 
 
 ; ################  ITEM SPAWN CHANGES  ###############
@@ -363,18 +341,6 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Block standing on the edge of the tent by the generator - Removed until angled clip bug is fixed (#34)
-;{
-;	"classname" "env_physics_blocker"
-;	"origin" "1610 2682 1073"
-;	"angles" "0 353.5 0"
-;	"mins" "-3 -190.5 -399.5"
-;	"maxs" "3 190.5 399.5"
-;	"boxmins" "-3 -190.5 -399.5"
-;	"boxmaxs" "3 190.5 399.5"
-;	"initialstate" "1"
-;	"BlockType" "1"
-;}
 ; --- Block survivors from standing on the hedges on the first road
 {
 	"classname" "env_physics_blocker"
@@ -526,7 +492,28 @@ add:
 	"mins" "-896 -32 -576"
 	"maxs" "896 32 576"
 	"initialstate" "1"
-	"BlockType" "2"
+	"BlockType" "0"
+}
+; --- Block players going out of bounds at the back of the highway
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1504 -1940 192"
+	"mins" "-96 -1132 -192"
+	"maxs" "96 1132 192"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Block players going out of bounds behind the gun store / end saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "-4168.6 -3320 418.84"
+	"angles" "-6.75 0 0"
+	"mins" "-560 -8 -96"
+	"maxs" "560 8 96"
+	"boxmins" "-560 -8 -96"
+	"boxmaxs" "560 8 96"
+	"initialstate" "1"
+	"BlockType" "0"
 }
 
 ; =====================================================
@@ -853,15 +840,6 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Hedge to jump on a highway sign at the back of the underpass
-{
-	"classname" "prop_dynamic"
-	"origin" "-940 4800 553"
-	"angles" "0 0 0"
-	"model" "models/props_foliage/urban_hedge_128_64_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
 ; --- Fence cover by dumpster drop
 {
 	"classname" "prop_dynamic"
@@ -880,32 +858,24 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Boxes to jump on the platform after the one way drop
+; --- Traffic barrel to jump on the platform by the hedge before the overpass
 {
 	"classname" "prop_dynamic"
-	"origin" "-4702 1568 384"
-	"angles" "0 225 0"
-	"model" "models/props/cs_militia/boxes_garage_lower.mdl"
+	"origin" "-4701 1665 384"
+	"angles" "0 90 0"
+	"model" "models/props_fairgrounds/traffic_barrel.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-4693 1687 406"
+	"mins" "-13 -23	 -22"
+	"maxs" "13 23 22"
+	"initialstate" "1"
+	"BlockType" "0"
 }
 ; --- Fences on platform up the stairs after the one way drop
-{
-	"classname" "prop_dynamic"
-	"origin" "-4510 1444 448"
-	"angles" "0 345 0"
-	"model" "models/props_urban/fence003_64.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-4502 1474 448"
-	"angles" "0 345 0"
-	"model" "models/props_urban/fence_post003.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
 {
 	"classname" "prop_dynamic"
 	"origin" "-4470 1597 448"
@@ -939,17 +909,6 @@ add:
 	"maxs" "4 134 23"
 	"boxmins" "-4 -134 -23"
 	"boxmaxs" "4 134 23"
-	"initialstate" "1"
-	"BlockType" "0"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-4508 1441 471"
-	"angles" "0 -14 0"
-	"mins" "-4 -34 -23"
-	"maxs" "4 34 23"
-	"boxmins" "-4 -34 -23"
-	"boxmaxs" "4 34 23"
 	"initialstate" "1"
 	"BlockType" "0"
 }
@@ -987,7 +946,7 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Crashed bus after the event
+; --- Bus after the event
 {
 	"classname" "prop_dynamic"
 	"origin" "-7980 -496 384"
@@ -1058,7 +1017,7 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Block LOS under van
+; --- Block LOS under bus
 {
 	"classname" "logic_auto"
 	"OnMapSpawn" "losfix_bus_endsaferoom_a,AddOutput,mins -1 -95 -10,0,-1"
@@ -1199,6 +1158,17 @@ add:
 	"normal.y" "0.00"
 	"normal.z" "0.00"
 	"team" "2"
+}
+; --- Infected ladder to climb on a highway sign by the van
+{
+    "classname" "func_simpleladder"
+    "origin" "-266 8176 -82"
+    "angles" "0 180 0"
+    "model" "*41"
+    "normal.x" "1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "2"
 }
 ; --- Infected ladder to get above the back of the underpass by the white van
 {

--- a/cfg/stripper/zonemod/maps/c1m3_mall.cfg
+++ b/cfg/stripper/zonemod/maps/c1m3_mall.cfg
@@ -8,10 +8,6 @@ filter:
 {
 	"hammerid" "8442672"
 }
-; --- Remove entity that affects the event path route based on the "event" removed above
-{
-	"targetname" "compare_minifinale"
-}
 ; --- Remove natural horde script after the event
 modify:
 {
@@ -27,160 +23,6 @@ modify:
 	{
 		"OnPressed" "director,EndScript,,0,-1"
 	}
-}
-; --- Force survivors to always take the lower path leading to the event
-modify:
-{
-	match:
-	{
-		"hammerid" "1310374"
-	}
-	insert:
-	{
-		"OnMapSpawn" "relay_hallway_closeTrigger0-1"
-	}
-}
-; --- Open up the Just For Kidz store so tanks don't need to use the vent, survivors can still go to this area but the path back remains blocked
-filter:
-{
-	"targetname" "trigger_glass_breakable"
-}
-{
-	"targetname" "brush_shop_blocked"
-}
-{
-	"targetname" "breakble_glass_minifinale"
-}
-{
-	"targetname" "nav_blocker_storefront"
-}
-{
-	"targetname" "window_glow"
-}
-{
-	"targetname" "instructor_window"
-}
-{
-	"targetname" "filter_breakglass"
-}
-{
-	"targetname" "filter_melee"
-}
-{
-	"targetname" "filter_invunerable"
-}
-{
-	"targetname" "trigger_glass_breakable"
-}
-{
-	"targetname" "prop_door_mallshop_straight"
-}
-; --- Remove a trigger on the upper path that sets the escalator positions
-{
-	"hammerid" "221997"
-}
-; --- Close the partially open door before the store
-modify:
-{
-	match:
-	{
-		"hammerid" "118980"
-	}
-	replace:
-	{
-		"ajarangles" "0 315 0"
-	}
-}
-; --- Create our own custom case for spawning the escalators we want
-add:
-{
-	"classname" "logic_relay"
-	"targetname" "relay_elevator_path_custom"
-	"origin" "1280 -3328 9"
-	"StartDisabled" "0"
-	"spawnflags" "0"
-	; --- Event - Lower floor - Spawn both
-	"OnTrigger" "escalator_lower_01*,FireUser1,,0,-1"
-	"OnTrigger" "escalator_lower_02*,FireUser1,,0,-1"
-	; --- Event - Upper floor - Spawn standard versus path
-	"OnTrigger" "escalator_upper_01*,FireUser1,,0,-1"
-	; --- Saferoom - Lower floor - Spawn escalator leading away from the upper escalators
-	"OnTrigger" "escalator_lower_04*,FireUser1,,0,-1"
-	; --- Saferoom - Upper floor - Spawn standard versus path
-	"OnTrigger" "escalator_upper_03*,FireUser1,,0,-1"
-}
-modify:
-{
-	match:
-	{
-		"targetname" "relay_director_set_paths"
-	}
-	delete:
-	{
-		"OnTrigger" "director_query_elevator_pathHowAngry01"
-	}
-	insert:
-	{
-		"OnTrigger" "relay_elevator_path_custom,Trigger,,0,-1"
-	}
-}
-; --- Remove other relay for setting paths as a precaution (the trigger for it seems to be missing)
-filter:
-{
-	"targetname" "relay_director_set_paths2"
-}
-; --- Remove items on the upper path
-; --- Keep the items in the Just For Kidz area so survivors can still choose to shop for items/ammo
-; --- Room opposite to Just For Kidz pill room
-{
-	"hammerid" "1549716"
-}
-{
-	"hammerid" "1549729"
-}
-{
-	"hammerid" "1313698"
-}
-; --- Bathroom items
-{
-	"hammerid" "321240"
-}
-{
-	"hammerid" "321242"
-}
-{
-	"hammerid" "321244"
-}
-{
-	"hammerid" "321246"
-}
-{
-	"hammerid" "321238"
-}
-{
-	"hammerid" "321236"
-}
-{
-	"hammerid" "321316"
-}
-{
-	"hammerid" "321318"
-}
-{
-	"hammerid" "321314"
-}
-{
-	"hammerid" "321310"
-}
-{
-	"hammerid" "321312"
-}
-; --- Room opposite to bathrooms
-{
-	"hammerid" "1551939"
-}
-{
-	"hammerid" "1551926"
 }
 
 
@@ -218,18 +60,7 @@ modify:
 		"weapon_selection" "any_smg"
 	}
 }
-; --- Move the pill cabinet on the lower route to the other side of the wall
-{
-	match:
-	{
-		"hammerid" "354455"
-	}
-	replace:
-	{
-		"origin" "880 -2457 0.224243"
-		"angles" "0 180 0"
-	}
-}
+
 
 ; =====================================================
 ; ==                STATIC AMMO PILES                ==
@@ -260,11 +91,11 @@ modify:
 	}
 }
 add:
-; --- Ammo pile on boxes near the start of the path leading to the event
+; --- Ammo pile in stairwell in offices before event
 {
 	"classname" "weapon_ammo_spawn"
-	"origin" "746 -681 32"
-	"angles" "0 90 0"
+	"origin" "538 -566 88"
+	"angles" "0 30 0"
 	"model" "models/props/terror/ammo_stack.mdl"
 	"solid" "6"
 	"disableshadows" "1"
@@ -287,7 +118,7 @@ add:
 ; ==                 HITTABLE CHANGES                ==
 ; ==           Add/remove/modify hittables           ==
 ; =====================================================
-; --- Move the hand truck at the start of the event path to a less obtrusive position
+; --- Move the hand truck at the start of the event path to a less obstructive position
 modify:
 {
 	match:
@@ -341,6 +172,38 @@ add:
 ; ==                 NUISANCE CHANGES                ==
 ; ==      Clipping improvements, QOL map changes     ==
 ; =====================================================
+; --- Clipping to eliminate need to jump into tall shelves by the saferoom
+add:
+{
+	"classname" "env_physics_blocker"
+	"origin" "6331 -1636.5 25.6"
+	"mins" "-112 -0.5 -2"
+	"maxs" "112 0.5 2"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "7185.55 -1796.55 25.6"
+	"angles" "0 135 0"
+	"mins" "-112 -0.5 -2"
+	"maxs" "112 0.5 2"
+	"boxmins" "-112 -0.5 -2"
+	"boxmaxs" "112 0.5 2"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "7424.45 -2035.45 25.6"
+	"angles" "0 135 0"
+	"mins" "-112 -0.5 -2"
+	"maxs" "112 0.5 2"
+	"boxmins" "-112 -0.5 -2"
+	"boxmaxs" "112 0.5 2"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Make the office chair used for the return shortcut solid
 modify:
 {
@@ -353,6 +216,36 @@ modify:
 		"spawnflags" "256"
 	}
 }
+; --- Fix event trigger doors on the lower route opening slowly
+modify:
+{
+	match:
+	{
+		"targetname" "door_hallway_lower4"
+	}
+	replace:
+	{
+		"speed" "200"
+	}
+	delete:
+	{
+		"OnOpen" "!selfSetSpeed1000.1-1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "door_hallway_lower4a"
+	}
+	replace:
+	{
+		"speed" "200"
+	}
+	delete:
+	{
+		"OnOpen" "!selfSetSpeed1000.1-1"
+	}
+}
 ; --- Remove glass that looks like leftover beta content hiding inside another glass panel
 filter:
 {
@@ -360,6 +253,7 @@ filter:
 }
 ; --- Remove some glass panels around the event to help infected
 ; --- Glass by main escalator
+filter:
 {
 	"hammerid" "1663586"
 }
@@ -482,178 +376,66 @@ filter:
 ; ==       New props for balance and SI spawns       ==
 ; =====================================================
 add:
-; --- Fence cover prop immediately outside saferoom
+; --- Shelves by second set of escalators behind the collapsed gate
 {
 	"classname" "prop_dynamic"
-	"origin" "6708 -1748 -18"
-	"angles" "0 97.5 0"
-	"model" "models/props_urban/fence_cover001_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Fence cover prop by the collapsed gate after the first set of escalators
-{
-	"classname" "prop_dynamic"
-	"origin" "5196 -2585 280"
-	"angles" "0 75 0"
+	"origin" "5134 -2376 280"
+	"angles" "0 155.5 0"
 	"model" "models/props_mall/mall_display_07.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
-{
-	"classname" "env_physics_blocker"
-	"origin" "5196 -2585 428"
-	"angles" "0 75 0"
-	"mins" "-18 -48 -60"
-	"maxs" "18 48 60"
-	"boxmins" "-18 -48 -60"
-	"boxmaxs" "18 48 60"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Fence cover props in front of the escalators on the far side in the second escalator room
+; --- Boxes by fences by second set of escalators
 {
 	"classname" "prop_dynamic"
-	"origin" "3598 -2691 280"
-	"angles" "0 39 0"
-	"model" "models/props_mall/mall_display_07.mdl"
+	"origin" "3629 -2480 280"
+	"angles" "0 113.5 0"
+	"model" "models/props/cs_militia/boxes_garage_lower.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
-{
-	"classname" "env_physics_blocker"
-	"origin" "3598 -2691 428"
-	"angles" "0 39 0"
-	"mins" "-18 -48 -60"
-	"maxs" "18 48 60"
-	"boxmins" "-18 -48 -60"
-	"boxmaxs" "18 48 60"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Fence cover prop in the dark area in the second escalator room
+; --- Additional kiosks after second set of escalators
 {
 	"classname" "prop_dynamic"
-	"origin" "2928 -2814 280"
-	"angles" "0 136.5 0"
-	"model" "models/props_mall/mall_display_07.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "2928 -2814 428"
-	"angles" "0 136.5 0"
-	"mins" "-18 -48 -60"
-	"maxs" "18 48 60"
-	"boxmins" "-18 -48 -60"
-	"boxmaxs" "18 48 60"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Fence cover prop on the right after going down second set of escalators
-{
-	"classname" "prop_dynamic"
-	"origin" "3703 -2285 0"
-	"angles" "0 129 0"
-	"model" "models/props_mall/mall_display_07.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "3703 -2285 148"
-	"angles" "0 129 0"
-	"mins" "-18 -48 -60"
-	"maxs" "18 48 60"
-	"boxmins" "-18 -48 -60"
-	"boxmaxs" "18 48 60"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Fence cover prop in front after going down second set of escalators
-{
-	"classname" "prop_dynamic"
-	"origin" "3167 -2707 0"
-	"angles" "0 189.5 0"
-	"model" "models/props_mall/mall_display_07.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "3167 -2707 148"
-	"angles" "0 189.5 0"
-	"mins" "-18 -48 -60"
-	"maxs" "18 48 60"
-	"boxmins" "-18 -48 -60"
-	"boxmaxs" "18 48 60"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Fence cover prop to the left of the drop leading to the event path
-{
-	"classname" "prop_dynamic"
-	"origin" "1778 -1144 280"
-	"angles" "0 264 0"
-	"model" "models/props_mall/mall_display_07.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "1778 -1144 428"
-	"angles" "0 264 0"
-	"mins" "-18 -48 -60"
-	"maxs" "18 48 60"
-	"boxmins" "-18 -48 -60"
-	"boxmaxs" "18 48 60"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Props to separate the open area before the drop leading to the event
-{
-	"classname" "prop_dynamic"
-	"origin" "2272 -1680 251"
-	"angles" "0 0 0"
-	"model" "models/props_mall/mall_column_large.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "2220.12 -1736.43 280"
-	"angles" "0 150 0"
-	"model" "models/props_mall/mall_display_07.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "2220.12 -1736.43 424"
-	"angles" "0 -30 0"
-	"mins" "-16 -48 -64"
-	"maxs" "16 48 64"
-	"boxmins" "-16 -48 -64"
-	"boxmaxs" "16 49 64"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "2192 -1899 280"
+	"origin" "2694.03 -2553.97 0"
 	"angles" "0 180 0"
-	"model" "models/props_mall/mall_display_08.mdl"
+	"model" "models/props_mall/mall_kioskc.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Kiosks in dark area before drop into the offices
+{
+	"classname" "prop_dynamic"
+	"origin" "2268 -1514 280"
+	"angles" "0 90 0"
+	"model" "models/props_mall/mall_kioskc.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "2268 -1627 280"
+	"angles" "0 270 0"
+	"model" "models/props_mall/mall_kioskc.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
 {
 	"classname" "env_physics_blocker"
-	"origin" "2192 -1899 448"
-	"mins" "-18 -112 -40"
-	"maxs" "18 112 40"
+	"origin" "2268 -1570.5 384"
+	"mins" "-43 -107.5 -104"
+	"maxs" "43 107.5 104"
 	"initialstate" "1"
 	"BlockType" "1"
+}
+; --- Shelves by fences before drop into the offices
+{
+	"classname" "prop_dynamic"
+	"origin" "1836 -1293 280"
+	"angles" "0 90 0"
+	"model" "models/props_mall/mall_display_07.mdl"
+	"solid" "6"
+	"disableshadows" "1"
 }
 ; --- Desk to block survivors from standing in a safe on the drop to the event path
 {
@@ -690,25 +472,14 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Fence cover props at the entrance of the final area after the event
+; --- Shelves at the entrance of the saferoom escalator room
 {
 	"classname" "prop_dynamic"
-	"origin" "-91 -4425 280"
-	"angles" "0 67.5 0"
+	"origin" "-107 -4463 280"
+	"angles" "0 247 0"
 	"model" "models/props_mall/mall_display_07.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-91 -4425 428"
-	"angles" "0 67.5 0"
-	"mins" "-18 -48 -60"
-	"maxs" "18 48 60"
-	"boxmins" "-18 -48 -60"
-	"boxmaxs" "18 48 60"
-	"initialstate" "1"
-	"BlockType" "1"
 }
 ; --- Kiosk on floor below the end saferoom
 {
@@ -813,213 +584,296 @@ modify:
 
 ; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
 ; =====================================================
-; ==              SAFEROOM ROUTE REWORK              ==
-; ==   Make the route to the saferoom to be longer   ==
+; ==                LOWER EVENT PATH                 ==
+; ==  Use the lower route for the path to the event  ==
 ; =====================================================
+; --- Remove the original logic for determining the path leading to the event
+filter:
+{
+	"hammerid" "196210"
+}
+{
+	"targetname" "compare_minifinale"
+}
+; --- Force survivors to always take the lower path leading to the event
 add:
-; --- Block going immediately left through the fences after the under construction area
 {
-	"classname" "prop_dynamic"
-	"origin" "-760 -4689 280"
-	"angles" "0 166 0"
-	"model" "models/props_fortifications/barricade001_128_reference.mdl"
-	"solid" "6"
-	"disableshadows" "1"
+	"classname" "logic_auto"
+	"OnMapSpawn" "relay_hallway_close,Trigger,,0,-1"
 }
-; --- Shelves to block going directly to the escalator
+; --- Force the specific set of escalators we want to spawn for the event
+add:
 {
-	"classname" "prop_dynamic"
-	"origin" "-960 -4128 280"
-	"angles" "0 270 0"
-	"model" "models/props_mall/mall_display_08.mdl"
-	"solid" "6"
-	"disableshadows" "1"
+	"classname" "logic_auto"
+	; --- Event - Lower floor - Spawn both
+	"OnMapSpawn" "escalator_lower_01*,FireUser1,,0,-1"
+	"OnMapSpawn" "escalator_lower_02*,FireUser1,,0,-1"
+	; --- Event - Upper floor - Spawn standard versus path
+	"OnMapSpawn" "escalator_upper_01*,FireUser1,,0,-1"
 }
+; --- Remove relay on lower path that sets the escalator positions when the doors that trigger the event are opened
+filter:
 {
-	"classname" "prop_dynamic"
-	"origin" "-900 -4124 409"
-	"angles" "0 90 0"
-	"model" "models/props_fortifications/barricade_razorwire001_128_reference.mdl"
-	"solid" "6"
-	"disableshadows" "1"
+	"targetname" "relay_director_set_paths"
 }
+; --- Remove an unused relay for setting paths from the lower path
 {
-	"classname" "prop_dynamic"
-	"origin" "-1020 -4124 409"
-	"angles" "0 90 0"
-	"model" "models/props_fortifications/barricade_razorwire001_128_reference.mdl"
-	"solid" "6"
-	"disableshadows" "1"
+	"targetname" "relay_director_set_paths2"
+}
+; --- Remove a trigger on the upper path that sets the escalator positions
+{
+	"hammerid" "221997"
+}
+; --- Open up the Just For Kidz store so tanks don't need to use the vent, survivors can still go to this area but the path back remains blocked
+filter:
+{
+	"targetname" "trigger_glass_breakable"
 }
 {
-	"classname" "prop_dynamic"
-	"origin" "-861 -4122 283"
-	"angles" "0 195 0"
-	"model" "models/deadbodies/cemetary/pose_c.mdl"
-	"solid" "0"
-	"disableshadows" "1"
+	"targetname" "brush_shop_blocked"
 }
 {
-	"classname" "env_physics_blocker"
-	"origin" "-960 -4128 635"
-	"mins" "-112 -18 -227"
-	"maxs" "112 18 227"
-	"initialstate" "1"
-	"BlockType" "1"
+	"targetname" "breakble_glass_minifinale"
 }
 {
+	"targetname" "nav_blocker_storefront"
+}
+{
+	"targetname" "window_glow"
+}
+{
+	"targetname" "instructor_window"
+}
+{
+	"targetname" "filter_breakglass"
+}
+{
+	"targetname" "filter_melee"
+}
+{
+	"targetname" "filter_invunerable"
+}
+{
+	"targetname" "trigger_glass_breakable"
+}
+{
+	"targetname" "prop_door_mallshop_straight"
+}
+; --- Close the partially open door before the store
+modify:
+{
+	match:
+	{
+		"hammerid" "118980"
+	}
+	replace:
+	{
+		"spawnpos" "0"
+	}
+}
+; --- Remove item spawns on the upper path
+filter:
+; --- Just For Kidz store items
+;{
+;	"hammerid" "8569913" ; --- Ammo pile on table
+;}
+{
+	"hammerid" "354419"
+}
+{
+	"hammerid" "8569915"
+}
+{
+	"hammerid" "8569911"
+}
+; --- Room opposite to Just For Kidz pill room
+{
+	"hammerid" "1549716"
+}
+{
+	"hammerid" "1549729"
+}
+{
+	"hammerid" "1313698"
+}
+; --- Bathroom items
+{
+	"hammerid" "321240"
+}
+{
+	"hammerid" "321242"
+}
+{
+	"hammerid" "321244"
+}
+{
+	"hammerid" "321246"
+}
+{
+	"hammerid" "321238"
+}
+{
+	"hammerid" "321236"
+}
+{
+	"hammerid" "321316"
+}
+{
+	"hammerid" "321318"
+}
+{
+	"hammerid" "321314"
+}
+{
+	"hammerid" "321310"
+}
+{
+	"hammerid" "321312"
+}
+; --- Room opposite to bathrooms
+{
+	"hammerid" "1551939"
+}
+{
+	"hammerid" "1551926"
+}
+
+; =====================================================
+; ==              SAFEROOM ROUTE REWORK              ==
+; ==       Extend the path to the end saferoom       ==
+; =====================================================
+; --- Modify map logic so the escalators are always spawned
+add:
+{
+	"classname" "logic_auto"
+	; --- Lower floor - Spawn escalator set facing towards the saferoom
+	"OnMapSpawn" "escalator_lower_04*,FireUser1,,0,-1"
+	; --- Upper floor - Spawn escalators leading to saferoom
+	"OnMapSpawn" "escalator_upper_03*,FireUser1,,1,-1"
+}
+modify:
+{
+	match:
+	{
+		"hammerid" "1310675"
+	}
+	delete:
+	{
+		"OnMapSpawn" "escalator_upper_03-liftDisableCollision0-1"
+	}
+}
+; --- Move the escalator by the end saferoom over the hole
+{
+	match:
+	{
+		"targetname" "escalator_upper_03-lift"
+	}
+	replace:
+	{
+		"origin" "-1404 -4281 381.669"
+	}
+	delete:
+	{
+		"OnUser1" "escalator_upper_03-railing_breakableKill0-1"
+		"OnUser1" "escalator_upper_03-navblockerUnblockNav0-1"
+		"OnUser1" "escalator_upper_03-railingDisable0-1"
+		"OnUser1" "escalator_upper_03-navblocker_blockBlockNav0-1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "escalator_03-brush_lift_collision"
+	}
+	replace:
+	{
+		"origin" "-1403.99 -4258.01 409.1"
+	}
+}
+; --- Remove glass at top and bottom of new escalator position
+filter:
+{
+	"hammerid" "661312"
+}
+{
+	"hammerid" "661724"
+}
+; -- Add fences to block the short path to the escalator
+add:
+{
 	"classname" "prop_dynamic"
-	"origin" "-684 -4204 280"
+	"origin" "-1125 -3957 280"
 	"angles" "0 0 0"
-	"model" "models/props_mall/mall_display_08.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-692 -4144 409"
-	"angles" "0 180 0"
-	"model" "models/props_fortifications/barricade_razorwire001_128_reference.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-692 -4264 409"
-	"angles" "0 180 0"
-	"model" "models/props_fortifications/barricade_razorwire001_128_reference.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-684 -4204 448"
-	"mins" "-18 -112 -40"
-	"maxs" "18 112 40"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Fences to block going directly to the escalator
-{
-	"classname" "prop_dynamic"
-	"origin" "-680 -4032 280"
-	"angles" "0 165 0"
-	"model" "models/props_fortifications/barricade001_128_reference.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-671 -4034 456"
-	"angles" "0 165 0"
-	"mins" "-8 -48 -32"
-	"maxs" "8 48 32"
-	"boxmins" "-8 -48 -32"
-	"boxmaxs" "8 48 32"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-668 -3928 280"
-	"angles" "0 180 0"
 	"model" "models/props_fortifications/barricade001_128_reference.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
 {
 	"classname" "prop_dynamic"
-	"origin" "-668 -3820 280"
-	"angles" "0 180 0"
+	"origin" "-1120 -3876 280"
+	"angles" "0 1 0"
+	"model" "models/props_fortifications/barricade001_64_reference.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-1118 -3798 280"
+	"angles" "0 5 0"
 	"model" "models/props_fortifications/barricade001_128_reference.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
 {
+	"classname" "prop_dynamic"
+	"origin" "-1181.9 -3991 280"
+	"angles" "0 268 0"
+	"model" "models/props_fortifications/barricade001_64_reference.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
 	"classname" "env_physics_blocker"
-	"origin" "-659 -3874 456"
-	"mins" "-8 -102 -32"
-	"maxs" "8 102 32"
+	"origin" "-1166.5 -4013 353"
+	"mins" "-39.5 -3 -72"
+	"maxs" "39.5 3 72"
 	"initialstate" "1"
 	"BlockType" "1"
+	"targetname" "saferoom_barricade_blocker1"
 }
-; --- Fences on construction lift to block jumping around
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1234.5 -4013 353"
+	"mins" "-28.5 -3 -72"
+	"maxs" "28.5 3 72"
+	"initialstate" "1"
+	"BlockType" "1"
+	"targetname" "saferoom_barricade_blocker2"
+}
+; --- Trigger to remove the extended part of the blocker once survivors reach the escalator
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "saferoom_barricade_trigger,AddOutput,mins -16 -208 -96,0,-1"
+	"OnMapSpawn" "saferoom_barricade_trigger,AddOutput,maxs 16 208 96,0,-1"
+	"OnMapSpawn" "saferoom_barricade_trigger,AddOutput,boxmins -16 -208 -96,0,-1"
+	"OnMapSpawn" "saferoom_barricade_trigger,AddOutput,boxmaxs 16 208 96,0,-1"
+	"OnMapSpawn" "saferoom_barricade_trigger,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "trigger_once"
+	"origin" "-1472 -3888 376"
+	"targetname" "saferoom_barricade_trigger"
+	"filtername" "filter_survivor"
+	"spawnflags" "1"
+	; --- Trigger event output here
+	"OnTrigger" "saferoom_barricade_blocker2,Kill,,0,-1"
+}
+; --- Kiosk where the original escalators were before the end saferoom
 {
 	"classname" "prop_dynamic"
-	"origin" "-1139 -4176 249"
+	"origin" "-840 -4222 280"
 	"angles" "0 270 0"
-	"model" "models/props_exteriors/roadsidefence_64.mdl"
+	"model" "models/props_mall/mall_kioskc.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-1139 -4176 572"
-	"mins" "-33 -3 -290"
-	"maxs" "33 3 290"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-1167 -4208 249"
-	"angles" "0 0 0"
-	"model" "models/props_exteriors/roadsidefence_64.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-1168 -4209 572"
-	"mins" "-4 -31 -290"
-	"maxs" "4 31 290"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Dead body on construction lift
-{
-	"classname" "prop_dynamic"
-	"origin" "-1171 -4276 278"
-	"angles" "0 165 0"
-	"model" "models/deadbodies/common_worker_male01_fence01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-; --- Additional clipping to prevent gaps survivors can go through
-{
-	"classname" "env_physics_blocker"
-	"origin" "-1089 -4128 572"
-	"mins" "-16 -18 -290"
-	"maxs" "16 18 290"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-1103 -4163 572"
-	"mins" "-2 -16 -290"
-	"maxs" "2 16 290"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; ---  Infected ladders to climb over the shelves
-{
-	"classname" "func_simpleladder"
-	"origin" "-389.93 -1136.49 23"
-	"angles" "0 315 0"
-	"model" "*172"
-	"normal.x" "0.00"
-	"normal.y" "-1.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
-{
-	"classname" "func_simpleladder"
-	"origin" "-1528.06 -7119.5 23"
-	"angles" "0 135 0"
-	"model" "*172"
-	"normal.x" "0.00"
-	"normal.y" "1.00"
-	"normal.z" "0.00"
-	"team" "2"
 }

--- a/cfg/stripper/zonemod/maps/c1m4_atrium.cfg
+++ b/cfg/stripper/zonemod/maps/c1m4_atrium.cfg
@@ -331,10 +331,10 @@ add:
 {
 	"classname" "env_physics_blocker"
 	"origin" "-6247 -3354 736"
-	"mins" "-175 -134 -3"
-	"maxs" "175 134 3"
-	"boxmins" "-175 -134 -3"
-	"boxmaxs" "175 134 3"
+	"mins" "-175 -134 -8"
+	"maxs" "175 134 8"
+	"boxmins" "-175 -134 -8"
+	"boxmaxs" "175 134 8"
 	"initialstate" "1"
 	"BlockType" "4"
 }
@@ -486,7 +486,7 @@ add:
 ; ==             LADDER / ELEVATOR NERF              ==
 ; ==   Nerf ladder & elevator attacks for infected   ==
 ; =====================================================
-; --- Add a railing elevator so survivors can stand on it
+; --- Add a railing in the elevator so survivors can stand on it
 add:
 {
 	"classname" "prop_dynamic"

--- a/cfg/stripper/zonemod/maps/c2m1_highway.cfg
+++ b/cfg/stripper/zonemod/maps/c2m1_highway.cfg
@@ -572,6 +572,39 @@ add:
 ; ==      Clipping improvements, QOL map changes     ==
 ; =====================================================
 add:
+; --- Ledge for infected to jump to on interstate sign outside saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "8720 7798 -367"
+	"mins" "-20 -3 -6"
+	"maxs" "20 3 6"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "8720 7800 -351"
+	"mins" "-20 -3 -3"
+	"maxs" "20 3 3"
+	"initialstate" "1"
+	"BlockType" "2"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "8711.55 7801 -359"
+	"angles" "0 90 -180"
+	"model" "models/gibs/metal_gib2.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "8728 7801 -359"
+	"angles" "0 90 -180"
+	"model" "models/gibs/metal_gib2.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
 ; --- Clipping on car window in the middle saferoom path to stop players getting stuck
 {
 	"classname" "env_physics_blocker"
@@ -617,19 +650,52 @@ add:
 	"disableshadows" "1"
 	"rendermode" "10"
 }
-; --- Make the door for the smoker pull down at the billboard start open
-modify:
+; --- Clipping on police car lights outside saferoom
 {
-	match:
-	{
-		"hammerid" "455654"
-	}
-	replace:
-	{
-		"spawnpos" "2"
-	}
+	"classname" "env_physics_blocker"
+	"origin" "7260.58 7073.06 -567.5"
+	"angles" "0 -15 0"
+	"mins" "-11 -23 -5.5"
+	"maxs" "11 23 5.5"
+	"boxmins" "-11 -23 -5.5"
+	"boxmaxs" "11 23 5.5"
+	"initialstate" "1"
+	"BlockType" "0"
 }
-add:
+{
+	"classname" "env_physics_blocker"
+	"origin" "7253.25 7075.37 -568"
+	"angles" "0 -15 0"
+	"mins" "-14 -16 -5"
+	"maxs" "14 16 5"
+	"boxmins" "-14 -16 -5"
+	"boxmaxs" "14 16 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Clipping on police car lights by the offramp
+{
+	"classname" "env_physics_blocker"
+	"origin" "6304.36 7036.45 -620.5"
+	"angles" "0 -3 0"
+	"mins" "-11 -23 -5.5"
+	"maxs" "11 23 5.5"
+	"boxmins" "-11 -23 -5.5"
+	"boxmaxs" "11 23 5.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "6296.71 7037.18 -621"
+	"angles" "0 -3 0"
+	"mins" "-14 -16 -5"
+	"maxs" "14 16 5"
+	"boxmins" "-14 -16 -5"
+	"boxmaxs" "14 16 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Add missing glass to vehicles
 {
 	"classname" "prop_dynamic"
@@ -646,6 +712,42 @@ add:
 	"model" "models/props_vehicles/longnose_truck_glass.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+; --- Block LOS under floating AC vents on the motel cafeteria roof
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "losfix_cafe_ac1,AddOutput,mins -71 -30.5 -1,0,-1"
+	"OnMapSpawn" "losfix_cafe_ac1,AddOutput,maxs 71 30.5 1,0,-1"
+	"OnMapSpawn" "losfix_cafe_ac1,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "losfix_cafe_ac2,AddOutput,mins -15 -30 -0.5,0,-1"
+	"OnMapSpawn" "losfix_cafe_ac2,AddOutput,maxs 15 30 0.5,0,-1"
+	"OnMapSpawn" "losfix_cafe_ac2,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "losfix_cafe_ac3,AddOutput,mins -15 -30 -0.5,0,-1"
+	"OnMapSpawn" "losfix_cafe_ac3,AddOutput,maxs 15 30 0.5,0,-1"
+	"OnMapSpawn" "losfix_cafe_ac3,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "losfix_cafe_ac4,AddOutput,mins -15 -30 -0.5,0,-1"
+	"OnMapSpawn" "losfix_cafe_ac4,AddOutput,maxs 15 30 0.5,0,-1"
+	"OnMapSpawn" "losfix_cafe_ac4,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "func_brush"
+	"origin" "2481 5679.5 -767"
+	"targetname" "losfix_cafe_ac1"
+}
+{
+	"classname" "func_brush"
+	"origin" "2640 5844 -767.5"
+	"targetname" "losfix_cafe_ac2"
+}
+{
+	"classname" "func_brush"
+	"origin" "2080 5796 -799.5"
+	"targetname" "losfix_cafe_ac3"
+}
+{
+	"classname" "func_brush"
+	"origin" "1760 5796 -799.5"
+	"targetname" "losfix_cafe_ac4"
 }
 ; --- Clip off car stops to prevent players getting stuck
 {
@@ -761,17 +863,46 @@ add:
 	"spawnflags" "1"
 	"OnTrigger" "pool_fence_navblock,UnblockNav,,0,-1"
 }
-; --- Clipping on police car lights
+; --- Clipping on police car lights before the highway
+
 {
 	"classname" "env_physics_blocker"
-	"origin" "3412 3856 -941"
-	"angles" "0 150 0"
-	"mins" "-23 -11 -6"
-	"maxs" "23 11 6"
-	"boxmins" "-23 -11 -6"
-	"boxmaxs" "23 11 6"
+	"origin" "3413.41 3856.02 -940.5"
+	"angles" "0 60 0"
+	"mins" "-11 -23 -5.5"
+	"maxs" "11 23 5.5"
+	"boxmins" "-11 -23 -5.5"
+	"boxmaxs" "11 23 5.5"
 	"initialstate" "1"
 	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3409.29 3849.54 -941"
+	"angles" "0 60 0"
+	"mins" "-14 -16 -5"
+	"maxs" "14 16 5"
+	"boxmins" "-14 -16 -5"
+	"boxmaxs" "14 16 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Ledge for infected to climb on top of a tree on the highway before the one way drop
+{
+	"classname" "prop_dynamic_override"
+	"origin" "4083 4479 -763"
+	"angles" "0 329 90"
+	"model" "models/props_junk/wood_crate001a_chunk05.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4085 4498 -757"
+	"mins" "-11 -7 -3"
+	"maxs" "11 7 3"
+	"initialstate" "1"
+	"BlockType" "2"
 }
 ; --- Fences to show where skybox blocks off the motel roof
 {
@@ -870,7 +1001,107 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-
+; --- Roof trim to help with the crossing on the motel roof by the drop
+{
+	"classname" "prop_dynamic"
+	"origin" "795 3136 -646"
+	"angles" "0 180 0"
+	"model" "models/props_street/building_trim_piece02_512_damaged.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"fademindist" "1600"
+	"fademaxdist" "1800"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1299 3136 -646"
+	"angles" "0 180 0"
+	"model" "models/props_street/building_trim_piece02_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"fademindist" "1600"
+	"fademaxdist" "1800"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1563 3136 -646"
+	"angles" "0 180 0"
+	"model" "models/props_street/building_trim_piece02_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"fademindist" "1600"
+	"fademaxdist" "1800"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1691 3136 -646"
+	"angles" "0 180 0"
+	"model" "models/props_street/building_trim_piece02_512_damaged.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"fademindist" "1600"
+	"fademaxdist" "1800"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "2203 3136 -646"
+	"angles" "0 180 0"
+	"model" "models/props_street/building_trim_piece02_512_damaged.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"fademindist" "1600"
+	"fademaxdist" "1800"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "2715 3136 -646"
+	"angles" "0 180 0"
+	"model" "models/props_street/building_trim_piece02_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"fademindist" "1600"
+	"fademaxdist" "1800"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "2843 3136 -646"
+	"angles" "0 180 0"
+	"model" "models/props_street/building_trim_piece02_128.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"fademindist" "1600"
+	"fademaxdist" "1800"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "2971 3135 -657"
+	"angles" "0 90 0"
+	"model" "models/props_interiors/railing_trim_64.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+	"fademindist" "1600"
+	"fademaxdist" "1800"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "2907 3135 -657"
+	"angles" "0 90 0"
+	"model" "models/props_interiors/railing_trim_64.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+	"fademindist" "1600"
+	"fademaxdist" "1800"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "2843 3135 -657"
+	"angles" "0 90 0"
+	"model" "models/props_interiors/railing_trim_64.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+	"fademindist" "1600"
+	"fademaxdist" "1800"
+}
 
 ; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
 ; =====================================================
@@ -1074,44 +1305,59 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Shrubs in grassy area on street before one way drop
+; --- Shrub in grassy area on the highway before the one way drop
 {
 	"classname" "prop_dynamic"
-	"origin" "4234 4730 -969"
-	"angles" "-4.99065 3.51334 -0.306017"
-	"model" "models/props_foliage/swamp_shrubwall_block_512_deep.mdl"
+	"origin" "4294 4685 -912.99"
+	"angles" "-13.8104 329.01 8.15905"
+	"model" "models/props_foliage/swamp_shrubwall_block_128_deep.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4233 4685 -508"
+	"mins" "-23 -67 -276"
+	"maxs" "23 67 276"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4280 4685 -502"
+	"mins" "-24 -72 -270"
+	"maxs" "24 72 270"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4316 4682 -494"
+	"mins" "-12 -54 -262"
+	"maxs" "12 54 262"
+	"initialstate" "1"
+	"BlockType" "1"
 }
 ; --- Shrub by the drop after the highway
 {
 	"classname" "prop_dynamic"
-	"origin" "2817 2782 -1056"
+	"origin" "2789 2738 -1057.81"
 	"angles" "0 168 0"
 	"model" "models/props_foliage/swamp_shrubwall_block_256_deep.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Clipping above shrubs
 {
 	"classname" "env_physics_blocker"
-	"origin" "2811 2767 -656"
-	"mins" "-64 -78 -400"
-	"maxs" "64 78 400"
+	"origin" "2784 2715 -656"
+	"mins" "-64 -71 -400"
+	"maxs" "64 71 400"
 	"initialstate" "1"
 	"BlockType" "1"
 }
 {
 	"classname" "env_physics_blocker"
-	"origin" "2840 2873 -656"
-	"mins" "-23 -28 -400"
-	"maxs" "23 28 400"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "2790 2860 -656"
+	"origin" "2762 2816 -656"
 	"angles" "0 44 0"
 	"mins" "-50 -8 -400"
 	"maxs" "50 8 400"
@@ -1120,46 +1366,24 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Boards to assist with crossing around the skybox on the motel roof
 {
-	"classname" "prop_dynamic"
-	"origin" "2807 3130 -647"
-	"angles" "0 270 0"
-	"model" "models/lighthouse/props/wood_plank_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "2807 3118 -647"
-	"angles" "0 90 0"
-	"model" "models/lighthouse/props/wood_plank_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "2910 3130 -646.9"
-	"angles" "0 270 0"
-	"model" "models/lighthouse/props/wood_plank_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "2910 3118 -646.9"
-	"angles" "0 90 0"
-	"model" "models/lighthouse/props/wood_plank_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
+	"classname" "env_physics_blocker"
+	"origin" "2808 2848 -656"
+	"mins" "-16 -8 -400"
+	"maxs" "16 8 400"
+	"initialstate" "1"
+	"BlockType" "1"
 }
 {
 	"classname" "env_physics_blocker"
-	"origin" "2858.5 3124 -647"
-	"mins" "-115.5 -12 -1"
-	"maxs" "115.5 12 1.15"
+	"origin" "2827.49 2816.44 -656"
+	"angles" "0 110 0"
+	"mins" "-38 -8 -400"
+	"maxs" "38 8 400"
+	"boxmins" "-38 -8 -400"
+	"boxmaxs" "38 8 400"
 	"initialstate" "1"
-	"BlockType" "0"
+	"BlockType" "1"
 }
 ; --- Tree in back corner before the final hill
 {
@@ -1170,14 +1394,42 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Bus at the top of the hill before the end saferoom
+; --- Van at the top of the hill before the end saferoom
 {
 	"classname" "prop_dynamic"
-	"origin" "-40 -812 -1088"
-	"angles" "0 180 0"
-	"model" "models/props_vehicles/bus01_2.mdl"
+	"origin" "-107 -838 -1087"
+	"angles" "0 80 0"
+	"model" "models/props_vehicles/van.mdl"
 	"solid" "6"
 	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-107 -838 -1087"
+	"angles" "0 80 0"
+	"model" "models/props_vehicles/van_glass.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Block LOS under van
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "losfix_end_van_a,AddOutput,mins -106 -1 -11,0,-1"
+	"OnMapSpawn" "losfix_end_van_a,AddOutput,maxs 106 1 11,0,-1"
+	"OnMapSpawn" "losfix_end_van_a,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "losfix_end_van_b,AddOutput,mins -1 -33 -11,0,-1"
+	"OnMapSpawn" "losfix_end_van_b,AddOutput,maxs 1 33 11,0,-1"
+	"OnMapSpawn" "losfix_end_van_b,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "func_brush"
+	"origin" "-113 -825 -1079"
+	"targetname" "losfix_end_van_a"
+}
+{
+	"classname" "func_brush"
+	"origin" "-8 -859 -1079"
+	"targetname" "losfix_end_van_b"
 }
 ; --- Bus outside the end saferoom
 {
@@ -1188,12 +1440,9 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Block LOS under buses
+; --- Block LOS under bus
 {
 	"classname" "logic_auto"
-	"OnMapSpawn" "losfix_end_bus_a,AddOutput,mins -212 -1 -10,0,-1"
-	"OnMapSpawn" "losfix_end_bus_a,AddOutput,maxs 212 1 10,0,-1"
-	"OnMapSpawn" "losfix_end_bus_a,AddOutput,solid 2,0,-1"
 	"OnMapSpawn" "losfix_end_bus_b,AddOutput,mins -1 -93 -10,0,-1"
 	"OnMapSpawn" "losfix_end_bus_b,AddOutput,maxs 1 93 10,0,-1"
 	"OnMapSpawn" "losfix_end_bus_b,AddOutput,solid 2,0,-1"
@@ -1203,11 +1452,6 @@ add:
 	"OnMapSpawn" "losfix_end_bus_d,AddOutput,mins -1 -93 -10,0,-1"
 	"OnMapSpawn" "losfix_end_bus_d,AddOutput,maxs 1 93 10,0,-1"
 	"OnMapSpawn" "losfix_end_bus_d,AddOutput,solid 2,0,-1"
-}
-{
-	"classname" "func_brush"
-	"origin" "-47 -812 -1080"
-	"targetname" "losfix_end_bus_a"
 }
 {
 	"classname" "func_brush"
@@ -1412,27 +1656,7 @@ modify:
 	}
 }
 add:
-; --- Infected ladders to climb to the motel balcony before the drop
-{
-	"classname" "func_simpleladder"
-	"origin" "-2722 4507 122"
-	"angles" "0 270 0"
-	"model" "*139"
-	"normal.x" "0.00"
-	"normal.y" "-1.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
-{
-	"classname" "func_simpleladder"
-	"origin" "-2722 4507 -6"
-	"angles" "0 270 0"
-	"model" "*139"
-	"normal.x" "0.00"
-	"normal.y" "-1.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
+; --- Infected ladder to climb on the motel roof above the campsite
 {
 	"classname" "func_simpleladder"
 	"origin" "-3948 4507 122"
@@ -1452,32 +1676,6 @@ add:
 	"normal.y" "-1.00"
 	"normal.z" "0.00"
 	"team" "2"
-}
-; --- Infected clipping to help reach balcony
-{
-	"classname" "env_physics_blocker"
-	"origin" "2772 3128 -786"
-	"mins" "-18 -5 -20"
-	"maxs" "18 5 20"
-	"initialstate" "1"
-	"BlockType" "2"
-}
-; --- Props for ladder
-{
-	"classname" "prop_dynamic"
-	"origin" "2706 3134 -649"
-	"angles" "0 0 0"
-	"model" "models/props_rooftop/gutter_pipe_256.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "2706 3134 -905"
-	"angles" "0 0 0"
-	"model" "models/props_rooftop/gutter_pipe_256.mdl"
-	"solid" "0"
-	"disableshadows" "1"
 }
 {
 	"classname" "prop_dynamic"

--- a/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
+++ b/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
@@ -113,12 +113,20 @@ add:
 ; ==      Block intentionally performed exploits     ==
 ; =====================================================
 add:
-; --- Block standing on tents by the start saferoom
+; --- Block standing on tents by the starting saferoom
 {
 	"classname" "env_physics_blocker"
 	"origin" "1906 1092 456"
 	"mins" "-130 -64 -312.5"
 	"maxs" "130 64 312.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1372 1372 456"
+	"mins" "-64 -64 -312"
+	"maxs" "64 64 312"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -548,17 +556,17 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Block jumping on the buggies ride (can be re-enabled if angled blockers get fixed) (#34)
-;{
-;	"classname" "env_physics_blocker"
-;	"origin" "-1341 -1333 401"
-;	"angles" "0 10 0"
-;	"mins" "-106 -10 -367"
-;	"maxs" "106 10 367"
-;	"boxmins" "-106 -10 -367"
-;	"boxmaxs" "106 10 367"
-;	"initialstate" "1"
-;	"BlockType" "1"
+; --- Block jumping on the buggies ride
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1341 -1333 412"
+	"angles" "0 10 0"
+	"mins" "-106 -10 -367"
+	"maxs" "106 10 367"
+	"boxmins" "-106 -10 -367"
+	"boxmaxs" "106 10 367"
+	"initialstate" "1"
+	"BlockType" "1"
 }
 {
 	"classname" "env_physics_blocker"
@@ -568,18 +576,18 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Block jumping on the trains ride (can be re-enabled if angled blockers get fixed) (#34)
-;{
-;	"classname" "env_physics_blocker"
-;	"origin" "-2114 -564 401"
-;	"angles" "0 10 0"
-;	"mins" "-106 -10 -367"
-;	"maxs" "106 10 367"
-;	"boxmins" "-106 -10 -367"
-;	"boxmaxs" "106 10 367"
-;	"initialstate" "1"
-;	"BlockType" "1"
-;}
+; --- Block jumping on the trains ride
+{
+	"classname" "env_physics_blocker"
+	"origin" "-2114 -564 412"
+	"angles" "0 10 0"
+	"mins" "-106 -10 -367"
+	"maxs" "106 10 367"
+	"boxmins" "-106 -10 -367"
+	"boxmaxs" "106 10 367"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 {
 	"classname" "env_physics_blocker"
 	"origin" "-2176 -256 441"
@@ -659,6 +667,15 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+; --- Block standing on the telephone pole by the ladder
+{
+	"classname" "env_physics_blocker"
+	"origin" "-3850.5 -1165 520.5"
+	"mins" "-64.5 -28 -247.5"
+	"maxs" "64.5 28 247.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block standing on wooden supports for wall before the slide
 {
 	"classname" "env_physics_blocker"
@@ -711,14 +728,15 @@ add:
 	"BlockType" "1"
 }
 ; --- Block getting on the left platform at the one way drop - Removed while "Carousel Room" is open
-;{
-;	"classname" "env_physics_blocker"
-;	"origin" "-1916 -4160 392"
-;	"mins" "-132 -320 -376"
-;	"maxs" "132 320 376"
-;	"initialstate" "1"
-;	"BlockType" "1"
-;}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1916 -4160 392"
+	"mins" "-132 -320 -376"
+	"maxs" "132 320 376"
+	"initialstate" "1"
+	"BlockType" "1"
+	"targetname" "carousel_room_blocker"
+}
 ; --- Block jumping on the light post to common jump back up the one way drop
 {
 	"classname" "env_physics_blocker"
@@ -731,9 +749,9 @@ add:
 ; --- Block jumping on the ice machine to common jump back up the one way drop
 {
 	"classname" "env_physics_blocker"
-	"origin" "-3400 -4124 -86"
-	"mins" "-40 -28 -42.5"
-	"maxs" "40 28 42.5"
+	"origin" "-3400 -4124 -82"
+	"mins" "-40 -28 -46"
+	"maxs" "40 28 46"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -986,6 +1004,59 @@ modify:
 		"spawnflags" "1"
 	}
 }
+; --- Block LOS under the fences on the monorail track
+add:
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "monorail_back_fence_a,AddOutput,mins -257 -0.5 -2,0,-1"
+	"OnMapSpawn" "monorail_back_fence_a,AddOutput,maxs 257 0.5 2,0,-1"
+	"OnMapSpawn" "monorail_back_fence_a,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "monorail_back_fence_b,AddOutput,mins -257 -0.5 -2,0,-1"
+	"OnMapSpawn" "monorail_back_fence_b,AddOutput,maxs 257 0.5 2,0,-1"
+	"OnMapSpawn" "monorail_back_fence_b,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_a,AddOutput,mins -0.5 -128 -2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_a,AddOutput,maxs 0.5 128 2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_a,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_b,AddOutput,mins -0.5 -128 -2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_b,AddOutput,maxs 0.5 128 2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_b,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_c,AddOutput,mins -0.5 -128 -2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_c,AddOutput,maxs 0.5 128 2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_c,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_d,AddOutput,mins -0.5 -128 -2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_d,AddOutput,maxs 0.5 128 2,0,-1"
+	"OnMapSpawn" "monorail_slide_fence_d,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "func_brush"
+	"origin" "-1375 1160.5 135"
+	"targetname" "monorail_back_fence_a"
+}
+{
+	"classname" "func_brush"
+	"origin" "-1375 1272.5 135"
+	"targetname" "monorail_back_fence_b"
+}
+{
+	"classname" "func_brush"
+	"origin" "-1591.5 -2047.51 134"
+	"targetname" "monorail_slide_fence_a"
+}
+{
+	"classname" "func_brush"
+	"origin" "-1479.5 -2047.51 134"
+	"targetname" "monorail_slide_fence_b"
+}
+{
+	"classname" "func_brush"
+	"origin" "-1591.5 -2623.51 134"
+	"targetname" "monorail_slide_fence_c"
+}
+{
+	"classname" "func_brush"
+	"origin" "-1479.5 -2623.51 134"
+	"targetname" "monorail_slide_fence_c"
+}
 
 
 ; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
@@ -1076,15 +1147,6 @@ add:
 	"origin" "3066 -1760 2"
 	"angles" "0 0 0"
 	"model" "models/props_urban/fence_cover001_64.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Concrete block to spawn behind and jump over the fences by the warehouse entrance
-{
-	"classname" "prop_dynamic"
-	"origin" "3023 -1888 42"
-	"angles" "0 90 -45"
-	"model" "models/props_fortifications/concrete_block001_128_reference.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
@@ -1191,7 +1253,6 @@ add:
 	"solid" "0"
 	"disableshadows" "1"
 }
-; --- Clip to make pipe solid for infected
 {
 	"classname" "env_physics_blocker"
 	"origin" "-900 -1536 72"
@@ -1200,7 +1261,7 @@ add:
 	"initialstate" "1"
 	"BlockType" "2"
 }
-; --- Props under the slide pill room to make chipping through the fence more risky
+; --- Vending machine under the room before the one way drop
 {
 	"classname" "prop_dynamic"
 	"origin" "-2082 -3607 -128"
@@ -1271,23 +1332,6 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Fence under platforms before the carousel
-;{
-;	"classname" "prop_dynamic"
-;	"origin" "-1855 -4478 -121"
-;	"angles" "0 90 0"
-;	"model" "models/props_urban/fence001_128.mdl"
-;	"solid" "6"
-;	"disableshadows" "1"
-;}
-;{
-;	"classname" "prop_dynamic"
-;	"origin" "-1855 -4478 -121"
-;	"angles" "0 90 0"
-;	"model" "models/props_urban/fence_cover001_128.mdl"
-;	"solid" "6"
-;	"disableshadows" "1"
-;}
 ; --- Vending machine under platforms before the carousel - Removed due to "Carousel Room" being open
 ;{
 ;	"classname" "prop_dynamic"
@@ -1297,22 +1341,6 @@ add:
 ;	"solid" "6"
 ;	"disableshadows" "1"
 ;}
-; --- Hedge by the stairs leading to the end saferoom
-{
-	"classname" "prop_dynamic"
-	"origin" "-3071 -6180 -123"
-	"angles" "0 180 0"
-	"model" "models/props_foliage/urban_hedge_256_128_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"rendercolor" "218 200 184"
-	"lightingorigin" "hedge_lighting"
-}
-{
-	"classname" "info_target"
-	"origin" "-2924 -6274 -127"
-	"targetname" "hedge_lighting"
-}
 ; --- Tent after the stairs by the end saferoom
 {
 	"classname" "prop_dynamic"
@@ -1366,7 +1394,6 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Clipping on porta potties
 {
 	"classname" "env_physics_blocker"
 	"origin" "-3558 -5072 412"
@@ -2093,21 +2120,114 @@ add:
 	"origin" "1741 2854 156"
 	"targetname" "saferoom_roof_lighting1"
 }
-; --- Stop infected falling in the small gap
+; --- Fill in the gap at the back - Bottom
 {
-	"classname" "env_physics_blocker"
-	"origin" "1563 2787 160"
-	"mins" "-6 -223.5 -13"
-	"maxs" "6 223.5 13"
-	"initialstate" "1"
-	"BlockType" "0"
+	"classname" "prop_dynamic"
+	"origin" "1565 2654.05 156"
+	"angles" "0 0 90"
+	"model" "models/props_urban/concreteblock_corner001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"disablereceiveshadows" "1"
+	"rendercolor" "140 192 221"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1565 2746 156"
+	"angles" "0 0 90"
+	"model" "models/props_urban/concreteblock_corner001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"disablereceiveshadows" "1"
+	"rendercolor" "140 192 221"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1565 2838 156"
+	"angles" "0 0 90"
+	"model" "models/props_urban/concreteblock_corner001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"disablereceiveshadows" "1"
+	"rendercolor" "140 192 221"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1565 2930 156"
+	"angles" "0 0 90"
+	"model" "models/props_urban/concreteblock_corner001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"disablereceiveshadows" "1"
+	"rendercolor" "140 192 221"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1565.05 3010 156"
+	"angles" "0 0 90"
+	"model" "models/props_urban/concreteblock_corner001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"disablereceiveshadows" "1"
+	"rendercolor" "140 192 221"
+}
+; --- Fill in the gap at the back - Top
+{
+	"classname" "prop_dynamic"
+	"origin" "1564.95 2653.95 165.05"
+	"angles" "0 0 90"
+	"model" "models/props_urban/concreteblock_corner001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"disablereceiveshadows" "1"
+	"rendercolor" "140 192 221"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1564.95 2746 164.95"
+	"angles" "0 0 90"
+	"model" "models/props_urban/concreteblock_corner001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"disablereceiveshadows" "1"
+	"rendercolor" "140 192 221"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1564.95 2838 164.95"
+	"angles" "0 0 90"
+	"model" "models/props_urban/concreteblock_corner001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"disablereceiveshadows" "1"
+	"rendercolor" "140 192 221"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1564.95 2930 164.95"
+	"angles" "0 0 90"
+	"model" "models/props_urban/concreteblock_corner001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"disablereceiveshadows" "1"
+	"rendercolor" "140 192 221"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "1565 3010 164.90"
+	"angles" "0 0 90"
+	"model" "models/props_urban/concreteblock_corner001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"disablereceiveshadows" "1"
+	"rendercolor" "140 192 221"
 }
 ; --- Clip the pipes
 {
 	"classname" "env_physics_blocker"
 	"origin" "1653 2786 177"
-	"mins" "-11 -31 -5"
-	"maxs" "11 31 5"
+	"mins" "-16 -36 -5"
+	"maxs" "16 36 5"
 	"initialstate" "1"
 	"BlockType" "0"
 }
@@ -2213,37 +2333,6 @@ modify:
 	{
 		"origin" "985.459 865.531 2"
 	}
-}
-; --- ITEMS
-add:
-; --- Add pistol/deagle and melee spawns to new area
-{
-	"classname" "weapon_spawn"
-	"origin" "1686 -278 33"
-	"angles" "0 259.5 -90"
-	"weapon_selection" "any_pistol"
-	"spawn_without_director" "1"
-	"solid" "6"
-	"disableshadows" "1"
-	"spawnflags" "2"
-	"count" "5"
-}
-{
-	"classname" "weapon_melee_spawn"
-	"origin" "1208 296 32"
-	"angles" "0 60 -90"
-	"melee_weapon" "any"
-	"spawn_without_director" "1"
-	"solid" "0"
-	"disableshadows" "1"
-	"spawnflags" "2"
-	"count" "1"
-}
-; --- Add a potential pill spawn on one of the game buildings
-{
-	"classname" "weapon_pain_pills_spawn"
-	"origin" "1341 -74 42"
-	"angles" "0 0 0"
 }
 
 ; =====================================================
@@ -2411,7 +2500,7 @@ add:
 	"spawnflags" "0"
 	"targetname" "carouselroom_lights"
 }
-; --- Trigger to turn lights on
+; --- Trigger to turn lights on and remove blocker on the platform
 {
 	"classname" "logic_auto"
 	"OnMapSpawn" "carouselroom_lights_trigger,AddOutput,mins -64 -16 -72,0,-1"
@@ -2428,6 +2517,7 @@ add:
 	"filtername" "survivor_filter"
 	"spawnflags" "1"
 	"OnTrigger" "carouselroom_lights,TurnOn,,0,-1"
+	"OnTrigger" "carousel_room_blocker,Kill,,0,-1"
 }
 
 ; =====================================================

--- a/cfg/stripper/zonemod/maps/c2m3_coaster.cfg
+++ b/cfg/stripper/zonemod/maps/c2m3_coaster.cfg
@@ -17,7 +17,7 @@ add:
 ; ==           PILL / ITEM / WEAPON SPAWNS           ==
 ; ==   Remove or change pill, item & weapon spawns   ==
 ; =====================================================
-; --- Make the gun spawns on the table at the tunnel of love exit always spawn different types
+; --- Make the gun spawns on the table at the tunnel of love exit always spawn an SMG and shotgun
 modify:
 {
 	match:
@@ -69,12 +69,12 @@ add:
 ; ==                STATIC AMMO PILES                ==
 ; ==          Add or modify ammo pile spawns         ==
 ; =====================================================
-; --- Add an ammo pile by the second tunnel of love painting
+; --- Add an ammo pile in the side room by the collapsed pipe in the tunnel of love
 add:
 {
 	"classname" "weapon_ammo_spawn"
-	"origin" "3125 2939 -8"
-	"angles" "0 0 0"
+	"origin" "2221 2895 -4"
+	"angles" "0 285 0"
 	"model" "models/props/terror/ammo_stack.mdl"
 	"solid" "6"
 	"disableshadows" "1"
@@ -144,6 +144,24 @@ add:
 	"origin" "676 4842 219"
 	"mins" "-27 -23 -101"
 	"maxs" "27 23 101"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on the electrial box next to the water tank in the swan room
+{
+	"classname" "env_physics_blocker"
+	"origin" "553 4859.5 221"
+	"mins" "-28 -4.5 -84"
+	"maxs" "28 4.5 84"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on the infected ladder by the console in the swan room
+{
+	"classname" "env_physics_blocker"
+	"origin" "501 4865 189"
+	"mins" "-16 -2 -37"
+	"maxs" "16 2 37"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -533,6 +551,15 @@ add:
 ; ==  Prevent players from getting stuck in the map  ==
 ; =====================================================
 add:
+; --- Fix a sliding stuck spot by the console in the swan room
+{
+	"classname" "env_physics_blocker"
+	"origin" "436 4846 145"
+	"mins" "-4 -1 -19"
+	"maxs" "4 1 19"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Block a stuck spot before the coaster one way drop, between some hedges and support beams
 {
 	"classname" "env_physics_blocker"
@@ -1428,20 +1455,4 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 	"skin" "1"
-}
-; --- Extend the middle railings to the wall
-{
-	"classname" "prop_dynamic"
-	"origin" "-5251.63 1940.39 4.25"
-	"angles" "0 180 0"
-	"model" "models/props_urban/wood_railing001_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "end_railing_lighting"
-}
-; --- Fix lighting origin
-{
-	"classname" "info_target"
-	"origin" "-5252 1812 4"
-	"targetname" "end_railing_lighting"
 }

--- a/cfg/stripper/zonemod/maps/c2m4_barns.cfg
+++ b/cfg/stripper/zonemod/maps/c2m4_barns.cfg
@@ -91,10 +91,10 @@ filter:
 ; ==          Add or modify ammo pile spawns         ==
 ; =====================================================
 add:
-; --- Ammo pile after bumper cars section
+; --- Ammo pile in the bumper cars area
 {
 	"classname" "weapon_ammo_spawn"
-	"origin" "431 1990 -192"
+	"origin" "1547 1399 -148"
 	"angles" "0 180 0"
 	"model" "models/props/terror/ammo_stack.mdl"
 	"solid" "6"
@@ -217,6 +217,32 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+; --- Block standing on the first set of tents outside the saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "2483 2497 544"
+	"mins" "-66.5 -129 -608"
+	"maxs" "66.5 129 608"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2778 2432 544"
+	"mins" "-66.5 -64 -608"
+	"maxs" "66.5 64 608"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on the food cart by the tends outside the saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "2816 2568 490"
+	"mins" "-107 -53 -534"
+	"maxs" "107 53 534"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block standing on the food carts by the coaster entrance
 {
 	"classname" "env_physics_blocker"
@@ -335,45 +361,46 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Block standing on the hedges at the barns exit
-{
-	"classname" "prop_dynamic"
-	"origin" "136 256 -112"
-	"angles" "0 180 0"
-	"model" "models/props_foliage/urban_hedge_256_128_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "272 128 -112"
-	"angles" "0 90 0"
-	"model" "models/props_foliage/urban_hedge_256_128_high.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
+; --- Block standing on the hedges outside the barn exit
 {
 	"classname" "env_physics_blocker"
-	"origin" "252 -220 416"
-	"mins" "-4 -452 -608"
-	"maxs" "4 452 608"
+	"origin" "12 256 480"
+	"mins" "-252 -24 -544"
+	"maxs" "252 24 544"
 	"initialstate" "1"
 	"BlockType" "1"
 }
 {
 	"classname" "env_physics_blocker"
-	"origin" "139 256 530"
-	"mins" "-125 -22 -494"
-	"maxs" "125 22 494"
+	"origin" "253 -210 416"
+	"mins" "-3 -462 -608"
+	"maxs" "3 462 608"
 	"initialstate" "1"
 	"BlockType" "1"
 }
 ; --- Block standing on shrub walls next to the barn
 {
 	"classname" "env_physics_blocker"
-	"origin" "-1032 -669 532"
-	"mins" "-1216 -4 -492"
-	"maxs" "1216 4 492"
+	"origin" "-1320 -669 532"
+	"mins" "-1504 -4 -492"
+	"maxs" "1504 4 492"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-2368 -669 -76"
+	"mins" "-1 -4 -116"
+	"maxs" "1 4 116"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on a fence near the barn one way drop
+{
+	"classname" "env_physics_blocker"
+	"origin" "-2819.5 -591.5 416"
+	"mins" "-4.5 -80.5 -608"
+	"maxs" "4.5 80.5 608"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -543,45 +570,6 @@ add:
 ; ==                 NUISANCE CHANGES                ==
 ; ==      Clipping improvements, QOL map changes     ==
 ; =====================================================
-add:
-; --- Teleport survivors that get stuck inside new saferoom props
-{
-	"classname" "info_teleport_destination"
-	"origin" "3060 3579 -179"
-	"angles" "0 180 0"
-	"targetname" "saferoom_teleport_position"
-}
-{
-	"classname" "logic_auto"
-	"OnMapSpawn" "large_crate_teleport_trigger,AddOutput,mins -46 -46 -63,0,-1"
-	"OnMapSpawn" "large_crate_teleport_trigger,AddOutput,maxs 46 46 63,0,-1"
-	"OnMapSpawn" "large_crate_teleport_trigger,AddOutput,boxmins -46 -46 -63,0,-1"
-	"OnMapSpawn" "large_crate_teleport_trigger,AddOutput,boxmaxs 46 46 63,0,-1"
-	"OnMapSpawn" "large_crate_teleport_trigger,AddOutput,solid 2,0,-1"
-	"OnMapSpawn" "small_crate_teleport_trigger,AddOutput,mins -30 -30 -30,0,-1"
-	"OnMapSpawn" "small_crate_teleport_trigger,AddOutput,maxs 30 30 30,0,-1"
-	"OnMapSpawn" "small_crate_teleport_trigger,AddOutput,boxmins -30 -30 -30,0,-1"
-	"OnMapSpawn" "small_crate_teleport_trigger,AddOutput,boxmaxs 30 30 30,0,-1"
-	"OnMapSpawn" "small_crate_teleport_trigger,AddOutput,solid 2,0,-1"
-}
-{
-	"classname" "trigger_teleport"
-	"origin" "3329 3873 -124"
-	"targetname" "large_crate_teleport_trigger"
-	"filtername" "filter_survivors"
-	"spawnflags" "1"
-	"StartDisabled" "0"
-	"target" "saferoom_teleport_position"
-}
-{
-	"classname" "trigger_teleport"
-	"origin" "3344 3789 -156"
-	"targetname" "small_crate_teleport_trigger"
-	"filtername" "filter_survivors"
-	"spawnflags" "1"
-	"StartDisabled" "0"
-	"target" "saferoom_teleport_position"
-}
 filter:
 ; --- Disable the Strongman event
 {
@@ -598,10 +586,30 @@ filter:
 {
 	"targetname" "game_start_button"
 }
-; --- Remove one of the windows on the building before the barn
-filter:
+; --- Remove trash bins that allow survivors to jump on the tents by the bumper cars
+; --- Group of 3 on the right
 {
-	"hammerid" "1405561"
+	"hammerid" "1682336"
+}
+{
+	"hammerid" "1682332"
+}
+{
+	"hammerid" "1682340"
+}
+; --- Group of 2 on the right
+{
+	"hammerid" "1682352"
+}
+{
+	"hammerid" "1682356"
+}
+; --- Group of 2 on the left
+{
+	"hammerid" "1682320"
+}
+{
+	"hammerid" "1682324"
 }
 add:
 ; --- Fix LOS on carnival sign props before barns
@@ -764,6 +772,39 @@ add:
 	"disableshadows" "1"
 	"rendermode" "10"
 }
+; --- Clipping on fallen fence at the top of the stairs by the event
+{
+	"classname" "env_physics_blocker"
+	"origin" "-2626 729 -190"
+	"mins" "-74 -35 -2"
+	"maxs" "74 35 2"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-2626 737.5 -186"
+	"mins" "-70 -22.5 -2"
+	"maxs" "70 22.5 2"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-2626 729 -182.5"
+	"mins" "-67 -7 -1.5"
+	"maxs" "67 7 1.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-2626 746 -181.5"
+	"mins" "-66 -10 -2.5"
+	"maxs" "66 10 2.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 
 
 ; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
@@ -772,7 +813,7 @@ add:
 ; ==       New props for balance and SI spawns       ==
 ; =====================================================
 add:
-; --- Dumpster after bumper cars
+; --- Static dumpster after bumper cars
 {
 	"classname" "prop_dynamic"
 	"origin" "443 2146 -166.75"
@@ -955,20 +996,12 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Plywood to block LOS on the CEDA balcony at the event
+; --- Vending machine on the balcony by the event
 {
 	"classname" "prop_dynamic"
-	"origin" "-3078 1284 -55"
-	"angles" "0 90 -90"
-	"model" "models/props_highway/plywood_01.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-3078 1212 -55"
-	"angles" "0 90 -90"
-	"model" "models/props_highway/plywood_03.mdl"
+	"origin" "-3129 1182 -96"
+	"angles" "0 0 0"
+	"model" "models/props_office/vending_machine01.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
@@ -982,7 +1015,6 @@ add:
 	"disableshadows" "1"
 	"rendercolor" "69 118 102"
 }
-; --- Clipping on tent
 {
 	"classname" "env_physics_blocker"
 	"origin" "-2369 1235 444"
@@ -991,7 +1023,7 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Additional porta potties at the end of the event
+; --- Additional porta potty at the end of the event
 {
 	"classname" "prop_dynamic"
 	"origin" "208 1856 -256"
@@ -1000,7 +1032,6 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Clipping on porta potties
 {
 	"classname" "env_physics_blocker"
 	"origin" "209 1857 453"
@@ -1078,6 +1109,17 @@ add:
 ; ==              Add or change ladders              ==
 ; =====================================================
 add:
+; --- Infected ladder to climb on yellow tents by the saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "4417 4874 -113"
+    "angles" "0 180 0"
+    "model" "*90"
+    "normal.x" "-1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "2"
+}
 ; --- Infected ladder to climb over gazebo fence behind the garbage area
 {
 	"classname" "func_simpleladder"
@@ -1241,21 +1283,43 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
-; --- Extend the middle railings to the wall
+; --- Teleport survivors that get stuck inside new saferoom props
 {
-	"classname" "prop_dynamic"
-	"origin" "3116.37 3860.39 -187.75"
+	"classname" "info_teleport_destination"
+	"origin" "3060 3579 -179"
 	"angles" "0 180 0"
-	"model" "models/props_urban/wood_railing001_128.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "start_railing_lighting"
+	"targetname" "saferoom_teleport_position"
 }
-; --- Fix lighting origin
 {
-	"classname" "info_target"
-	"origin" "3116 3732 -188"
-	"targetname" "start_railing_lighting"
+	"classname" "logic_auto"
+	"OnMapSpawn" "large_crate_teleport_trigger,AddOutput,mins -46 -46 -63,0,-1"
+	"OnMapSpawn" "large_crate_teleport_trigger,AddOutput,maxs 46 46 63,0,-1"
+	"OnMapSpawn" "large_crate_teleport_trigger,AddOutput,boxmins -46 -46 -63,0,-1"
+	"OnMapSpawn" "large_crate_teleport_trigger,AddOutput,boxmaxs 46 46 63,0,-1"
+	"OnMapSpawn" "large_crate_teleport_trigger,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "small_crate_teleport_trigger,AddOutput,mins -30 -30 -30,0,-1"
+	"OnMapSpawn" "small_crate_teleport_trigger,AddOutput,maxs 30 30 30,0,-1"
+	"OnMapSpawn" "small_crate_teleport_trigger,AddOutput,boxmins -30 -30 -30,0,-1"
+	"OnMapSpawn" "small_crate_teleport_trigger,AddOutput,boxmaxs 30 30 30,0,-1"
+	"OnMapSpawn" "small_crate_teleport_trigger,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "trigger_teleport"
+	"origin" "3329 3873 -124"
+	"targetname" "large_crate_teleport_trigger"
+	"filtername" "filter_survivors"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"target" "saferoom_teleport_position"
+}
+{
+	"classname" "trigger_teleport"
+	"origin" "3344 3789 -156"
+	"targetname" "small_crate_teleport_trigger"
+	"filtername" "filter_survivors"
+	"spawnflags" "1"
+	"StartDisabled" "0"
+	"target" "saferoom_teleport_position"
 }
 
 ; =====================================================
@@ -1289,61 +1353,8 @@ modify:
 		"OnMapSpawn" "randompath_1_navblocker,BlockNav,,0,-1"
 	}
 }
-; --- Remove trash bins that allow survivors to jump on the tents by the bumper cars
-filter:
-; --- Group of 3 on the right
-{
-	"hammerid" "1682336"
-}
-{
-	"hammerid" "1682332"
-}
-{
-	"hammerid" "1682340"
-}
-; --- Group of 2 on the right
-{
-	"hammerid" "1682352"
-}
-{
-	"hammerid" "1682356"
-}
-; --- Group of 2 on the left
-{
-	"hammerid" "1682320"
-}
-{
-	"hammerid" "1682324"
-}
-; --- Block getting on the props by the blocked route
+; --- Block getting on the fence
 add:
-; --- Tents
-{
-	"classname" "env_physics_blocker"
-	"origin" "2483 2497 544"
-	"mins" "-66.5 -129 -608"
-	"maxs" "66.5 129 608"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "2778 2432 544"
-	"mins" "-66.5 -64 -608"
-	"maxs" "66.5 64 608"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Food cart
-{
-	"classname" "env_physics_blocker"
-	"origin" "2816 2568 490"
-	"mins" "-107 -53 -534"
-	"maxs" "107 53 534"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Fence
 {
 	"classname" "env_physics_blocker"
 	"origin" "2640 2632 488"
@@ -1352,7 +1363,7 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Infected ladder on fence blocking the route at the start
+; --- Infected ladders on fence blocking the route at the start
 {
 	"classname" "func_simpleladder"
 	"origin" "5033 632 -74"
@@ -1363,25 +1374,13 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
-; --- Infected ladder on food cart by the blocked route at the start
 {
-	"classname" "func_simpleladder"
-	"origin" "5172 182 -13"
-	"angles" "0 90 0"
-	"model" "*91"
-	"normal.x" "-1.00"
-	"normal.y" "0.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
-; --- Infected ladder on the green fence by the blocked route at the start
-{
-	"classname" "func_simpleladder"
-	"origin" "4782 4916 0"
-	"angles" "0 180 0"
-	"model" "*91"
-	"normal.x" "0.00"
-	"normal.y" "-1.00"
-	"normal.z" "0.00"
-	"team" "2"
+    "classname" "func_simpleladder"
+    "origin" "224 4626 -74"
+    "angles" "0 270 0"
+    "model" "*90"
+    "normal.x" "0"
+    "normal.y" "-1"
+    "normal.z" "0"
+    "team" "2"
 }

--- a/cfg/stripper/zonemod/maps/c3m2_swamp.cfg
+++ b/cfg/stripper/zonemod/maps/c3m2_swamp.cfg
@@ -769,155 +769,6 @@ add:
 ; ==      Clipping improvements, QOL map changes     ==
 ; =====================================================
 add:
-; --- Additional trees to show where invisible walls are between some trees
-; --- Left of docks near start - 2 sets
-{
-	"classname" "prop_dynamic"
-	"origin" "-4756 4831 -3"
-	"angles" "0 99 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-4803 4867 -3"
-	"angles" "0 219 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-4847 4848 -3"
-	"angles" "0 234 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-5345 5438 -3"
-	"angles" "0 309 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-5304 5401 -3"
-	"angles" "0 354 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-5242 5337 -3"
-	"angles" "0 39 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-; --- Right of docks near start - 2 sets
-{
-	"classname" "prop_dynamic"
-	"origin" "-6318 3530 -3"
-	"angles" "0 318 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6356 3536 -3"
-	"angles" "0 213 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6400 3576 -3"
-	"angles" "0 258 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6056 3418 -3"
-	"angles" "0 242.5 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-6071 3416 -3"
-	"angles" "0 107.5 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-5972 3439 -3"
-	"angles" "0 69 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-; --- Water by docks
-{
-	"classname" "prop_dynamic"
-	"origin" "-4425 3531 0"
-	"angles" "0 66 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-4365 3488 0"
-	"angles" "0 36 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "-4437 3513 -13"
-	"angles" "0 15 0"
-	"model" "models/props_foliage/urban_tree_base_bushes01_large.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-; --- By the sunken house near the end of the map
-{
-	"classname" "prop_dynamic"
-	"origin" "6536 1082 -17"
-	"angles" "0 36 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "6626 1033 -17"
-	"angles" "0 246 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "6605 1046 -17"
-	"angles" "0 201 0"
-	"model" "models/props_foliage/swamp_trees_small01.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
 ; --- Block LOS under floating trees
 {
 	"classname" "logic_auto"
@@ -2201,7 +2052,7 @@ add:
 	"initialstate" "1"
 	"BlockType" "2"
 }
-; --- Trailer and pickup truck by the end saferoom
+; --- Trailer by the end saferoom
 {
 	"classname" "prop_dynamic"
 	"origin" "7399 -345 120"
@@ -2222,7 +2073,7 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Fix LOS under trailer / car
+; --- Fix LOS under trailer
 {
 	"classname" "logic_auto"
 	"OnMapSpawn" "losfix_end_trailer,AddOutput,mins -3 -134 -14,0,-1"

--- a/cfg/stripper/zonemod/maps/c3m3_shantytown.cfg
+++ b/cfg/stripper/zonemod/maps/c3m3_shantytown.cfg
@@ -646,8 +646,8 @@ add:
 {
 	"classname" "env_physics_blocker"
 	"origin" "-1826 -21 59"
-	"mins" "-26 -116 -65"
-	"maxs" "26 116 65"
+	"mins" "-25 -110 -65"
+	"maxs" "25 110 65"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -683,7 +683,32 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
+; --- Make 2 barrels outside the saferoom static
+add:
+{
+	"classname" "prop_dynamic"
+	"origin" "-5636.76 1163.97 128.25"
+	"angles" "0 0 0"
+	"model" "models/props_urban/oil_drum001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-5652 1200 128.25"
+	"angles" "0 255 0"
+	"model" "models/props_urban/oil_drum001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Remove all original barrels
+filter:
+{
+	"classname" "prop_physics"
+	"model" "models/props_urban/oil_drum001.mdl"
+}
 ; --- Make orange fences solid to hittables
+add:
 {
 	"classname" "env_physics_blocker"
 	"origin" "-3322 880 -1"
@@ -1107,25 +1132,6 @@ add:
 	"OnMapSpawn" "InstanceAuto84-2e_screen01,Break,,0,-1"
 	"OnMapSpawn" "InstanceAuto84-2f_screen01,Break,,0,-1"
 	"OnMapSpawn" "InstanceAuto84-2g_screen01,Break,,0,-1"
-}
-; --- Solidify non-solid trash clusters inside the buildings in the event area
-{
-	"classname" "prop_dynamic"
-	"origin" "553 -4140 117"
-	"angles" "0 15 0"
-	"model" "models/props_junk/trashcluster01a_corner.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"rendermode" "10"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "1315 -3419 69"
-	"angles" "0 15 0"
-	"model" "models/props_junk/trashcluster01a_corner.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"rendermode" "10"
 }
 ; --- Block LOS under floating trees
 {
@@ -2222,12 +2228,12 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Tractor by the walkway at the end saferoom
+; --- Shrub wall by the walkway at the end saferoom
 {
 	"classname" "prop_dynamic"
-	"origin" "4621 -4483 206"
-	"angles" "-12.4995 359.889 0.512139"
-	"model" "models/props_vehicles/tractor01.mdl"
+	"origin" "4640.59 -4374.65 211.01"
+	"angles" "-0.499696 270.026 10.5003"
+	"model" "models/props_foliage/swamp_shrubwall_block_256_deep.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }

--- a/cfg/stripper/zonemod/maps/c4m1_milltown_a.cfg
+++ b/cfg/stripper/zonemod/maps/c4m1_milltown_a.cfg
@@ -661,6 +661,7 @@ add:
 	"extent" "8 648 224"
 	"filtername" "filter_hittables"
 	"StartDisabled" "0"
+	"targetname" "dock_weapons_clip"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -669,6 +670,7 @@ add:
 	"extent" "134 8 224"
 	"filtername" "filter_hittables"
 	"StartDisabled" "0"
+	"targetname" "dock_weapons_clip"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -677,6 +679,7 @@ add:
 	"extent" "80 8 224"
 	"filtername" "filter_hittables"
 	"StartDisabled" "0"
+	"targetname" "dock_weapons_clip"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -685,6 +688,7 @@ add:
 	"extent" "80 8 224"
 	"filtername" "filter_hittables"
 	"StartDisabled" "0"
+	"targetname" "dock_weapons_clip"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -693,6 +697,7 @@ add:
 	"extent" "90 8 224"
 	"filtername" "filter_hittables"
 	"StartDisabled" "0"
+	"targetname" "dock_weapons_clip"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -701,6 +706,7 @@ add:
 	"extent" "84 8 224"
 	"filtername" "filter_hittables"
 	"StartDisabled" "0"
+	"targetname" "dock_weapons_clip"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -709,6 +715,7 @@ add:
 	"extent" "8 118 224"
 	"filtername" "filter_hittables"
 	"StartDisabled" "0"
+	"targetname" "dock_weapons_clip"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -717,6 +724,7 @@ add:
 	"extent" "134 8 224"
 	"filtername" "filter_hittables"
 	"StartDisabled" "0"
+	"targetname" "dock_weapons_clip"
 }
 {
 	"classname" "script_clip_vphysics"
@@ -725,8 +733,36 @@ add:
 	"extent" "23 32 224"
 	"filtername" "filter_hittables"
 	"StartDisabled" "0"
+	"targetname" "dock_weapons_clip"
 }
-; --- Cliping on pickup truck by burger tank to make the jump to the awning possible on all tickrates
+{
+	"classname" "script_clip_vphysics"
+	"origin" "-7113.5 7978.5 89"
+	"angles" "0 0 0"
+	"extent" "66.5 725.5 25"
+	"filtername" "filter_hittables"
+	"StartDisabled" "0"
+	"targetname" "dock_weapons_clip"
+}
+; --- Trigger to remove the clips after going through the burger tank to prevent unintended blocking of hittables etc.
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "dock_weapons_clip_trigger,AddOutput,mins -16 -736 -736,0,-1"
+	"OnMapSpawn" "dock_weapons_clip_trigger,AddOutput,maxs 16 736 736,0,-1"
+	"OnMapSpawn" "dock_weapons_clip_trigger,AddOutput,boxmins -16 -736 -736,0,-1"
+	"OnMapSpawn" "dock_weapons_clip_trigger,AddOutput,boxmaxs 16 736 736,0,-1"
+	"OnMapSpawn" "dock_weapons_clip_trigger,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "trigger_once"
+	"origin" "-6096 7328 800"
+	"targetname" "dock_weapons_clip_trigger"
+	"filtername" "filter_survivor"
+	"spawnflags" "1"
+	; --- Trigger event output here
+	"OnTrigger" "dock_weapons_clip,Kill,,0,-1"
+}
+; --- Cliping on pickup truck by burger tank to make the jump to the awning possible on standard gravity
 {
 	"classname" "env_physics_blocker"
 	"origin" "-5374 7281 193"
@@ -906,6 +942,46 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Clipping on the SUV by the sugarmill saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "3246.23 -1401.01 165"
+	"angles" "0 -40 0"
+	"mins" "-12 -33 -5"
+	"maxs" "12 33 5"
+	"boxmins" "-12 -33 -5"
+	"boxmaxs" "12 33 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3239.92 -1395.7 175"
+	"angles" "0 -40 0"
+	"mins" "-12 -31 -5"
+	"maxs" "12 31 5"
+	"boxmins" "-12 -31 -5"
+	"boxmaxs" "12 31 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3229.83 -1387.49 183"
+	"angles" "0 -40 0"
+	"mins" "-12 -29 -3"
+	"maxs" "12 29 3"
+	"boxmins" "-12 -29 -3"
+	"boxmaxs" "12 29 3"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Remove non-static traffic barrels by the sugarmill saferoom
+filter:
+{
+	"classname" "prop_physics"
+	"model" "models/props_fairgrounds/traffic_barrel.mdl"
+}
 ; --- Remove 2 doors in the upstairs room by the balcony
 filter:
 {
@@ -1069,6 +1145,21 @@ add:
 	"disableshadows" "1"
 	"spawnflags" "264"
 }
+; --- Box under the tree house
+{
+	"classname" "prop_dynamic"
+	"origin" "1735 3087 108.484"
+	"angles" "0 0 0"
+	"model" "models/props/cs_assault/washer_box.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "treehouse_box_lighting"
+}
+{
+	"classname" "info_target"
+	"origin" "1735 3037 108.484"
+	"targetname" "treehouse_box_lighting"
+}
 ; --- Fences behind tree house so players that skip over the fence still have to go around to the usual area
 {
 	"classname" "prop_dynamic"
@@ -1131,12 +1222,12 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Chimney on house by the blue SUV
+; --- AC unit on house by the blue SUV
 {
 	"classname" "prop_dynamic"
-	"origin" "2468 2392 394"
-	"angles" "0 90 0"
-	"model" "models/props_exteriors/chimney2.mdl"
+	"origin" "2393.01 2391.98 332"
+	"angles" "0 180 0"
+	"model" "models/props/de_train/acunit1.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
@@ -1211,23 +1302,6 @@ add:
 	"origin" "3395 -856 110"
 	"targetname" "losfix_blue_pickup_b"
 }
-; --- Washer boxes at house by the sugarmill saferoom
-{
-	"classname" "prop_dynamic"
-	"origin" "3858 -810 97"
-	"angles" "1 270 -2"
-	"model" "models/props/cs_assault/washer_box.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "3550 -471 96"
-	"angles" "0 270 0"
-	"model" "models/props/cs_assault/washer_box.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
 
 ; =====================================================
 ; ==             LADDER / ELEVATOR NERF              ==
@@ -1262,6 +1336,8 @@ add:
 	"OnMapSpawn" "anv_mapfixes_booster_ginnytop,Kill,,30,-1"
 	; --- Replace blocker on fence by garage sale
 	"OnMapSpawn" "anv_mapfixes_treehouse_whitefence,Kill,,30,-1"
+	; --- Infected ladder on raised house, replaced with better ladder
+	"OnMapSpawn" "anv_mapfixes_ladder_cornerhomeplants_cloned_garagesalehome,Kill,,30,-1"
 }
 ; --- Replacement for anv_mapfixes_booster_ginnyjon
 {
@@ -1563,7 +1639,6 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
-; --- Prop for ladder
 {
 	"classname" "prop_dynamic"
 	"origin" "-3680 8145 277"
@@ -1583,7 +1658,6 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
-; --- Prop for ladder
 {
 	"classname" "prop_dynamic"
 	"origin" "-2746 8144 280"
@@ -1591,6 +1665,27 @@ add:
 	"model" "models/props_downtown/gutter_downspout_straight_160_02.mdl"
 	"solid" "0"
 	"disableshadows" "1"
+}
+; --- Replacement infected ladder to get on the roof of the raised house at the end of the street (anv_mapfixes_ladder_cornerhomeplants_cloned_garagesalehome)
+{
+    "classname" "func_simpleladder"
+    "origin" "-1924 9145.5 161"
+    "angles" "0 270 0"
+    "model" "*187"
+    "normal.x" "0"
+    "normal.y" "1"
+    "normal.z" "0"
+    "team" "2"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "-1924 9145.5 129"
+    "angles" "0 270 0"
+    "model" "*187"
+    "normal.x" "0"
+    "normal.y" "1"
+    "normal.z" "0"
+    "team" "2"
 }
 ; --- Infected ladder to get on the back of the boat garage building
 {
@@ -1603,7 +1698,6 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
-; --- Prop for ladder
 {
 	"classname" "prop_dynamic"
 	"origin" "4169 -454 248"

--- a/cfg/stripper/zonemod/maps/c4m2_sugarmill_a.cfg
+++ b/cfg/stripper/zonemod/maps/c4m2_sugarmill_a.cfg
@@ -301,17 +301,36 @@ add:
 }
 {
 	"classname" "env_physics_blocker"
-	"origin" "2821 -4730 132"
-	"mins" "-70.5 -21.5 -44"
-	"maxs" "70.5 21.5 44"
+	"origin" "2827 -4716 104"
+	"mins" "-32 -28 -100"
+	"maxs" "32 28 100"
 	"initialstate" "1"
 	"BlockType" "1"
 }
 {
 	"classname" "env_physics_blocker"
-	"origin" "2249 -4408 202"
-	"mins" "-20 -38 -38.5"
-	"maxs" "20 38 38.5"
+	"origin" "2278 -4395 220"
+	"mins" "-14 -25 -12"
+	"maxs" "14 25 12"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2253 -4406 220"
+	"mins" "-11 -14 -12"
+	"maxs" "11 14 12"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2264 -4391.2 219.5"
+	"angles" "0 45 0"
+	"mins" "-15 -15 -12"
+	"maxs" "15 15 12"
+	"boxmins" "-15 -15 -12"
+	"boxmaxs" "15 15 12"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -1133,15 +1152,6 @@ add:
 ; ==       New props for balance and SI spawns       ==
 ; =====================================================
 add:
-; --- Additional porta potty in the construction site
-{
-	"classname" "prop_dynamic"
-	"origin" "4481 -4413 112"
-	"angles" "-2.93438 12.016 -0.624281"
-	"model" "models/props_urban/outhouse001.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
 ; --- Prop on roof by 2 silos for spawns
 {
 	"classname" "prop_dynamic"
@@ -1167,7 +1177,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting1"
+	"lightingorigin" "scratch_blocker_lighting1"
 }
 {
 	"classname" "prop_dynamic"
@@ -1176,7 +1186,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting1"
+	"lightingorigin" "scratch_blocker_lighting1"
 }
 {
 	"classname" "prop_dynamic"
@@ -1185,7 +1195,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting1"
+	"lightingorigin" "scratch_blocker_lighting1"
 }
 {
 	"classname" "prop_dynamic"
@@ -1194,7 +1204,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting1"
+	"lightingorigin" "scratch_blocker_lighting1"
 }
 {
 	"classname" "prop_dynamic"
@@ -1203,7 +1213,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting2"
+	"lightingorigin" "scratch_blocker_lighting2"
 }
 {
 	"classname" "prop_dynamic"
@@ -1212,7 +1222,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting2"
+	"lightingorigin" "scratch_blocker_lighting2"
 }
 {
 	"classname" "prop_dynamic"
@@ -1221,7 +1231,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting2"
+	"lightingorigin" "scratch_blocker_lighting2"
 }
 {
 	"classname" "prop_dynamic"
@@ -1230,18 +1240,18 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting2"
+	"lightingorigin" "scratch_blocker_lighting2"
 }
 ; --- Fix lighting origin
 {
 	"classname" "info_target"
 	"origin" "-1553.1 -9573 684"
-	"targetname" "scrath_blocker_lighting1"
+	"targetname" "scratch_blocker_lighting1"
 }
 {
 	"classname" "info_target"
 	"origin" "-1553.1 -9573 204"
-	"targetname" "scrath_blocker_lighting2"
+	"targetname" "scratch_blocker_lighting2"
 }
 
 ; =====================================================
@@ -1418,6 +1428,17 @@ add:
 	"normal.y" "0.00"
 	"normal.z" "0.00"
 	"team" "2"
+}
+; --- Infected ladder to prevent a perma-stuck spot behind the fence near the two shacks
+{
+    "classname" "func_simpleladder"
+    "origin" "4334 -10015.7 -18.6454"
+    "angles" "0 180 0"
+    "model" "*16"
+    "normal.x" "1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "2"
 }
 ; --- Infected ladder to get on the gas station roof from the street without jumping over props
 {

--- a/cfg/stripper/zonemod/maps/c4m3_sugarmill_b.cfg
+++ b/cfg/stripper/zonemod/maps/c4m3_sugarmill_b.cfg
@@ -19,19 +19,6 @@ filter:
 	"targetname" "spawn_witch_vskeep"
 }
 
-; adjust postion of trigger area ,avoid svv from being locked out of the elevator the moment it closes
-; 调整检测区域，降低卡出电梯的几率
-modify:
-{
-	match:
-	{
-		"targetname" "trigger_elevator"
-	}
-	replace:
-	{
-		"origin" "-1484 -9546 196"
-	}
-}
 
 ; ################  ITEM SPAWN CHANGES  ###############
 ; =====================================================
@@ -326,23 +313,36 @@ add:
 }
 {
 	"classname" "env_physics_blocker"
-	"origin" "2821 -4730 132"
-	"mins" "-70.5 -21.5 -44"
-	"maxs" "70.5 21.5 44"
+	"origin" "2827 -4716 104"
+	"mins" "-32 -28 -100"
+	"maxs" "32 28 100"
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; block plyers jump on the cooling tank model by metal step
-; change angles to solve stuck spot, and keep block jump
 {
 	"classname" "env_physics_blocker"
-	"targetname" "eb871"
-	"origin" "2254 -4413 202"
-	"angles" "0 -20 0"
-	"mins" "-20 -38 -39"
-	"maxs" "20 38 39"
-	"boxmins" "-20 -38 -39"
-	"boxmaxs" "20 38 39"
+	"origin" "2278 -4395 220"
+	"mins" "-14 -25 -12"
+	"maxs" "14 25 12"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2253 -4406 220"
+	"mins" "-11 -14 -12"
+	"maxs" "11 14 12"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2264 -4391.2 219.5"
+	"angles" "0 45 0"
+	"mins" "-15 -15 -12"
+	"maxs" "15 15 12"
+	"boxmins" "-15 -15 -12"
+	"boxmaxs" "15 15 12"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -1156,6 +1156,18 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Attempt to prevent survivors from being able to escape the elevator door before it closes by moving the check trigger
+modify:
+{
+	match:
+	{
+		"targetname" "trigger_elevator"
+	}
+	replace:
+	{
+		"origin" "-1483.82 -9546.5 196"
+	}
+}
 
 
 ; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
@@ -1164,15 +1176,6 @@ add:
 ; ==       New props for balance and SI spawns       ==
 ; =====================================================
 add:
-; --- Additional porta potty in the construction site
-{
-	"classname" "prop_dynamic"
-	"origin" "4481 -4413 112"
-	"angles" "-2.93438 12.016 -0.624281"
-	"model" "models/props_urban/outhouse001.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
 ; --- Prop on roof by 2 silos for spawns
 {
 	"classname" "prop_dynamic"
@@ -1198,7 +1201,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting1"
+	"lightingorigin" "scratch_blocker_lighting1"
 }
 {
 	"classname" "prop_dynamic"
@@ -1207,7 +1210,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting1"
+	"lightingorigin" "scratch_blocker_lighting1"
 }
 {
 	"classname" "prop_dynamic"
@@ -1216,7 +1219,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting1"
+	"lightingorigin" "scratch_blocker_lighting1"
 }
 {
 	"classname" "prop_dynamic"
@@ -1225,7 +1228,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting1"
+	"lightingorigin" "scratch_blocker_lighting1"
 }
 {
 	"classname" "prop_dynamic"
@@ -1234,7 +1237,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting2"
+	"lightingorigin" "scratch_blocker_lighting2"
 }
 {
 	"classname" "prop_dynamic"
@@ -1243,7 +1246,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting2"
+	"lightingorigin" "scratch_blocker_lighting2"
 }
 {
 	"classname" "prop_dynamic"
@@ -1252,7 +1255,7 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting2"
+	"lightingorigin" "scratch_blocker_lighting2"
 }
 {
 	"classname" "prop_dynamic"
@@ -1261,18 +1264,18 @@ add:
 	"model" "models/props_urban/metal_plate001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "scrath_blocker_lighting2"
+	"lightingorigin" "scratch_blocker_lighting2"
 }
 ; --- Fix lighting origin
 {
 	"classname" "info_target"
 	"origin" "-1553.1 -9573 684"
-	"targetname" "scrath_blocker_lighting1"
+	"targetname" "scratch_blocker_lighting1"
 }
 {
 	"classname" "info_target"
 	"origin" "-1553.1 -9573 204"
-	"targetname" "scrath_blocker_lighting2"
+	"targetname" "scratch_blocker_lighting2"
 }
 
 ; =====================================================
@@ -1492,6 +1495,17 @@ add:
 	"normal.y" "0.00"
 	"normal.z" "0.00"
 	"team" "2"
+}
+; --- Infected ladder to prevent a stuck spot behind the fence near the two shacks
+{
+    "classname" "func_simpleladder"
+    "origin" "4334 -10015.7 -18.6454"
+    "angles" "0 180 0"
+    "model" "*24"
+    "normal.x" "1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "2"
 }
 ; --- Infected ladder to get on the gas station roof from the street without jumping over props
 {

--- a/cfg/stripper/zonemod/maps/c4m4_milltown_b.cfg
+++ b/cfg/stripper/zonemod/maps/c4m4_milltown_b.cfg
@@ -723,6 +723,46 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Clipping on the SUV by the sugarmill saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "3246.23 -1401.01 165"
+	"angles" "0 -40 0"
+	"mins" "-12 -33 -5"
+	"maxs" "12 33 5"
+	"boxmins" "-12 -33 -5"
+	"boxmaxs" "12 33 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3239.92 -1395.7 175"
+	"angles" "0 -40 0"
+	"mins" "-12 -31 -5"
+	"maxs" "12 31 5"
+	"boxmins" "-12 -31 -5"
+	"boxmaxs" "12 31 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3229.83 -1387.49 183"
+	"angles" "0 -40 0"
+	"mins" "-12 -29 -3"
+	"maxs" "12 29 3"
+	"boxmins" "-12 -29 -3"
+	"boxmaxs" "12 29 3"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Remove non-static traffic barrels by the sugarmill saferoom
+filter:
+{
+	"classname" "prop_physics"
+	"model" "models/props_fairgrounds/traffic_barrel.mdl"
+}
 ; --- Remove 2 doors in the upstairs room by the balcony
 filter:
 {
@@ -868,6 +908,21 @@ add:
 	"disableshadows" "1"
 	"spawnflags" "264"
 }
+; --- Box under the tree house
+{
+	"classname" "prop_dynamic"
+	"origin" "1735 3087 108.484"
+	"angles" "0 0 0"
+	"model" "models/props/cs_assault/washer_box.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"lightingorigin" "treehouse_box_lighting"
+}
+{
+	"classname" "info_target"
+	"origin" "1735 3037 108.484"
+	"targetname" "treehouse_box_lighting"
+}
 ; --- Fences behind tree house so players that skip over the fence still have to go around to the usual area
 {
 	"classname" "prop_dynamic"
@@ -930,12 +985,12 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Chimney on house by the blue SUV
+; --- AC unit on house by the blue SUV
 {
 	"classname" "prop_dynamic"
-	"origin" "2468 2392 394"
-	"angles" "0 90 0"
-	"model" "models/props_exteriors/chimney2.mdl"
+	"origin" "2393.01 2391.98 332"
+	"angles" "0 180 0"
+	"model" "models/props/de_train/acunit1.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
@@ -1010,23 +1065,6 @@ add:
 	"origin" "3395 -856 110"
 	"targetname" "losfix_blue_pickup_b"
 }
-; --- Washer boxes at house by the sugarmill saferoom
-{
-	"classname" "prop_dynamic"
-	"origin" "3858 -810 97"
-	"angles" "1 270 -2"
-	"model" "models/props/cs_assault/washer_box.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "3550 -471 96"
-	"angles" "0 270 0"
-	"model" "models/props/cs_assault/washer_box.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
 
 ; =====================================================
 ; ==             LADDER / ELEVATOR NERF              ==
@@ -1080,6 +1118,8 @@ add:
 	"classname" "logic_auto"
 	; --- Replace blocker on fence by garage sale
 	"OnMapSpawn" "anv_mapfixes_treehouse_whitefence,Kill,,30,-1"
+	; --- Infected ladder on raised house, replaced with better ladder
+	"OnMapSpawn" "anv_mapfixes_ladder_cornerhomeplants_cloned_garagesalehome,Kill,,30,-1"
 }
 ; --- Remove Valve's commentary blockers so we can replace them with our own
 add:
@@ -1222,7 +1262,6 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
-; --- Prop for ladder
 {
 	"classname" "prop_dynamic"
 	"origin" "-2746 8144 280"
@@ -1230,6 +1269,27 @@ add:
 	"model" "models/props_downtown/gutter_downspout_straight_160_02.mdl"
 	"solid" "0"
 	"disableshadows" "1"
+}
+; --- Replacement infected ladder to get on the roof of the raised house at the end of the street (anv_mapfixes_ladder_cornerhomeplants_cloned_garagesalehome)
+{
+    "classname" "func_simpleladder"
+    "origin" "-1924 9145.5 161"
+    "angles" "0 270 0"
+    "model" "*186"
+    "normal.x" "0"
+    "normal.y" "1"
+    "normal.z" "0"
+    "team" "2"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "-1924 9145.5 129"
+    "angles" "0 270 0"
+    "model" "*186"
+    "normal.x" "0"
+    "normal.y" "1"
+    "normal.z" "0"
+    "team" "2"
 }
 ; --- Infected ladder to get on the back of the boat garage building
 {
@@ -1242,7 +1302,6 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
-; --- Prop for ladder
 {
 	"classname" "prop_dynamic"
 	"origin" "4169 -454 248"
@@ -1502,4 +1561,18 @@ add:
 	"normal.y" "0.00"
 	"normal.z" "0.00"
 	"team" "2"
+}
+; --- Nav blocker on the blocked door to prevent AI from trying to path through it
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "blocked_door_nav_blocker,AddOutput,mins -4 -34 -12,0,-1"
+	"OnMapSpawn" "blocked_door_nav_blocker,AddOutput,maxs 4 34 12,0,-1"
+	"OnMapSpawn" "blocked_door_nav_blocker,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "blocked_door_nav_blocker,BlockNav,,1,-1"
+}
+{
+	"classname" "func_nav_blocker"
+	"origin" "-892 5742 116"
+	"targetname" "blocked_door_nav_blocker"
+	"teamToBlock" "-1"
 }

--- a/cfg/stripper/zonemod/maps/c4m5_milltown_escape.cfg
+++ b/cfg/stripper/zonemod/maps/c4m5_milltown_escape.cfg
@@ -180,7 +180,7 @@ add:
 ; ==      Clipping improvements, QOL map changes     ==
 ; =====================================================
 add:
-; --- Cliping on pickup truck by burger tank to make the jump to the awning possible on all tickrates
+; --- Cliping on pickup truck by burger tank to make the jump to the awning possible on standard gravity
 {
 	"classname" "env_physics_blocker"
 	"origin" "-5374 7281 193"
@@ -581,7 +581,6 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
-; --- Prop for ladder
 {
 	"classname" "prop_dynamic"
 	"origin" "-3680 8145 277"

--- a/cfg/stripper/zonemod/maps/c5m1_waterfront.cfg
+++ b/cfg/stripper/zonemod/maps/c5m1_waterfront.cfg
@@ -50,6 +50,29 @@ modify:
 ; ==      Block intentionally performed exploits     ==
 ; =====================================================
 add:
+; --- Block getting on top of fence on the left outside saferoom (Replaces TLS blocker)
+{
+	"classname" "env_physics_blocker"
+	"origin" "589 -141.5 -24"
+	"angles" "0 29.5 0"
+	"mins" "-2 -48.5 -168"
+	"maxs" "2 48.5 168"
+	"boxmins" "-2 -48.5 -168"
+	"boxmaxs" "2 48.5 168"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "592.5 -132 -36"
+	"angles" "0 32.5 0"
+	"mins" "-2.5 -38 -180"
+	"maxs" "2.5 38 180"
+	"boxmins" "-2.5 -38 -180"
+	"boxmaxs" "2.5 38 180"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block standing under a sign at the start to avoid infected
 {
 	"classname" "env_physics_blocker"
@@ -503,6 +526,13 @@ add:
 	"origin" "-4080 -1120 -120"
 	"mapupdate" "1"
 	"BlockType" "1" ; --- Type was originally unspecified, blocking infected too
+}
+; --- Remove TLS entities after loading
+add:
+{
+	"classname" "logic_auto"
+	; --- On the fence on the left outside saferoom
+	"OnMapSpawn" "anv_mapfixes_ledgehang_startfenceleft,Kill,,30,-1"
 }
 
 ; =====================================================

--- a/cfg/stripper/zonemod/maps/c5m2_park.cfg
+++ b/cfg/stripper/zonemod/maps/c5m2_park.cfg
@@ -1143,22 +1143,14 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Extend a hedge by exit to the middle section of the park on the right side
+; --- Small hedge at the exit of the right side of the center section of the park
 {
 	"classname" "prop_dynamic"
-	"origin" "-7243 -1687 -260"
-	"angles" "0 0 0"
-	"model" "models/props_foliage/urban_hedge_256_128_high.mdl"
+	"origin" "-7201 -1694 -256.241"
+	"angles" "0 321.5 0"
+	"model" "models/props_foliage/urban_hedge_128_64_high.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-7243 -1687 700"
-	"mins" "-125 -22 -964"
-	"maxs" "125 22 964"
-	"initialstate" "1"
-	"BlockType" "1"
 }
 ; --- Tree in the park by the restrooms on the right side
 {

--- a/cfg/stripper/zonemod/maps/c5m3_cemetery.cfg
+++ b/cfg/stripper/zonemod/maps/c5m3_cemetery.cfg
@@ -203,18 +203,7 @@ add:
 ; ==      Block intentionally performed exploits     ==
 ; =====================================================
 add:
-; --- Block survivors from standing on the fence by the saferoom - Replaced until angled clip bug fixed (#34)
-;{
-;	"classname" "env_physics_blocker"
-;	"origin" "6092 8456 404"
-;	"angles" "0 -5.5 0"
-;	"mins" "-116 -4 -236"
-;	"maxs" "116 4 236"
-;	"boxmins" "-116 -4 -236"
-;	"boxmaxs" "116 4 236"
-;	"initialstate" "1"
-;	"BlockType" "1"
-;}
+; --- Block survivors from standing on the fence by the saferoom
 {
 	"classname" "env_physics_blocker"
 	"origin" "6072 8456 58"
@@ -271,6 +260,29 @@ add:
 	"origin" "5946 8470 412"
 	"mins" "-10 -7 -228"
 	"maxs" "10 7 228"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from standing on the large dumpster by the stairs (via a low-gravity jump onto a TLS infected ladder)
+{
+	"classname" "env_physics_blocker"
+	"origin" "3864.5 6109 316"
+	"angles" "0 23 0"
+	"mins" "-192.5 -65 -324"
+	"maxs" "192.5 65 324"
+	"boxmins" "-192.5 -65 -324"
+	"boxmaxs" "192.5 65 324"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3759.5 5992.5 380"
+	"angles" "0 23 0"
+	"mins" "-20.5 -2.5 -260"
+	"maxs" "20.5 2.5 260"
+	"boxmins" "-20.5 -2.5 -260"
+	"boxmaxs" "20.5 2.5 260"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -535,20 +547,10 @@ add:
 ; ==      Clipping improvements, QOL map changes     ==
 ; =====================================================
 filter:
-; --- Remove 2 fallen oil barrels near the saferoom
+; --- Remove oil barrels that block movement / can be exploited
 {
-	"hammerid" "1588934"
-}
-{
-	"hammerid" "1588938"
-}
-; --- Remove fallen oil barrel by the shed
-{
-	"hammerid" "1549590"
-}
-; --- Remove oil barrel on top of stack by the shed after the bridge
-{
-	"hammerid" "1549682"
+	"classname" "prop_physics"
+	"model" "models/props_urban/oil_drum001.mdl"
 }
 add:
 ; --- Add missing glass to vehicles
@@ -724,6 +726,15 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Prop for ladder on shack after the bridge as a visual indicator
+{
+	"classname" "prop_dynamic"
+	"origin" "7021 -4032 248"
+	"angles" "0 90 0"
+	"model" "models/props_downtown/gutter_downspout_straight02.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
 
 
 ; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
@@ -840,21 +851,54 @@ add:
 	"origin" "4226 1714 9"
 	"targetname" "losfix_sewer_street_van"
 }
-; --- Manhole cover by the sewer drop
+; --- Fence cover by the sewer drop
 {
 	"classname" "prop_dynamic"
-	"origin" "4075 376 29"
-	"angles" "84 334.5 0"
-	"model" "models/props_street/manhole_cover.mdl"
+	"origin" "4368 -80 9"
+	"angles" "0 180 0"
+	"model" "models/props_urban/fence_cover001_256.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Extend concrete block behind fence at the sewer drop
+; --- Fridges by the sewer drop
 {
 	"classname" "prop_dynamic"
-	"origin" "4256 -240 37"
-	"angles" "0 285.5 0"
-	"model" "models/props_fortifications/concrete_block001_128_reference.mdl"
+	"origin" "4377 580 1.12648"
+	"angles" "0 195.5 0"
+	"model" "models/props_urban/fridge001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4377 552 15.1265"
+	"angles" "-85.427 84.9924 19.7675"
+	"model" "models/props_urban/fridge001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Oil barrels behind the fence by the sewer drop
+{
+	"classname" "prop_dynamic"
+	"origin" "4391.54 755.298 1"
+	"angles" "0 95.5 0"
+	"model" "models/props_urban/oil_drum001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4393.46 735.39 49"
+	"angles" "0 95.5 0"
+	"model" "models/props_urban/oil_drum001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "4395.18 717.473 1"
+	"angles" "0 95.5 0"
+	"model" "models/props_urban/oil_drum001.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
@@ -912,32 +956,6 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Extend wall at the cemetery entrance - Lighting cannot be made to match joining incorrectly lit walls
-{
-	"classname" "prop_dynamic"
-	"origin" "6712 -4832 96"
-	"angles" "0 0 0"
-	"model" "models/props_urban/gate_wall001_64.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "6712 -4800 96"
-	"angles" "0 270 0"
-	"model" "models/props_urban/gate_column001_32.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Clipping on wall
-{
-	"classname" "env_physics_blocker"
-	"origin" "6712 -4820 528"
-	"mins" "-12 -32 -432"
-	"maxs" "12 32 432"
-	"initialstate" "1"
-	"BlockType" "1"
-}
 
 ; =====================================================
 ; ==             LADDER / ELEVATOR NERF              ==
@@ -947,34 +965,9 @@ add:
 ; --- Pipe to stand on at the ladder in the sewer
 {
 	"classname" "prop_dynamic"
-	"origin" "5952 403 -99"
+	"origin" "5952 403 -73"
 	"angles" "0 0 -90"
 	"model" "models/props_pipes/pipeset08d_256_001a.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "5945 405 -48"
-	"mins" "-17 -3 -48"
-	"maxs" "17 3 48"
-	"initialstate" "1"
-	"BlockType" "0"
-}
-; --- Fences at the top of the sewer ladder
-{
-	"classname" "prop_dynamic"
-	"origin" "5997 376 20"
-	"angles" "0 180 0"
-	"model" "models/props_c17/handrail04_medium.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "5891 376 20"
-	"angles" "0 180 0"
-	"model" "models/props_c17/handrail04_medium.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
@@ -985,7 +978,7 @@ add:
 ; ==                  SOUND REMOVAL                  ==
 ; ==    Remove or adjust sounds played by the map    ==
 ; =====================================================
-; --- Stop survivors saying some of the same annoying lines every single round
+; --- Stop survivors saying some of the same voice lines every round
 filter:
 ; --- When leaving saferoom
 {
@@ -1101,6 +1094,34 @@ filter:
 ; ==             LADDER ADDITIONS / FIXES            ==
 ; ==              Add or change ladders              ==
 ; =====================================================
+; --- Remove TLS ladders after loading and replace them with our own
+add:
+{
+	"classname" "logic_auto"
+	; --- Ladders on green fence before the sewer
+	"OnMapSpawn" "anv_mapfixes_ladder_fencecornerright_cloned_fencebacksouthl,Kill,,30,-1"
+	"OnMapSpawn" "anv_mapfixes_ladder_fencecornerleft_cloned_fencebackeastr,Kill,,30,-1"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "4353 893 0"
+    "angles" "0 180 0"
+    "model" "*371"
+    "normal.x" "1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "2"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "6005 -275 0"
+    "angles" "0 180 0"
+    "model" "*117"
+    "normal.x" "0"
+    "normal.y" "1"
+    "normal.z" "0"
+    "team" "2"
+}
 ; --- Fix the sewer ladder ending slightly before the top of the hole, causing players to fall off near the top
 modify:
 {
@@ -1125,7 +1146,7 @@ add:
 	"normal.z" "0.00"
 	"team" "2"
 }
-; --- Infected ladder behind the fence at the start in the open area
+; --- Infected ladder behind the fence by the fire at the start of the map
 {
 	"classname" "func_simpleladder"
 	"origin" "8857 9854 -16"
@@ -1159,127 +1180,19 @@ add:
 	"team" "2"
 }
 {
-	"classname" "func_simpleladder"
-	"origin" "-369 -1649 6"
-	"angles" "0 0 0"
-	"model" "*374"
-	"normal.x" "1.00"
-	"normal.y" "0.00"
-	"normal.z" "0.00"
-	"team" "2"
+    "classname" "func_simpleladder"
+    "origin" "4781 -3867 -52"
+    "angles" "0 90 0"
+    "model" "*122"
+    "normal.x" "0"
+    "normal.y" "1"
+    "normal.z" "0"
+    "team" "2"
 }
 
 
 ; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
 ; =====================================================
-; ==                 CEMETERY PATHING                ==
-; ==      Change route through cemetery section      ==
+; ==                   BLANK HEADER                  ==
+; ==                Blank description                ==
 ; =====================================================
-; --- Modify names of entities so that they get spawned on the default versus path (Path A)
-modify:
-; --- Crypt walls at the start of the path
-{
-	match:
-	{
-		"hammerid" "1058418"
-	}
-	replace:
-	{
-		"targetname" "Path_A_clip"
-	}
-}
-{
-	match:
-	{
-		"hammerid" "1058416"
-	}
-	replace:
-	{
-		"targetname" "Path_A_navblock"
-		"affectsFlow" "0"
-	}
-}
-{
-	match:
-	{
-		"hammerid" "1058408"
-	}
-	replace:
-	{
-		"targetname" "Path_A_fence"
-	}
-}
-{
-	match:
-	{
-		"hammerid" "1058412"
-	}
-	replace:
-	{
-		"targetname" "Path_A_fence"
-	}
-}
-; --- Fence by the tree at the first corner
-{
-	match:
-	{
-		"hammerid" "1058629"
-	}
-	replace:
-	{
-		"targetname" "Path_A_clip"
-	}
-}
-{
-	match:
-	{
-		"hammerid" "1058619"
-	}
-	replace:
-	{
-		"targetname" "Path_A_navblock"
-		"affectsFlow" "0"
-	}
-}
-{
-	match:
-	{
-		"hammerid" "1058625"
-	}
-	replace:
-	{
-		"targetname" "Path_A_fence"
-	}
-}
-{
-	match:
-	{
-		"hammerid" "1058621"
-	}
-	replace:
-	{
-		"targetname" "Path_A_fence"
-	}
-}
-; --- Infected ladders to climb over blocked route
-add:
-{
-	"classname" "func_simpleladder"
-	"origin" "-476 1448 -84"
-	"angles" "0 0 0"
-	"model" "*268"
-	"normal.x" "-1.00"
-	"normal.y" "0.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
-{
-	"classname" "func_simpleladder"
-	"origin" "-386 1472 -84"
-	"angles" "0 0 0"
-	"model" "*283"
-	"normal.x" "1.00"
-	"normal.y" "0.00"
-	"normal.z" "0.00"
-	"team" "2"
-}

--- a/cfg/stripper/zonemod/maps/c6m1_riverbank.cfg
+++ b/cfg/stripper/zonemod/maps/c6m1_riverbank.cfg
@@ -1314,6 +1314,124 @@ modify:
 		"spawnflags" "1"
 	}
 }
+; --- Clipping on window frames throughout the map to make jumping onto them easiser
+add:
+; --- Outside saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "752 2636 325"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1008 2636 325"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1136 2636 325"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1664 2636 357"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1920 2636 357"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2048 2636 357"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- In the store
+{
+	"classname" "env_physics_blocker"
+	"origin" "3136 2604 234"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3520 2604 234"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3648 2604 234"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Above the alarm cars
+{
+	"classname" "env_physics_blocker"
+	"origin" "1416 1620 542"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "888 1620 542"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "888 1596 542"
+	"mins" "-32 -1 -5"
+	"maxs" "32 1 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- End saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "-3860 -400 1030"
+	"mins" "-1 -32 -5"
+	"maxs" "1 32 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-3860 -144 1030"
+	"mins" "-1 -32 -5"
+	"maxs" "1 32 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 
 
 ; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
@@ -1508,8 +1626,8 @@ add:
 ; --- Boxes to get on the bus by the ramp
 {
 	"classname" "prop_dynamic"
-	"origin" "-1067 1172 206"
-	"angles" "0 324 0"
+	"origin" "-1068.17 1171.21 204.916"
+	"angles" "2.14234 -36.1901 352.132"
 	"model" "models/props/cs_militia/boxes_garage_lower.mdl"
 	"solid" "6"
 	"disableshadows" "1"
@@ -1566,26 +1684,34 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
-; --- Bus behind tent by the end saferoom
+; --- Van by the end saferoom
 {
 	"classname" "prop_dynamic"
-	"origin" "-3105 543 703"
-	"angles" "0 174.5 0.4"
-	"model" "models/props_vehicles/bus01_2.mdl"
+	"origin" "-3185 540 704"
+	"angles" "0 78 0"
+	"model" "models/props_vehicles/van.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Block LOS under bus
+{
+	"classname" "prop_dynamic"
+	"origin" "-3185 540 704"
+	"angles" "0 78 0"
+	"model" "models/props_vehicles/van_glass.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+; --- Block LOS under van
 {
 	"classname" "logic_auto"
-	"OnMapSpawn" "losfix_bus_end,AddOutput,mins -163 -2 -10,0,-1"
-	"OnMapSpawn" "losfix_bus_end,AddOutput,maxs 163 2 10,0,-1"
-	"OnMapSpawn" "losfix_bus_end,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "losfix_van_end,AddOutput,mins -108 -2 -10,0,-1"
+	"OnMapSpawn" "losfix_van_end,AddOutput,maxs 108 2 10,0,-1"
+	"OnMapSpawn" "losfix_van_end,AddOutput,solid 2,0,-1"
 }
 {
 	"classname" "func_brush"
-	"origin" "-3127 542 712"
-	"targetname" "losfix_bus_end"
+	"origin" "-3186 539 712"
+	"targetname" "losfix_van_end"
 }
 
 ; =====================================================

--- a/cfg/stripper/zonemod/maps/c6m2_bedlam.cfg
+++ b/cfg/stripper/zonemod/maps/c6m2_bedlam.cfg
@@ -361,18 +361,18 @@ add:
 }
 {
 	"classname" "env_physics_blocker"
-	"origin" "894 579 168"
-	"mins" "-47 -3 -24"
-	"maxs" "47 3 24"
+	"origin" "894 579 132"
+	"mins" "-47 -3 -60"
+	"maxs" "47 3 60"
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Block survivors from standing on the AC units by the Jones & Sons building exit
+; --- Block survivors from standing on the AC units on the street before the jazz club
 {
 	"classname" "env_physics_blocker"
-	"origin" "-50 3709 268"
-	"mins" "-60.5 -32 -158"
-	"maxs" "60.5 32 158"
+	"origin" "-49.5 3710.5 456"
+	"mins" "-60.5 -30.5 -312"
+	"maxs" "60.5 30.5 312"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -381,6 +381,26 @@ add:
 	"origin" "-172 3695 392"
 	"mins" "-48 -23 -376"
 	"maxs" "48 23 376"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-128 4577 496"
+	"mins" "-60 -31 -272"
+	"maxs" "60 31 272"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from standing on the barricade in the corner of the street before the jazz club
+{
+	"classname" "env_physics_blocker"
+	"origin" "-209.27 4589.73 408"
+	"angles" "0 135 0"
+	"mins" "-19.5 -48 -360"
+	"maxs" "19.5 48 360"
+	"boxmins" "-19.5 -48 -360"
+	"boxmaxs" "19.5 48 360"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -559,6 +579,34 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Fix gate by the bar lacking proper collisions
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "losfix_bar_fence1,AddOutput,mins -5 -0.5 -47.5,0,-1"
+	"OnMapSpawn" "losfix_bar_fence1,AddOutput,maxs 5 0.5 47.5,0,-1"
+	"OnMapSpawn" "losfix_bar_fence1,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "losfix_bar_fence2,AddOutput,mins -5 -0.5 -47.5,0,-1"
+	"OnMapSpawn" "losfix_bar_fence2,AddOutput,maxs 5 0.5 47.5,0,-1"
+	"OnMapSpawn" "losfix_bar_fence2,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "losfix_bar_fence3,AddOutput,mins -32 -0.5 -1,0,-1"
+	"OnMapSpawn" "losfix_bar_fence3,AddOutput,maxs 32 0.5 1,0,-1"
+	"OnMapSpawn" "losfix_bar_fence3,AddOutput,solid 2,0,-1"
+}
+{
+	"classname" "func_brush"
+	"origin" "437 1943.5 -16.5"
+	"targetname" "losfix_bar_fence1"
+}
+{
+	"classname" "func_brush"
+	"origin" "491.5 1943.5 -16.5"
+	"targetname" "losfix_bar_fence2"
+}
+{
+	"classname" "func_brush"
+	"origin" "464 1943.5 32"
+	"targetname" "losfix_bar_fence3"
+}
 ; --- Fix right end of jazz club awning having no collision
 {
 	"classname" "prop_dynamic"
@@ -580,6 +628,9 @@ filter:
 }
 {
 	"hammerid" "565846"
+}
+{
+	"hammerid" "565860"
 }
 ; --- Clipping on debris piles at the drop into the sewer
 add:
@@ -607,7 +658,7 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
-; --- Clipping on non-solid debris pile for consistency
+; --- Clipping on non-solid debris pile for consistency with water movement speed
 {
 	"classname" "env_physics_blocker"
 	"origin" "678 5316 -1185"
@@ -624,6 +675,12 @@ add:
 	"maxs" "27 436.5 6"
 	"initialstate" "1"
 	"BlockType" "0"
+}
+; --- Remove non-static traffic barrels
+filter:
+{
+	"classname" "prop_physics"
+	"model" "models/props_fairgrounds/traffic_barrel.mdl"
 }
 
 
@@ -659,6 +716,15 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
+; --- Traffic barrel to allow players to jump onto the large dumpster by the cement truck (replaces physics prop)
+{
+	"classname" "prop_dynamic"
+	"origin" "-14 1410 -72.234"
+	"angles" "0 224.5 0"
+	"model" "models/props_fairgrounds/traffic_barrel.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
 ; --- Bricks to climb into the pool room from the construction site
 {
 	"classname" "prop_dynamic"
@@ -673,15 +739,6 @@ add:
 	"origin" "1242 1301 -72"
 	"angles" "-0.370436 359.396 -4.23301"
 	"model" "models/props/de_nuke/cinderblock_stack.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Prop to spawn behind on unused fire escape
-{
-	"classname" "prop_dynamic"
-	"origin" "950 2768 263"
-	"angles" "0 0 0"
-	"model" "models/props_junk/trashcluster01b_corner.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
@@ -966,7 +1023,7 @@ modify:
 ; ==              Add or change ladders              ==
 ; =====================================================
 add:
-; --- Ladders to climb up the middle section diving the construction area
+; --- Ladders to climb up the middle section dividing the construction area
 {
 	"classname" "func_simpleladder"
 	"origin" "5706 135 1000"
@@ -1329,301 +1386,6 @@ add:
 
 ; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
 ; =====================================================
-; ==              PLANK CROSSING REWORK              ==
-; ==   Open alternative route at the plank crossing  ==
+; ==                   BLANK HEADER                  ==
+; ==                Blank description                ==
 ; =====================================================
-add:
-; --- Block survivors from avoiding the Red Flight bar building entirely by going through the alleyway
-{
-	"classname" "prop_dynamic"
-	"origin" "464 1944 -64"
-	"angles" "0 270 0"
-	"model" "models/props_urban/gate_wall_gate003_64.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Fix collision issues with gate
-{
-	"classname" "logic_auto"
-	"OnMapSpawn" "losfix_gate_alley,AddOutput,mins -34 -1 -49,0,-1"
-	"OnMapSpawn" "losfix_gate_alley,AddOutput,maxs 34 1 49,0,-1"
-	"OnMapSpawn" "losfix_gate_alley,AddOutput,solid 2,0,-1"
-}
-{
-	"classname" "func_brush"
-	"origin" "464 1944 -16"
-	"targetname" "losfix_gate_alley"
-}
-; --- Infected ladder to get over fence
-{
-	"classname" "func_simpleladder"
-	"origin" "1136 5614.5 68"
-	"angles" "0 180 0"
-	"model" "*92"
-	"normal.x" "0.00"
-	"normal.y" "-1.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
-; --- Open up an alternative route to the right (tunnel used for survival/scavenge)
-filter:
-{
-	"targetname" "navblock_tunnel_shortcut"
-}
-{
-	"targetname" "brush_tunnel_shortcut"
-}
-; --- Exit sign and lighting to highlight the path
-add:
-{
-	"classname" "prop_dynamic"
-	"origin" "1073 3168 -12"
-	"angles" "0 180 0"
-	"model" "models/props/cs_office/exit_wall.mdl"
-	"solid" "0"
-	"disableshadows" "1"
-}
-{
-	"classname" "beam_spotlight"
-	"origin" "1073 3157 -15"
-	"angles" "87 270 0"
-	"spawnflags" "3"
-	"HDRColorScale" ".35"
-	"rendercolor" "0 255 0"
-	"renderamt" "255"
-	"spotlightwidth" "40"
-	"spotlightlength" "150"
-	"disablereceiveshadows" "1"
-	"rendermode" "0"
-}
-; --- Force survivors to go inside the building at the tunnel exit so that the route takes a similar amount of time to the plank
-{
-	"classname" "prop_dynamic"
-	"origin" "1150 3739 -160"
-	"angles" "0 0 0"
-	"model" "models/props_street/police_barricade2.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "1080 3815 -161"
-	"angles" "0 90 0"
-	"model" "models/props_street/police_barricade2.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "985 3807 -161"
-	"angles" "0 99.5 0"
-	"model" "models/props_street/police_barricade.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "915 3739 -160"
-	"angles" "0 144.5 0"
-	"model" "models/props_street/police_barricade2.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "logic_auto"
-	"OnMapSpawn" "barricade_path_navblock1,BlockNav,,1,-1"
-	"OnMapSpawn" "barricade_path_navblock2,BlockNav,,1,-1"
-	"OnMapSpawn" "barricade_path_navblock3,BlockNav,,1,-1"
-	"OnMapSpawn" "barricade_path_navblock4,BlockNav,,1,-1"
-	"OnMapSpawn" "barricade_path_navblock5,BlockNav,,1,-1"
-}
-{
-	"classname" "script_nav_blocker"
-	"origin" "1036 3739 -152"
-	"extent" "140 71 18"
-	"targetname" "barricade_path_navblock1"
-	"teamToBlock" "2"
-	"affectsFlow" "1"
-}
-{
-	"classname" "script_nav_blocker"
-	"origin" "1055 3816 -152"
-	"extent" "95 24 18"
-	"targetname" "barricade_path_navblock2"
-	"teamToBlock" "2"
-	"affectsFlow" "1"
-}
-{
-	"classname" "script_nav_blocker"
-	"origin" "868 3688 -152"
-	"extent" "28 24 18"
-	"targetname" "barricade_path_navblock3"
-	"teamToBlock" "2"
-	"affectsFlow" "1"
-}
-{
-	"classname" "script_nav_blocker"
-	"origin" "826 3870 -152"
-	"extent" "24 24 18"
-	"targetname" "barricade_path_navblock4"
-	"teamToBlock" "2"
-	"affectsFlow" "1"
-}
-{
-	"classname" "script_nav_blocker"
-	"origin" "811 3235 22"
-	"extent" "35 35 18"
-	"targetname" "barricade_path_navblock5"
-	"teamToBlock" "2"
-	"affectsFlow" "1"
-}
-; --- Plywood on barricades for spawns and ladder visibility
-{
-	"classname" "prop_dynamic"
-	"origin" "1100 3814 -162"
-	"angles" "90 270 0"
-	"model" "models/props_highway/plywood_03.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "1151 3810 -161"
-	"angles" "90 180 0"
-	"model" "models/props_highway/plywood_03.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Infected ladders to get over the barricade
-{
-	"classname" "func_simpleladder"
-	"origin" "1795 7486 -58"
-	"angles" "0 180 0"
-	"model" "*92"
-	"normal.x" "0.00"
-	"normal.y" "-1.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
-{
-	"classname" "func_simpleladder"
-	"origin" "-2521 4456 -57"
-	"angles" "0 270 0"
-	"model" "*92"
-	"normal.x" "1.00"
-	"normal.y" "0.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
-; --- Clipping to stop players getting stuck between the car and barricades
-{
-	"classname" "env_physics_blocker"
-	"origin" "1082 3831 -138"
-	"mins" "-70 -15 -20"
-	"maxs" "70 15 20"
-	"initialstate" "1"
-	"BlockType" "0"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "1097 3831 -108"
-	"mins" "-35 -15 -10"
-	"maxs" "35 15 10"
-	"initialstate" "1"
-	"BlockType" "0"
-}
-; --- Boxes to get over the barricades from the outside (nearby car can also be used)
-{
-	"classname" "prop_dynamic"
-	"origin" "907 3787 -161"
-	"angles" "0 54.5 0"
-	"model" "models/props_crates/static_crate_40.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "878 3743 -161"
-	"angles" "0 54.5 0"
-	"model" "models/props_crates/static_crate_40.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "901 3759 -123"
-	"angles" "0 54.5 0"
-	"model" "models/props_crates/static_crate_40.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic_override"
-	"origin" "909 3753 -77"
-	"angles" "0 144.5 0"
-	"model" "models/props_crates/supply_crate01.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Block survivors from jumping into a window from the barricade
-{
-	"classname" "env_physics_blocker"
-	"origin" "851 3675 68"
-	"mins" "-2.5 -11 -57.5"
-	"maxs" "2.5 11 57.5"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Block the path at the lower stairs in the Jones & Sons building, forcing survivors to go to the top floor
-{
-	"classname" "prop_dynamic"
-	"origin" "859 3201 8"
-	"angles" "0 90 0"
-	"model" "models/props_interiors/dresser_tall.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "859 3233 8"
-	"angles" "0 90 0"
-	"model" "models/props_interiors/dresser_tall.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "907 3263 8"
-	"angles" "0 0 0"
-	"model" "models/props_street/police_barricade.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "867 3269 8"
-	"angles" "0 0 0"
-	"model" "models/props_crates/static_crate_40.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-; --- Clipping for survivors on shelves to stop a skip
-{
-	"classname" "env_physics_blocker"
-	"origin" "861 3215 47"
-	"mins" "-32 -31 -37"
-	"maxs" "32 31 37"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Infected ladder to get over boxes
-{
-	"classname" "func_simpleladder"
-	"origin" "-2781.5 3871 61"
-	"angles" "0 270 0"
-	"model" "*92"
-	"normal.x" "1.00"
-	"normal.y" "0.00"
-	"normal.z" "0.00"
-	"team" "2"
-}

--- a/cfg/stripper/zonemod/maps/c7m1_docks.cfg
+++ b/cfg/stripper/zonemod/maps/c7m1_docks.cfg
@@ -3,77 +3,6 @@
 ; ==          DIRECTOR & EVENT MODIFICATION          ==
 ; ==       Modify director behaviour and events      ==
 ; =====================================================
-add:
-; --- Fix scavenge spawn positions when using thesaccing addon, as the spawn points use the L4D1 survivor names but the addon spawns L4D2 survivors
-{
-	"classname" "info_survivor_position"
-	"origin" "6089.54 342.04 146.017"
-	"angles" "0 195 0"
-	"targetname" "scavenge_position3"
-	"SurvivorName" "Rochelle"
-	"Order" "1"
-	"GameMode" "scavenge"
-}
-{
-	"classname" "info_survivor_position"
-	"origin" "6077.26 256.76 149.017"
-	"angles" "0 195 0"
-	"targetname" "scavenge_position4"
-	"SurvivorName" "Ellis"
-	"Order" "1"
-	"GameMode" "scavenge"
-}
-{
-	"classname" "info_survivor_position"
-	"origin" "6147.4 267.4 150.017"
-	"angles" "0 180 0"
-	"targetname" "scavenge_position2"
-	"SurvivorName" "Nick"
-	"Order" "1"
-	"GameMode" "scavenge"
-}
-{
-	"classname" "info_survivor_position"
-	"origin" "6139.4 315.4 149.017"
-	"angles" "0 180 0"
-	"targetname" "scavenge_position1"
-	"SurvivorName" "Coach"
-	"Order" "1"
-	"GameMode" "scavenge"
-}
-; --- Add L4D2 survivor spawn positions to the saferoom, as thesaccing.vpk causes L4D2 survivors to be used when transitioning to this map
-{
-	"classname" "info_survivor_position"
-	"origin" "13915 2567 32.2028"
-	"angles" "0 270 0"
-	"targetname" "survivorPos_intro_01"
-	"SurvivorName" "Nick"
-	"Order" "1"
-}
-{
-	"classname" "info_survivor_position"
-	"origin" "13864.5 2593.2 32.2028"
-	"angles" "0 270 0"
-	"targetname" "survivorPos_intro_02"
-	"SurvivorName" "Rochelle"
-	"Order" "1"
-}
-{
-	"classname" "info_survivor_position"
-	"origin" "13806.5 2583 33"
-	"angles" "0 270 0"
-	"targetname" "survivorPos_intro_03"
-	"SurvivorName" "Coach"
-	"Order" "1"
-}
-{
-	"classname" "info_survivor_position"
-	"origin" "13765.1 2545 33"
-	"angles" "0 270 0"
-	"targetname" "survivorPos_intro_04"
-	"SurvivorName" "Ellis"
-	"Order" "1"
-}
 ; --- Automatically open the 2nd train car door 20 seconds after the tank is spawned
 modify:
 {
@@ -419,7 +348,7 @@ add:
 {
 	"classname" "env_physics_blocker"
 	"origin" "10252 -40 -73"
-	"mins" "-20 -32 -6"
+	"mins" "-20 -32	-6"
 	"maxs" "20 32 6"
 	"initialstate" "1"
 	"BlockType" "0"
@@ -626,33 +555,6 @@ add:
 	"normal.y" "0.00"
 	"normal.z" "0.00"
 	"team" "2"
-}
-; --- Infected ladder to climb on the boat at the back of the tank area
-{
-	"classname" "func_simpleladder"
-	"origin" "8679 9717 -31"
-	"angles" "0 270 0"
-	"model" "*10"
-	"normal.x" "0.00"
-	"normal.y" "1.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "9114 298 127"
-	"mins" "-16 -3 -6"
-	"maxs" "16 3 6"
-	"initialstate" "1"
-	"BlockType" "3"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "9114 293 136"
-	"mins" "-16 -5 -3"
-	"maxs" "16 5 3"
-	"initialstate" "1"
-	"BlockType" "3"
 }
 ; --- Infected ladder on the bricks by the yellow pickup truck
 {

--- a/cfg/stripper/zonemod/maps/c7m2_barge.cfg
+++ b/cfg/stripper/zonemod/maps/c7m2_barge.cfg
@@ -3,45 +3,6 @@
 ; ==          DIRECTOR & EVENT MODIFICATION          ==
 ; ==       Modify director behaviour and events      ==
 ; =====================================================
-add:
-; --- Fix scavenge spawn positions when using thesaccing addon, as the spawn points use the L4D1 survivor names but the addon spawns L4D2 survivors
-{
-	"classname" "info_survivor_position"
-	"origin" "-3209.14 269.716 2.08984"
-	"angles" "0 195 0"
-	"targetname" "scavenge_position4"
-	"SurvivorName" "Ellis"
-	"Order" "1"
-	"GameMode" "scavenge"
-}
-{
-	"classname" "info_survivor_position"
-	"origin" "-3139 280.356 2.08984"
-	"angles" "0 180 0"
-	"targetname" "scavenge_position2"
-	"SurvivorName" "Nick"
-	"Order" "1"
-	"GameMode" "scavenge"
-}
-{
-	"classname" "info_survivor_position"
-	"origin" "-3147 328.356 2.08984"
-	"angles" "0 180 0"
-	"targetname" "scavenge_position1"
-	"SurvivorName" "Coach"
-	"Order" "1"
-	"GameMode" "scavenge"
-}
-{
-	"classname" "info_survivor_position"
-	"origin" "-3196.86 354.997 4.08984"
-	"angles" "0 195 0"
-	"targetname" "scavenge_position3"
-	"SurvivorName" "Rochelle"
-	"Order" "1"
-	"GameMode" "scavenge"
-}
-
 
 ; ################  ITEM SPAWN CHANGES  ###############
 ; =====================================================
@@ -98,32 +59,6 @@ filter:
 ; ==                 HITTABLE CHANGES                ==
 ; ==           Add/remove/modify hittables           ==
 ; =====================================================
-; --- Make a car in the fueling area unhittable
-filter:
-{
-	"targetname" "car03"
-}
-{
-	"parentname" "car03"
-}
-add:
-{
-	"classname" "prop_dynamic"
-	"origin" "4256 1776 129"
-	"angles" "0 150 0"
-	"model" "models/props_vehicles/cara_84sedan.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "4256 1776 129"
-	"angles" "0 150 0"
-	"model" "models/props_vehicles/cara_84sedan_glass.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-
 
 ; #############  MAP CLIPPING AND ISSUES  #############
 ; =====================================================
@@ -212,6 +147,23 @@ add:
 	"disableshadows" "1"
 	"parentname" "car05"
 }
+; --- Clipping on trees after the saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "7372 365 141"
+	"mins" "-66 -70 -6"
+	"maxs" "66 70 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "8677 1393 127"
+	"mins" "-67 -67 -6"
+	"maxs" "67 67 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Clipping on fallen lamp post before open water section to stop players from getting stuck
 {
 	"classname" "env_physics_blocker"
@@ -270,7 +222,7 @@ add:
 ; ==       New props for balance and SI spawns       ==
 ; =====================================================
 add:
-; --- Tree by the first silo
+; --- Tree by the first silo on the platform
 {
 	"classname" "prop_dynamic"
 	"origin" "7497 215 254"
@@ -279,104 +231,15 @@ add:
 	"solid" "6"
 	"disableshadows" "1"
 }
-; --- Pipes in the water after the saferoom
+; --- Cargo container under the first silo
 {
 	"classname" "prop_dynamic"
-	"origin" "7836 1508 39"
-	"angles" "0 180 0"
-	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"origin" "7700 450 142"
+	"angles" "0 90 0"
+	"model" "models/props_equipment/cargo_container01_fixed.mdl"
 	"solid" "6"
 	"disableshadows" "1"
-	"lightingorigin" "pond_pipe_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "7516 1508 78"
-	"angles" "0 180 0"
-	"model" "models/props_pipes/pipeset32d_512_001a.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "pond_pipe_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "7132 1508 78"
-	"angles" "0 180 0"
-	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "pond_pipe_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "7804 1494 4"
-	"angles" "0 180 0"
-	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "pond_pipe_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "7484 1494 43"
-	"angles" "0 180 0"
-	"model" "models/props_pipes/pipeset32d_512_001a.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "pond_pipe_lighting"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "7100 1494 43"
-	"angles" "0 180 0"
-	"model" "models/props_pipes/pipeset32d_256_001a.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-	"lightingorigin" "pond_pipe_lighting"
-}
-{
-	"classname" "logic_auto"
-	"OnMapSpawn" "pond_pipe_brush,AddOutput,mins -402 -0.1 -31,0,-1"
-	"OnMapSpawn" "pond_pipe_brush,AddOutput,maxs 402 0.1 31,0,-1"
-	"OnMapSpawn" "pond_pipe_brush,AddOutput,solid 2,0,-1"
-}
-{
-	"classname" "func_brush"
-	"origin" "7435 1506 40"
-	"targetname" "pond_pipe_brush"
-}
-{
-	"classname" "info_target"
-	"origin" "7449 1507 83"
-	"targetname" "pond_pipe_lighting"
-}
-; --- Infected ladder on the pipes
-{
-	"classname" "func_simpleladder"
-	"origin" "-360 1206 -156"
-	"angles" "0 0 0"
-	"model" "*236"
-	"normal.x" "0.00"
-	"normal.y" "1.00"
-	"normal.z" "0.00"
-	"team" "2"
-}
-; --- Extra pole clusters by the sunken fishing boat
-{
-	"classname" "prop_dynamic"
-	"origin" "142 1562 36"
-	"angles" "0 0 0"
-	"model" "models/props_docks/dock01_polecluster01d_256.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "141 1863 34"
-	"angles" "0 180 0"
-	"model" "models/props_docks/dock01_polecluster01d_256.mdl"
-	"solid" "6"
-	"disableshadows" "1"
+	"rendercolor" "119 152 191"
 }
 ; --- Rock by the sunken barge
 {

--- a/cfg/stripper/zonemod/maps/c9m1_alleys.cfg
+++ b/cfg/stripper/zonemod/maps/c9m1_alleys.cfg
@@ -665,22 +665,24 @@ filter:
 	"parentname" "car_sedan19-car_physics"
 }
 ; --- Reduce number of hittable dumpsters (+ other hittables)
-; --- By the saferoom (was 6 dumpsters, now 1)
+; --- By the saferoom (was 6 dumpsters, now 2)
 filter:
+; --- "origin" "-8904.63 -9744.28 -0.6875"
 {
 	"hammerid" "187"
 }
+; --- "origin" "-8751.44 -9730.56 1.90625"
 {
 	"hammerid" "153"
 }
+; --- "origin" "-8048.5 -10203.8 -2.875"
 {
 	"hammerid" "119751"
 }
+; --- Removed by TLS
+; --- "origin" "-10274.9 -9823.31 -0.34375"
 {
 	"hammerid" "637"
-}
-{
-	"hammerid" "199"
 }
 ; --- Around the warehouse (was 2 dumpsters + 1 forklift, now 2 dumpsters + 0 forklifts)
 filter:

--- a/cfg/stripper/zonemod/maps/c9m2_lots.cfg
+++ b/cfg/stripper/zonemod/maps/c9m2_lots.cfg
@@ -319,7 +319,7 @@ modify:
 ; ==                 HITTABLE CHANGES                ==
 ; ==           Add/remove/modify hittables           ==
 ; =====================================================
-; --- By the saferoom (was 3 cars, now 0)
+; --- By the saferoom (was 3 cars, now 1)
 filter:
 {
 	"targetname" "car_sedan1-car_physics"
@@ -365,30 +365,6 @@ add:
 	"origin" "1248 -287 -224"
 	"angles" "1.84293 312.527 1.68956"
 	"model" "models/props_vehicles/cara_84sedan_glass.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-filter:
-{
-	"targetname" "car_hatchback1-car_physics"
-}
-{
-	"parentname" "car_hatchback1-car_physics"
-}
-add:
-{
-	"classname" "prop_dynamic"
-	"origin" "1943.91 -152.099 -217.962"
-	"angles" "-0.566462 45.5974 0.453201"
-	"model" "models/props_vehicles/cara_82hatchback.mdl"
-	"solid" "6"
-	"disableshadows" "1"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "1943.91 -152.099 -217.962"
-	"angles" "-0.566462 45.5974 0.453201"
-	"model" "models/props_vehicles/cara_82hatchback_glass.mdl"
 	"solid" "6"
 	"disableshadows" "1"
 }
@@ -545,27 +521,6 @@ filter:
 	"parentname" "car_hatchback4-car_physics"
 }
 ; --- Around the finale area (was 2 cars, unchanged)
-; --- Reduce number of hittable dumpsters (was 9 dumpsters, now 6 dumpsters)
-; --- By the saferoom (was 2 dumpsters, now 1)
-filter:
-{
-	"hammerid" "110215"
-}
-; --- By the alarm car/humvee (was 0 dumpsters, unchanged)
-; --- By the warehouses (was 1 dumpster, now 0)
-filter:
-{
-	"hammerid" "67369"
-}
-; --- After the shipping containers (was 3 dumpsters, now 1)
-filter:
-{
-	"hammerid" "48656"
-}
-{
-	"hammerid" "248947"
-}
-; --- Around the finale area (was 3 dumpsters, unchanged)
 
 
 ; #############  MAP CLIPPING AND ISSUES  #############


### PR DESCRIPTION
Been a while, huh.
Mostly fixing some lingering issues and adjusting some things where I was not happy with how they played.
Some big changes on Dead Center in particular.

### All Maps
* Removed weapon skin enabler script
* Removed or reverted various nuisance physics props back to non-solid
	* Barrels
	* Trash cans
	* Wooden Sawhorse
	* Utility cart
	* Small green filing cabinet

### Dead Center
#### Map 1
* Adjusted placement of weapon spawns in the first hallway
* Fixed an issue where infected could remove an exploit blocker by breaking a door, it is now removed when survivors hit a trigger
* Blocked a stuck-warp spot on a pile of luggage after the elevator
* Re-worked the props by the end saferoom
* Blocked survivors reaching some unintended areas in the dining hall
* Improved the glow on the button for the elevator holdout event
#### Map 2
* Replaced a hedge prop to get on a highway sign with a ladder
* Blocked an out of bounds spot at the back of the highway
* Blocked an out of bounds spot stuck spot behind the gun store / end saferoom
* Replaced boxes to jump on a platform before the overpass with a traffic barrel
* Disabled alarm cars by the end saferoom
#### Map 3
* Re-worked logic for all event paths, routes are now set on map start to prevent issues with boss spawns
    * This was already partially done in a previous update but has now been improved
* Removed pill spawns in the Just For Kidz store
* Fixed an incorrectly opening / closing door in the Just For Kidz store
* Restored the lower path pill cabinet to it's original position
* Moved the ammo pile on the lower route from the boxes onto the stairwell
* Improved clipping on the tall shelves by the saferoom
* Made the doors to start the event open at a normal speed
* Removed the fence cover outside the saferoom
* Adjusted shelf by the second set of escalators behind the collapsed gate
* Replaced shelves on the far side of the second set of escalators with boxes
* Removed the additional shelves after the second set of escalators
* Added a kiosk by the shutters after the second set of escalators
* Re-worked the props in the side area before the offices (Reverted to ProMod)
* Added an additional kiosk on the lower floor of the end saferoom area
* Adjusted a shelf before the final escalator
* Re-worked the modified escalator route to the end saferoom (Reverted to ProMod)
#### Map 4
* Fixed a gascan blocker clip in the back corner

### Dark Carnival
#### Map 1
* Added a ledge for infected to jump / stand on the interstate sign outside the saferoom
* Restored the door under highway sign by the motel to its original closed state
* Blocked LOS under floating AC vents on the motel cafeteria roof to prevent spawn blocks
* Added clipping to all police car lights to prevent getting stuck
* Added a ledge for infected to climb on top of a tree by the highway before the one way drop
* Adjusted roof trim on the motel roof before the drop
* Removed the infected ladder to get on the motel roof closest to the one way drop
* Adjusted the two added bushes before the one way drop
* Replaced the bus at the top of the hill by the end saferoom with a van
#### Map 2
* Filled in the gap on the added saferoom roof props and improved clipping on the pipes
* Blocked standing on the yellow tent by the saferoom
* Removed the leaning concrete block by the warehouse entrance
* Removed item spawns in the previously fenced-off area before the ramp
* Blocked standing on the ride signs in Kiddyland
* Blocked LOS under the fences on the monorail track to prevent spawn blocks
* Blocked survivors being able to stand on the telephone pole by the ladder
* Removed the added hedge on the stairs by the end saferoom
#### Map 3
* Moved the ammo pile in the tunnel of love to the second set of rooms
* Blocked survivors from standing on the electrical box and infected ladder in the swan room
* Fixed a sliding stuck spot by the console in the swan room
* Removed the extra railing in the end saferoom
#### Map 4
* Moved ammo pile into the bumper cars area
* Removed the extra railing in the saferoom
* Adjusted infected ladders by the starting saferoom
* Adjusted clips on the hedges by the barn exit
* Adjusted clips on the shrub walls by the barn drop
* Blocked standing on a fence near the barn drop
* Re-added window to the building before the barn entrance
* Replaced plywood on balcony with a vending machine
* Added clipping on the fence at the top of the stairs by the event to prevent getting stuck on it

### Swamp Fever
#### Map 2
* Removed additional bushes between some trees with invisible walls
#### Map 3
* Removed solid trash bags at the event
* Replaced tractor by the end saferoom with a shrub wall

### Hard Rain
#### Maps 1 & 4
* Improved collisions on the SUV by the sugarmill saferoom
* Added a box under the treehouse
* Removed the boxes outside the sugarmill saferoom
* Replaced the TLS infected ladder on the raised house with a better one
* Improved clipping to prevent weapons being lost on the docks
* (Map 4) Blocked nav on the blocked door at the house drop to prevent AI getting stuck trying to path through it
* Removed non-static traffic barrels by the sugarmill saferoom
* Replaced chimney on roof with AC unit (Reverted to ProMod)
### Maps 2 & 3
* Removed the additional porta potty from the construction site
* Fixed some unintended skips caused by some exploit blockers at the fallen silos
* Added an infected ladder to prevent a perma-stuck spot behind the fence by the silos

### The Parish
#### Map 1
* Improved exploit blocker on a fence by the saferoom
#### Map 2
* Changed a hedge by the restrooms in the park to a smaller one
#### Map 3
* Blocked survivors from standing on the large dumpster by the stairs before the bus drop
* Adjusted infected ladders on the green fences before the sewers
* Adjusted an infected ladder by the sewer drop
* Re-worked the props around the sewer drop (reverted to ProMod)
* Made the pipe survivors can stand on at the sewer ladder choke higher up
* Removed the fences at the top of the sewer ladder
* Removed the extra wall by the bridge drop
* Added visual indication of the infected ladder on the shack after the bridge
* Removed the extra path blockers in the cemetery (reverted back to default pathing)

### The Passing
#### Map 1
* Added clipping on window frames throughout the map to make jumping onto them easier
* Adjusted boxes by the bus at the bottom of the ramp
* Replaced bus by the end saferoom with a van
#### Map 2
* Removed the alternate path by the fire escape chokepoint
* Adjusted blocker on the signs in the pool room
* Removed non-static traffic barrels
* Removed trash bags on the fire escape in the corner
* Adjusted blocker on the AC vent before the Jazz Club
* Blocked an AC vent above the bus stop
* Blocked standing on the barricade by the bus stop
* Removed one of the breakable walls in the side room on the left before the sewer

### The Sacrifice
#### Map 1
* Removed an added infected ladder to climb on a boat in the tank fight area that could block survivors
#### Map 2
* Added clipping to some trees after the saferoom
* Removed the pipes in the water after the saferoom
* Added a cargo container by the silo after the saferoom
* Restored the hittable car on the right-side path after the car shop

### Crash Course
#### Map 1
* Restored 1 hittable dumpster by the saferoom
#### Map 2
* Restored all hittable dumpsters
* Restored 1 hittable car by the saferoom

### Death Toll
#### Map 1
* Improved clipping on the wall at the end of the tunnel
#### Map 2
* Blocked standing on the bridge supports by the event
* Removed file cabinets on the ground by the end saferoom
#### Map 3
* Reverted the gravestones to being breakable
#### Map 4
* Blocked standing on a truck after the florist shop
* Added clipping to sleeping bags in the florist shop

### Dear Air
#### Map 5
* Blocked survivors from standing on a sky bridge

### Blood Harvest
#### Map 5
* Blocked an out of bounds stuck spot in the cliffs behind the saferoom

### Cold Stream
#### Map 2
* Blocked a stuck spot behind the barricade below the static tank spawn

### The Last Stand
#### Map 1
* Removed the sounds / dialogue from the plane crash at the start of the map
#### Map 2
* Added an ammo pile on the beach