### PR TITLE
Stripper review review

### DIFF
--- a/cfg/stripper/zonemod/global_filters.cfg
+++ b/cfg/stripper/zonemod/global_filters.cfg
@@ -3644,6 +3644,17 @@ modify:
 	match:
 	{
 		"classname" "/.*prop_physics.*/"
+		"model" "models/props_interiors/furniture_chair03a.mdl"
+	}
+	insert:
+	{
+		"spawnflags" "4"
+	}
+}
+{
+	match:
+	{
+		"classname" "/.*prop_physics.*/"
 		"model" "models/props_interiors/patio_chair2_white.mdl"
 	}
 	insert:

--- a/cfg/stripper/zonemod/global_filters.cfg
+++ b/cfg/stripper/zonemod/global_filters.cfg
@@ -4624,3 +4624,14 @@ modify:
 		"spawnflags" "4"
 	}
 }
+{
+	match:
+	{
+		"classname" "/.*prop_physics.*/"
+		"model" "models/props_normandy/haybale.mdl"
+	}
+	insert:
+	{
+		"spawnflags" "4"
+	}
+}

--- a/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
+++ b/cfg/stripper/zonemod/maps/c2m2_fairgrounds.cfg
@@ -829,6 +829,15 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+; --- Block skip to jump up to the fence by the carousel from below after clearing the event
+{
+	"classname" "env_physics_blocker"
+	"origin" "-3014 -5185.5 -42.5"
+	"mins" "-6 -1.5 -21.5"
+	"maxs" "6 1.5 21.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 
 ; =====================================================
 ; ==                  OUT OF BOUNDS                  ==

--- a/cfg/stripper/zonemod/maps/c5m3_cemetery.cfg
+++ b/cfg/stripper/zonemod/maps/c5m3_cemetery.cfg
@@ -604,6 +604,29 @@ add:
 	"parentname" "destruction_car_phys"
 	"targetname" "destruction_car_glass"
 }
+; --- Clipping on dryers by the shack
+{
+	"classname" "env_physics_blocker"
+	"origin" "5036.77 4186.99 50"
+	"angles" "0 210 0"
+	"mins" "-2 -15 -4"
+	"maxs" "2 15 4"
+	"boxmins" "-2 -15 -4"
+	"boxmaxs" "2 15 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4983.01 4229.81 49"
+	"angles" "0 285 0"
+	"mins" "-2 -15 -4"
+	"maxs" "2 15 4"
+	"boxmins" "-2 -15 -4"
+	"boxmaxs" "2 15 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Clipping on draped bodies by the shack
 {
 	"classname" "env_physics_blocker"

--- a/cfg/stripper/zonemod/maps/c5m3_cemetery.cfg
+++ b/cfg/stripper/zonemod/maps/c5m3_cemetery.cfg
@@ -286,6 +286,15 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+; --- Block section of rooftop by the shack survivors can stand on
+{
+	"classname" "env_physics_blocker"
+	"origin" "5152 5256 440"
+	"mins" "-256 -8 -200"
+	"maxs" "256 8 200"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block survivors from climbing electrical box by the shack
 {
 	"classname" "env_physics_blocker"

--- a/cfg/stripper/zonemod/maps/c7m2_barge.cfg
+++ b/cfg/stripper/zonemod/maps/c7m2_barge.cfg
@@ -164,7 +164,13 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Remove leaning filing cabinet in the car shop
+filter:
+{
+	"hammerid" "638358"
+}
 ; --- Clipping on fallen lamp post before open water section to stop players from getting stuck
+add:
 {
 	"classname" "env_physics_blocker"
 	"origin" "2365 1641 136"


### PR DESCRIPTION
- Global: Changed `models/props_interiors/furniture_chair03a.mdl` to debris (blue metal chair)
    - [6392eec](https://github.com/SirPlease/L4D2-Competitive-Rework/pull/945/commits/6392eecf85833ff47fdee2b3f3606fc11d8e45ab) it appears the duplicate should have been this chair as it's the next in the model list
- Global: Changed haybale physics props into debris
- c2m2: Blocked skip to jump up to the fence by the carousel from below after clearing the event
- c5m3: Added clipping on dryers by the shack to prevent getting stuck
- c5m3: Blocked section of rooftop by the shack that the survivors can stand on
- c7m2: Removed a leaning filing cabinet in the car shop


I checked the other duplicates that were cleaned up and they all looked fine