### PR TITLE
Carried Off Update

### DIFF
--- a/cfg/stripper/zonemod/maps/cwm1_intro.cfg
+++ b/cfg/stripper/zonemod/maps/cwm1_intro.cfg
@@ -88,7 +88,7 @@ add:
 ; =====================================================
 ; --- Run nav fixes script
 ; --- Fix 1: Fixes god spot on top of bus outside the saferoom
-; --- Fix 2: Fixes commons getting stuck at the top of the stairs by the millionth customer door
+; --- Fix 2: Fixes god spot on truck and buses after warehouse
 add:
 {
 	"classname" "logic_auto"

--- a/cfg/stripper/zonemod/maps/cwm1_intro.cfg
+++ b/cfg/stripper/zonemod/maps/cwm1_intro.cfg
@@ -81,6 +81,19 @@ add:
     "origin" "3144 3856 152"
 }
 
+; ############  DIRECTOR AND EVENT CHANGES  ###########
+; =====================================================
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==       Modify director behaviour and events      ==
+; =====================================================
+; --- Run nav fixes script
+; --- Fix 1: Fixes god spot on top of bus outside the saferoom
+; --- Fix 2: Fixes commons getting stuck at the top of the stairs by the millionth customer door
+add:
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "director,RunScriptFile,nav_fixes/cwm1_intro_navfixes,20,-1"
+}
 
 ; =====================================================
 ; ==                STATIC AMMO PILES                ==
@@ -586,7 +599,7 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- Block surviors getting on the end saferoom roof
+; --- Block survivors getting on the end saferoom roof and going out of bounds
 {
 	"classname" "env_physics_blocker"
 	"origin" "-1792 9493 902"
@@ -625,4 +638,151 @@ add:
 	"maxs" "45.5 136.5 56"
 	"initialstate" "1"
 	"BlockType" "0"
+}
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+add:
+; --- Ladder on front of red truck outside the starting saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "4883 -6133 -83"
+    "angles" "0 90 0"
+    "model" "*17"
+    "normal.x" "1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "0"
+}
+; --- Infected ladders on bus outside the starting saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "3793.7 474.279 -37"
+    "angles" "0 242 0"
+    "model" "*17"
+    "normal.x" "-0.882948"
+    "normal.y" "0.469472"
+    "normal.z" "0"
+    "team" "2"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "3826.3 -6471.28 -37"
+    "angles" "0 62 0"
+    "model" "*17"
+    "normal.x" "0.882948"
+    "normal.y" "-0.469472"
+    "normal.z" "0"
+    "team" "2"
+}
+; --- Infected ladder on hedge outside the starting saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "6578 -1873 -8"
+    "angles" "0 180 0"
+    "model" "*17"
+    "normal.x" "0"
+    "normal.y" "1"
+    "normal.z" "0"
+    "team" "2"
+}
+; --- Infected ladders on street corner fence outside the starting saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "2704 390 -24"
+    "angles" "0 270 0"
+    "model" "*17"
+    "normal.x" "-1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "2"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "5889 -5769 -24"
+    "angles" "0 90 0"
+    "model" "*17"
+    "normal.x" "1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "2"
+}
+; --- Infected ladder on back of semi trailer before the tents
+{
+    "classname" "func_simpleladder"
+    "origin" "5320.23 -816.963 -3"
+    "angles" "0 83 0"
+    "model" "*17"
+    "normal.x" "0.992546"
+    "normal.y" "-0.121869"
+    "normal.z" "0"
+    "team" "2"
+}
+; --- Infected ladder on fence at entrance to tents area
+{
+    "classname" "func_simpleladder"
+    "origin" "4977 -992 -32"
+    "angles" "0 90 0"
+    "model" "*17"
+    "normal.x" "1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "2"
+}
+; --- Ladder to climb on front of orange truck outside the warehouse
+{
+    "classname" "func_simpleladder"
+    "origin" "2809.15 -1408.46 -83"
+    "angles" "0 80.5 0"
+    "model" "*17"
+    "normal.x" "0.986286"
+    "normal.y" "-0.165048"
+    "normal.z" "0"
+    "team" "0"
+}
+; --- Infected ladders on trucks outside the warehouse
+{
+    "classname" "func_simpleladder"
+    "origin" "4126 3558 -3"
+    "angles" "0 180 0"
+    "model" "*17"
+    "normal.x" "0"
+    "normal.y" "1"
+    "normal.z" "0"
+    "team" "2"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "-1800 271 -3"
+    "angles" "0 360 0"
+    "model" "*17"
+    "normal.x" "1.74846e-007"
+    "normal.y" "-1"
+    "normal.z" "0"
+    "team" "2"
+}
+; --- Infected ladder on fallen semi trailer outside the warehouse
+{
+    "classname" "func_simpleladder"
+    "origin" "2181.69 5872.49 -93.7195"
+    "angles" "0 235 1"
+    "model" "*17"
+    "normal.x" "-0.819027"
+    "normal.y" "0.573489"
+    "normal.z" "-0.0174524"
+    "team" "2"
+}
+; --- Infected ladder on the far side of the warehouse by the truck
+{
+    "classname" "func_simpleladder"
+    "origin" "1584 4737 0"
+    "angles" "0 180 0"
+    "model" "*22"
+    "normal.x" "0"
+    "normal.y" "-1"
+    "normal.z" "0"
+    "team" "2"
 }

--- a/cfg/stripper/zonemod/maps/cwm1_intro.cfg
+++ b/cfg/stripper/zonemod/maps/cwm1_intro.cfg
@@ -49,17 +49,6 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-
-; --- Block jumping on some bags to get on a tent before the warehouse
-{
-	"classname" "env_physics_blocker"
-	"origin" "2861 1850 214"
-	"mins" "-79 -53 -105"
-	"maxs" "79 53 105"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-
 ; --- Block warehouse shelves for survivors
 {
 	"classname" "env_physics_blocker"
@@ -90,4 +79,550 @@ add:
     "initialstate" "1"
     "targetname" "eb_fix1"
     "origin" "3144 3856 152"
+}
+
+
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
+; --- Ammo pile at the warehouse exit
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "466 1829 176.5"
+	"angles" "0 90 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+; --- Block room accessible from the awnings by the starting saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "2048 -2876 400"
+	"mins" "-156 -4 -48"
+	"maxs" "156 4 48"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block balconies accessible from the awnings by the starting saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "1792 -2836 799"
+	"mins" "-36 -24 -481"
+	"maxs" "36 24 481"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1664 -2840 799"
+	"mins" "-36 -24 -481"
+	"maxs" "36 24 481"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1536 -2840 799"
+	"mins" "-36 -24 -481"
+	"maxs" "36 24 481"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1280 -2840 799"
+	"mins" "-36 -24 -481"
+	"maxs" "36 24 481"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on bus at the end of the street by the starting saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "1526.52 -3169.35 696"
+	"angles" "0 77.5 0"
+	"mins" "-51 -235 -584"
+	"maxs" "51 235 584"
+	"boxmins" "-51 -235 -584"
+	"boxmaxs" "51 235 584"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on the porta potties
+{
+	"classname" "env_physics_blocker"
+	"origin" "3052 2852 745.5"
+	"angles" "0 -4 0"
+	"mins" "-28 -28 -534.5"
+	"maxs" "28 28 534.5"
+	"boxmins" "-28 -28 -534.5"
+	"boxmaxs" "28 28 534.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2984 2848 745.5"
+	"angles" "0 -4 0"
+	"mins" "-28 -28 -534.5"
+	"maxs" "28 28 534.5"
+	"boxmins" "-28 -28 -534.5"
+	"boxmaxs" "28 28 534.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2916 2844 745.5"
+	"angles" "0 5 0"
+	"mins" "-28 -28 -534.5"
+	"maxs" "28 28 534.5"
+	"boxmins" "-28 -28 -534.5"
+	"boxmaxs" "28 28 534.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block tent by the fallen semi-trailer
+{
+	"classname" "env_physics_blocker"
+	"origin" "2265.73 2542.02 760"
+	"angles" "0 -1 0"
+	"mins" "-190 -5 -520"
+	"maxs" "190 5 520"
+	"boxmins" "-190 -5 -520"
+	"boxmaxs" "190 5 520"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2270.27 2801.98 760"
+	"angles" "0 -1 0"
+	"mins" "-190 -5 -520"
+	"maxs" "190 5 520"
+	"boxmins" "-190 -5 -520"
+	"boxmaxs" "190 5 520"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2081.03 2675.26 760"
+	"angles" "0 -1 0"
+	"mins" "-3 -125 -520"
+	"maxs" "3 125 520"
+	"boxmins" "-3 -125 -520"
+	"boxmaxs" "3 125 520"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2454.97 2668.74 760"
+	"angles" "0 -1 0"
+	"mins" "-3 -125 -520"
+	"maxs" "3 125 520"
+	"boxmins" "-3 -125 -520"
+	"boxmaxs" "3 125 520"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on fallen semi-trailer before the warehouse
+{
+	"classname" "env_physics_blocker"
+	"origin" "1838.11 2506.13 748"
+	"angles" "0 -35 0"
+	"mins" "-58.5 -266.5 -532"
+	"maxs" "58.5 266.5 532"
+	"boxmins" "-58.5 -266.5 -532"
+	"boxmaxs" "58.5 266.5 532"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2021.64 2621.78 748"
+	"angles" "0 -35 0"
+	"mins" "-25.5 -66.5 -532"
+	"maxs" "25.5 66.5 532"
+	"boxmins" "-25.5 -66.5 -532"
+	"boxmaxs" "25.5 66.5 532"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on the beige truck and trailer before the warehouse
+{
+	"classname" "env_physics_blocker"
+	"origin" "1327.27 3011.92 696"
+	"angles" "0 -23 0"
+	"mins" "-46 -51 -584"
+	"maxs" "46 51 584"
+	"boxmins" "-46 -51 -584"
+	"boxmaxs" "46 51 584"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1659.5 2836.5 779"
+	"angles" "0 59 0"
+	"mins" "-51.5 -266.5 -501"
+	"maxs" "51.5 266.5 501"
+	"boxmins" "-51.5 -266.5 -501"
+	"boxmaxs" "51.5 266.5 501"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from getting on the warehouse roof
+{
+	"classname" "env_physics_blocker"
+	"origin" "512 2367 880.5"
+	"mins" "-320 -576 -400.5"
+	"maxs" "320 576 400.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from standing on the rollup doors inside the warehouse
+{
+	"classname" "env_physics_blocker"
+	"origin" "804 2782 376.5"
+	"mins" "-12 -68 -87.5"
+	"maxs" "12 68 87.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "804 2494 376.5"
+	"mins" "-12 -68 -87.5"
+	"maxs" "12 68 87.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "804 2206 376.5"
+	"mins" "-12 -68 -87.5"
+	"maxs" "12 68 87.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from standing on the roof above the stairs after the warehouse
+{
+	"classname" "env_physics_blocker"
+	"origin" "-512 3167 904"
+	"mins" "-192 -160 -376"
+	"maxs" "192 160 376"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-480 2981.5 881"
+	"mins" "-2 -25.5 -399"
+	"maxs" "2 25.5 399"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-648.5 2993 899"
+	"mins" "-46.5 -14 -381"
+	"maxs" "46.5 14 381"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+; --- Block out of bounds areas for survivors by the starting saferoom
+; --- Hedges
+{
+	"classname" "env_physics_blocker"
+	"origin" "1082 -3686 672"
+	"mins" "-506 -218 -608"
+	"maxs" "506 218 608"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2302 -3878 672"
+	"mins" "-714 -26 -608"
+	"maxs" "714 26 608"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3280 -3685.5 672"
+	"mins" "-272 -218.5 -608"
+	"maxs" "272 218.5 608"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Fences
+{
+	"classname" "env_physics_blocker"
+	"origin" "3618.34 -3455.38 704"
+	"angles" "0 5 0"
+	"mins" "-64.5 -1 -576"
+	"maxs" "64.5 1 576"
+	"boxmins" "-64.5 -1 -576"
+	"boxmaxs" "64.5 1 576"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3743.56 -3433.34 704"
+	"angles" "0 15 0"
+	"mins" "-64.5 -1 -576"
+	"maxs" "64.5 1 576"
+	"boxmins" "-64.5 -1 -576"
+	"boxmaxs" "64.5 1 576"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3860.65 -3390.33 704"
+	"angles" "0 25.5 0"
+	"mins" "-64.5 -1 -576"
+	"maxs" "64.5 1 576"
+	"boxmins" "-64.5 -1 -576"
+	"boxmaxs" "64.5 1 576"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3969.5 -3331 704"
+	"angles" "0 34 0"
+	"mins" "-64.5 -1 -576"
+	"maxs" "64.5 1 576"
+	"boxmins" "-64.5 -1 -576"
+	"boxmaxs" "64.5 1 576"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4067.71 -3248.08 704"
+	"angles" "0 44.5 0"
+	"mins" "-64.5 -1 -576"
+	"maxs" "64.5 1 576"
+	"boxmins" "-64.5 -1 -576"
+	"boxmaxs" "64.5 1 576"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4149.5 -3154 704"
+	"angles" "0 53 0"
+	"mins" "-64.5 -1 -576"
+	"maxs" "64.5 1 576"
+	"boxmins" "-64.5 -1 -576"
+	"boxmaxs" "64.5 1 576"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4215.17 -3048.08 704"
+	"angles" "0 63 0"
+	"mins" "-64.5 -1 -576"
+	"maxs" "64.5 1 576"
+	"boxmins" "-64.5 -1 -576"
+	"boxmaxs" "64.5 1 576"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4262.74 -2929.72 704"
+	"angles" "0 74 0"
+	"mins" "-64.5 -1 -576"
+	"maxs" "64.5 1 576"
+	"boxmins" "-64.5 -1 -576"
+	"boxmaxs" "64.5 1 576"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4288.3 -2805.8 704"
+	"angles" "0 83.5 0"
+	"mins" "-64.5 -1 -576"
+	"maxs" "64.5 1 576"
+	"boxmins" "-64.5 -1 -576"
+	"boxmaxs" "64.5 1 576"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4295.5 -2554 704"
+	"mins" "-1.5 -193 -576"
+	"maxs" "1.5 193 576"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Bus
+{
+	"classname" "env_physics_blocker"
+	"origin" "4161 -2415 696"
+	"angles" "0 22 0"
+	"mins" "-51 -235 -584"
+	"maxs" "51 235 584"
+	"boxmins" "-51 -235 -584"
+	"boxmaxs" "51 235 584"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block out of bounds area behind the CEDA trucks / tents
+; --- Fences
+{
+	"classname" "env_physics_blocker"
+	"origin" "2764 1292 672"
+	"mins" "-621 -397 -608"
+	"maxs" "621 397 608"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2116.24 1578.6 672"
+	"angles" "0 -5 0"
+	"mins" "-1 -129 -608"
+	"maxs" "1 129 608"
+	"boxmins" "-1 -129 -608"
+	"boxmaxs" "1 129 608"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- CEDA trailers
+{
+	"classname" "env_physics_blocker"
+	"origin" "3064.5 1658 778"
+	"mins" "-305.5 -66 -502"
+	"maxs" "305.5 66 502"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2448.34 1682.05 697"
+	"angles" "0 -16.5 0"
+	"mins" "-305.5 -66 -502"
+	"maxs" "305.5 66 502"
+	"boxmins" "-305.5 -66 -583"
+	"boxmaxs" "305.5 66 583"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Tent
+{
+	"classname" "env_physics_blocker"
+	"origin" "2619.65 1982.57 760"
+	"angles" "0 -15 0"
+	"mins" "-190 -5 -520"
+	"maxs" "190 5 520"
+	"boxmins" "-190 -5 -520"
+	"boxmaxs" "190 5 520"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2552.35 1731.43 760"
+	"angles" "0 -15 0"
+	"mins" "-190 -5 -520"
+	"maxs" "190 5 520"
+	"boxmins" "-190 -5 -520"
+	"boxmaxs" "190 5 520"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2405.37 1905.4 760"
+	"angles" "0 -15 0"
+	"mins" "-3 -125 -520"
+	"maxs" "3 125 520"
+	"boxmins" "-3 -125 -520"
+	"boxmaxs" "3 125 520"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2766.63 1808.6 760"
+	"angles" "0 -15 0"
+	"mins" "-3 -125 -520"
+	"maxs" "3 125 520"
+	"boxmins" "-3 -125 -520"
+	"boxmaxs" "3 125 520"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivor out of bounds spot in bushes by the end saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "-694 8716 816"
+	"mins" "-97 -20 -448"
+	"maxs" "97 20 448"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block surviors getting on the end saferoom roof
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1792 9493 902"
+	"mins" "-68 -257 -378"
+	"maxs" "68 257 378"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+; --- Block a sliding stuck spot behind a house by the starting saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "2464 -3864 164"
+	"mins" "-96 -24 -20"
+	"maxs" "96 24 20"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2532 -3864 188"
+	"mins" "-12 -24 -4"
+	"maxs" "12 24 4"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Block perma-stuck spot in some bushes to the right of the warehouse
+{
+	"classname" "env_physics_blocker"
+	"origin" "141.5 3512.5 168"
+	"mins" "-45.5 -136.5 -56"
+	"maxs" "45.5 136.5 56"
+	"initialstate" "1"
+	"BlockType" "0"
 }

--- a/cfg/stripper/zonemod/maps/cwm2_warehouse.cfg
+++ b/cfg/stripper/zonemod/maps/cwm2_warehouse.cfg
@@ -9,7 +9,7 @@
 ;	"angles" "0 77 0"
 ;}
 
-; Make sure Event Doors can only be broken by Tank. - Redundant fix to issue that no longer occurs + doesn't allow tank to break the doors
+; Make sure Event Doors can only be broken by Tank. - Redundant fix for issue that no longer occurs + doesn't allow tank to break the doors
 modify:
 {
 	match:
@@ -191,6 +191,19 @@ add:
 	"BlockType" "0"
 }
 
+; ############  DIRECTOR AND EVENT CHANGES  ###########
+; =====================================================
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==       Modify director behaviour and events      ==
+; =====================================================
+; --- Run nav fixes script
+; --- Fix 1: Fixes god spot on top of truck after the alarmed door
+; --- Fix 2: Fixes god spot on top of van after the alarmed door
+add:
+{
+	"classname" "logic_auto"
+	"OnMapSpawn" "director,RunScriptFile,nav_fixes/cwm2_warehouse_navfixes,20,-1"
+}
 
 ; =====================================================
 ; ==                STATIC AMMO PILES                ==
@@ -558,6 +571,16 @@ add:
 ; ==                   STUCK SPOTS                   ==
 ; ==  Prevent players from getting stuck in the map  ==
 ; =====================================================
+add:
+; --- Block a perma-stuck spot between some trucks after the gas station
+{
+	"classname" "env_physics_blocker"
+	"origin" "1900 10 51"
+	"mins" "-32 -106 -51"
+	"maxs" "32 106 51"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 
 
 ; =====================================================
@@ -576,4 +599,196 @@ modify:
 		"OnTrigger" "alarm_sound,FadeOut,5,3,-1"
 		"OnTrigger" "alarm_sound,Kill,,10,-1"
 	}
+}
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+add:
+; --- Infected ladder on the starting saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "-1017 -3814 226"
+    "angles" "0 180 0"
+    "model" "*32"
+    "normal.x" "0"
+    "normal.y" "1"
+    "normal.z" "0"
+    "team" "2"
+}
+; --- Infected ladders on the truck outside the starting saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "-1487.86 634.122 -80"
+    "angles" "0 15 0"
+    "model" "*98"
+    "normal.x" "0.573506"
+    "normal.y" "0.819202"
+    "normal.z" "0"
+    "team" "2"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "-2895.14 -5760.12 -21"
+    "angles" "0 195 0"
+    "model" "*98"
+    "normal.x" "-0.573506"
+    "normal.y" "-0.819202"
+    "normal.z" "0"
+    "team" "2"
+}
+; --- Infected ladder on fallen delivery truck outside the starting saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "-1094.6 -1952.75 184"
+    "angles" "0 245 0"
+    "model" "*32"
+    "normal.x" "-0.906308"
+    "normal.y" "0.422618"
+    "normal.z" "0"
+    "team" "2"
+}
+; --- Infected ladder to climb over fence outside the starting saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "-2090 -2769 193"
+    "angles" "0 90 0"
+    "model" "*32"
+    "normal.x" "1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "2"
+}
+{
+    "classname" "env_physics_blocker"
+    "origin" "-1575 -2096 200"
+    "angles" "0 45 0"
+    "mins" "0 0 0"
+    "maxs" "1.5 13.5 178"
+    "boxmins" "0 0 0"
+    "boxmaxs" "1.5 13.5 178"
+    "initialstate" "1"
+    "BlockType" "0"
+}
+{
+    "classname" "env_physics_blocker"
+    "origin" "-1575 -2122 200"
+    "angles" "0 -45 0"
+    "mins" "0 0 0"
+    "maxs" "1.5 -13.5 178"
+    "boxmins" "0 0 0"
+    "boxmaxs" "1.5 -13.5 178"
+    "initialstate" "1"
+    "BlockType" "0"
+}
+; --- Infected ladders to climb over the middle of the bridge outside the starting saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "511 0 0"
+    "angles" "0 0 0"
+    "model" "*107"
+    "normal.x" "0.996193"
+    "normal.y" "-0"
+    "normal.z" "0.087177"
+    "team" "2"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "511 386 0"
+    "angles" "0 0 0"
+    "model" "*107"
+    "normal.x" "0.996193"
+    "normal.y" "-0"
+    "normal.z" "0.087177"
+    "team" "2"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "-507 0 0"
+    "angles" "0 0 0"
+    "model" "*109"
+    "normal.x" "-0.996193"
+    "normal.y" "0"
+    "normal.z" "0.087177"
+    "team" "2"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "-507 570 0"
+    "angles" "0 0 0"
+    "model" "*109"
+    "normal.x" "-0.996193"
+    "normal.y" "0"
+    "normal.z" "0.087177"
+    "team" "2"
+}
+; --- Infected ladders to climb on trucks after the gas station
+{
+    "classname" "func_simpleladder"
+    "origin" "-793 -1516 -173"
+    "angles" "0 0 0"
+    "model" "*38"
+    "normal.x" "-1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "2"
+}
+{
+    "classname" "func_simpleladder"
+    "origin" "3667.45 -2735.06 -200"
+    "angles" "0 93 0"
+    "model" "*38"
+    "normal.x" "0.0523359"
+    "normal.y" "-0.99863"
+    "normal.z" "0"
+    "team" "2"
+}
+; --- Additional infected ladder to climb on awning at the warehouse entrance
+{
+    "classname" "func_simpleladder"
+    "origin" "0 -512 0"
+    "angles" "0 0 0"
+    "model" "*40"
+    "normal.x" "-0.906183"
+    "normal.y" "0"
+    "normal.z" "-0.422885"
+    "team" "2"
+}
+; --- Infected ladder to climb back over fallen shelves at the start of the warehouse
+
+{
+    "classname" "func_simpleladder"
+    "origin" "7627 -37.5634 -79"
+    "angles" "0 167 0"
+    "model" "*71"
+    "normal.x" "0.97437"
+    "normal.y" "-0.224951"
+    "normal.z" "0"
+    "team" "2"
+}
+; --- Adjusted infected ladder by the alarmed door to help prevent falling off / getting stuck
+modify:
+{
+	match:
+	{
+		"hammerid" "449022"
+	}
+	insert:
+	{
+		"origin" "-4 0 0"
+	}
+}
+; --- Infected ladder by fenced off power transformers to prevent a perma-stuck spot and climb over the fence
+add:
+{
+    "classname" "func_simpleladder"
+    "origin" "1885 9979 -95"
+    "angles" "0 270 0"
+    "model" "*69"
+    "normal.x" "0"
+    "normal.y" "1"
+    "normal.z" "0"
+    "team" "2"
 }

--- a/cfg/stripper/zonemod/maps/cwm2_warehouse.cfg
+++ b/cfg/stripper/zonemod/maps/cwm2_warehouse.cfg
@@ -3,26 +3,23 @@
 ; =====================================================
 
 ; Remove hittable that can be used to get to god spot in warehouse
-filter:
-{
-	"model" "models/props/cs_assault/handtruck.mdl"
-	"angles" "0 77 0"
-}
+;filter:
+;{
+;	"model" "models/props/cs_assault/handtruck.mdl"
+;	"angles" "0 77 0"
+;}
 
-; Make sure Event Doors can only be broken by Tank.
-; --- And fade out alarm early!
+; Make sure Event Doors can only be broken by Tank. - Redundant fix to issue that no longer occurs + doesn't allow tank to break the doors
 modify:
 {
 	match:
 	{
-		"hammerid" "15897"
+		"targetname" "glow_trigger"
 	}
 	insert:
 	{
 		"OnTrigger" "door_emergencySetUnbreakable0-1"
 		"OnTrigger" "door_emergency1SetUnbreakable0-1"
-		"OnTrigger" "alarm_sound,FadeOut,5,3,-1"
-		"OnTrigger" "alarm_sound,Kill,,10,-1"
 	}
 }
 
@@ -32,35 +29,34 @@ add:
 ; --- Block jumping on saferoom roof
 {
 	"classname" "env_physics_blocker"
-	"origin" "-1724 -3560 594"
-	"mins" "-74 -266 -158"
-	"maxs" "74 266 158"
+	"origin" "-1724.5 -3560 787"
+	"mins" "-72.5 -265 -363"
+	"maxs" "72.5 265 363"
 	"initialstate" "1"
 	"BlockType" "1"
 }
-
 ; --- Block survivors from gas station roof / going around gas station
 {
 	"classname" "env_physics_blocker"
-	"origin" "872 -128 484"
-	"mins" "-232 -384 -300"
-	"maxs" "232 384 300"
+	"origin" "872 -128 924"
+	"mins" "-232 -384 -740"
+	"maxs" "232 384 740"
 	"initialstate" "1"
 	"BlockType" "1"
 }
 {
 	"classname" "env_physics_blocker"
-	"origin" "960 384 468"
-	"mins" "-272 -128 -316"
-	"maxs" "272 128 316"
+	"origin" "960 384 908"
+	"mins" "-272 -128 -756"
+	"maxs" "272 128 756"
 	"initialstate" "1"
 	"BlockType" "1"
 }
 {
 	"classname" "env_physics_blocker"
-	"origin" "1196 -4 471"
-	"mins" "-92 -260 -313"
-	"maxs" "92 260 313"
+	"origin" "1196 0 912"
+	"mins" "-92 -264 -752"
+	"maxs" "92 264 752"
 	"initialstate" "1"
 	"BlockType" "1"
 }
@@ -83,17 +79,23 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-
 ; --- Block skipping warehouse ladder by jumping off shelf
 {
 	"classname" "env_physics_blocker"
-	"origin" "4082 112 198"
-	"mins" "-2 -166 -6"
-	"maxs" "2 166 6"
+	"origin" "4081 93 198.5"
+	"mins" "-1 -198 -6.5"
+	"maxs" "1 198 6.5"
 	"initialstate" "1"
 	"BlockType" "1"
 }
-
+{
+	"classname" "env_physics_blocker"
+	"origin" "4083 93 195.5"
+	"mins" "-1 -198 -3.5"
+	"maxs" "1 198 3.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block survivors from standing in infected only doorways in warehouse
 {
 	"classname" "env_physics_blocker"
@@ -111,7 +113,6 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-
 ; --- Block jumping over warehouse vending machines early
 {
 	"classname" "env_physics_blocker"
@@ -121,7 +122,6 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-
 ; --- Block jesus spot truck after warehouse
 {
 	"classname" "env_physics_blocker"
@@ -139,46 +139,23 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-
 ; --- Block jesus spot shelves in power plant area
 {
 	"classname" "env_physics_blocker"
-	"origin" "6190 2227 95"
-	"mins" "-32 -163 -81"
-	"maxs" "32 163 81"
+	"origin" "6191 2228 96"
+	"mins" "-35 -162 -80"
+	"maxs" "35 162 80"
 	"initialstate" "1"
 	"BlockType" "1"
 }
 {
 	"classname" "env_physics_blocker"
-	"origin" "6412 2352 95"
-	"mins" "-32 -80 -81"
-	"maxs" "32 80 81"
+	"origin" "6411.5 2352 96"
+	"mins" "-32.5 -80 -80"
+	"maxs" "32.5 80 80"
 	"initialstate" "1"
 	"BlockType" "1"
 }
-
-; --- Block skipping apartment by jumping on generator/electrical box
-{
-	"classname" "env_physics_blocker"
-	"origin" "8622 5534 1009"
-	"angles" "0 150 0"
-	"mins" "-29 -10 -653"
-	"maxs" "29 10 653"
-	"boxmins" "-29 -10 -653"
-	"boxmaxs" "29 10 653"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "8699 5548 374"
-	"mins" "-4 -29 -137"
-	"maxs" "4 29 137"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-
 ; --- Block jumping over desks in apartment early
 {
 	"classname" "env_physics_blocker"
@@ -188,10 +165,7 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-
-
 ; --- Fix being able to spawn tanks early in the warehouse
-add:
 {
 	"classname" "logic_auto"
 	"OnMapSpawn" "warehouse_nav_skip_blocker,BlockNav,,1,-1"
@@ -204,7 +178,6 @@ add:
 	"teamToBlock" "2"
 	"affectsFlow" "0"
 }
-
 ; --- Block a stuck spot between van and wall
 {
 	"classname" "env_physics_blocker"
@@ -216,4 +189,391 @@ add:
 	"boxmaxs" "14 83.5 49"
 	"initialstate" "1"
 	"BlockType" "0"
+}
+
+
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
+add:
+; --- Ammo pile on the meeting table in the warehouse offices
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "2994 1707 302"
+	"angles" "0 0 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+; --- Ammo pile in the shop at the start of the apartments
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "8857 4225 217u"
+	"angles" "0 0 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+add:
+; --- Block skip over a fence by the starting saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1584 -2328 704"
+	"mins" "-1 -408 -448"
+	"maxs" "1 408 448"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors being able to access the bridge
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1536 16 960"
+	"mins" "-64 -64 -704"
+	"maxs" "64 64 704"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1516 -1840 960"
+	"mins" "-40 -16 -704"
+	"maxs" "40 16 704"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1642 -952 960"
+	"mins" "-86 -904 -704"
+	"maxs" "86 904 704"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1430 -920 960"
+	"mins" "-86 -872 -704"
+	"maxs" "86 872 704"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on gas station window frame
+{
+	"classname" "env_physics_blocker"
+	"origin" "639.38 -272 896"
+	"mins" "-0.625 -49 -768"
+	"maxs" "0.625 49 768"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block jumping over the hedges to skip the gas station
+{
+	"classname" "env_physics_blocker"
+	"origin" "1200.5 960 832"
+	"mins" "-19.5 -448 -832"
+	"maxs" "19.5 448 832"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block shelves to right of ladder in warehouse
+{
+	"classname" "env_physics_blocker"
+	"origin" "3832 -463 373"
+	"mins" "-80 -33 -123"
+	"maxs" "80 33 123"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3492 -463 256"
+	"mins" "-100 -33 -240"
+	"maxs" "100 33 240"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Remove handtrucks that can be used to access god spots in the warehouse
+filter:
+{
+	"hammerid" "14800"
+}
+{
+	"hammerid" "14796"
+}
+; --- Block god spot shelves under the walkway in the warehouse
+add:
+{
+	"classname" "env_physics_blocker"
+	"origin" "4129.3 622.67 96"
+	"angles" "0 349 0"
+	"mins" "-32 -78 -80"
+	"maxs" "32 78 80"
+	"boxmins" "-32 -78 -80"
+	"boxmaxs" "32 78 80"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4143.5 448 96"
+	"mins" "-32.5 -77 -80"
+	"maxs" "32.5 77 80"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on shelf under the warehouse ladder
+{
+	"classname" "env_physics_blocker"
+	"origin" "4120 -64.5 172"
+	"mins" "-40 -80.5 -4"
+	"maxs" "40 80.5 4"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on a shelf to the left of the warehouse ladder
+{
+	"classname" "env_physics_blocker"
+	"origin" "3830 91 289"
+	"angles" "0 10 0"
+	"mins" "-42 -73 -207"
+	"maxs" "42 73 207"
+	"boxmins" "-42 -73 -207"
+	"boxmaxs" "42 73 207"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block jumping on an electrical box on the warehouse walkway
+{
+	"classname" "env_physics_blocker"
+	"origin" "4169.5 123 344"
+	"mins" "-6.5 -35 -152"
+	"maxs" "6.5 35 152"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on the support beams in the warehouse
+{
+	"classname" "env_physics_blocker"
+	"origin" "3584 -488 401"
+	"mins" "-592 -8 -81"
+	"maxs" "592 8 81"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3584 -232 401"
+	"mins" "-592 -8 -81"
+	"maxs" "592 8 81"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3584 24 401"
+	"mins" "-592 -8 -81"
+	"maxs" "592 8 81"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3584 280 401"
+	"mins" "-592 -8 -81"
+	"maxs" "592 8 81"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3584 536 401"
+	"mins" "-592 -8 -81"
+	"maxs" "592 8 81"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3584 792 401"
+	"mins" "-592 -8 -81"
+	"maxs" "592 8 81"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3584 1048 401"
+	"mins" "-592 -8 -81"
+	"maxs" "592 8 81"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block shelves at the end of the walkway in the warehouse
+{
+	"classname" "env_physics_blocker"
+	"origin" "3824.5 960 256"
+	"mins" "-34.5 -80 -240"
+	"maxs" "34.5 80 240"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block being able to skip the event by jumping from a window in the offices over a fence
+{
+	"classname" "env_physics_blocker"
+	"origin" "4360 2328 908"
+	"mins" "-8 -400 -756"
+	"maxs" "8 400 756"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on blue food truck after the warehouse
+{
+	"classname" "env_physics_blocker"
+	"origin" "4643.86 880.8 884.5"
+	"angles" "0 7 0"
+	"mins" "-59 -51 -779.5"
+	"maxs" "59 51 779.5"
+	"boxmins" "-59 -51 -779.5"
+	"boxmaxs" "59 51 779.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4624.6 1037.62 832"
+	"angles" "0 7 0"
+	"mins" "-59 -107 -832"
+	"maxs" "59 107 832"
+	"boxmins" "-59 -107 -832"
+	"boxmaxs" "59 107 832"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on white truck after the warehouse
+{
+	"classname" "env_physics_blocker"
+	"origin" "4971.36 1480.98 832"
+	"angles" "0 7 0"
+	"mins" "-43 -36 -832"
+	"maxs" "43 36 832"
+	"boxmins" "-43 -36 -832"
+	"boxmaxs" "43 36 832"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "4990.89 1334.27 912"
+	"angles" "0 7 0"
+	"mins" "-57.5 -112 -752"
+	"maxs" "57.5 112 752"
+	"boxmins" "-57.5 -112 -752"
+	"boxmaxs" "57.5 112 752"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on an electrical box before the event button
+{
+	"classname" "env_physics_blocker"
+	"origin" "6007.5 3365 316"
+	"mins" "-4.5 -35 -164"
+	"maxs" "4.5 35 164"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block a ledge that can be used to skip the apartments
+{
+	"classname" "env_physics_blocker"
+	"origin" "8682 6010 1000"
+	"mins" "-246 -390 -664"
+	"maxs" "246 390 664"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block climbing on generator to skip the apartments
+{
+	"classname" "env_physics_blocker"
+	"origin" "8622.93 5533.07 257.5"
+	"angles" "0 150 0"
+	"mins" "-8 -8 -97.5"
+	"maxs" "8 8 97.5"
+	"boxmins" "-8 -8 -97.5"
+	"boxmaxs" "8 8 97.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "8622 5534 371"
+	"angles" "0 150 0"
+	"mins" "-29 -10 -16"
+	"maxs" "29 10 16"
+	"boxmins" "-29 -10 -16"
+	"boxmaxs" "29 10 16"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block climbing on 2 electrical boxes to skip the apartments
+{
+	"classname" "env_physics_blocker"
+	"origin" "8699.5 5548.5 347"
+	"mins" "-4.5 -29.5 -101"
+	"maxs" "4.5 29.5 101"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "8697.5 5265 286"
+	"mins" "-6.5 -35 -12"
+	"maxs" "6.5 35 12"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from accessing a room above the scaffolding
+{
+	"classname" "env_physics_blocker"
+	"origin" "8712 4924 560"
+	"mins" "-8 -28 -48"
+	"maxs" "8 28 48"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+
+
+; =====================================================
+; ==                  SOUND REMOVAL                  ==
+; ==    Remove or adjust sounds played by the map    ==
+; =====================================================
+; --- Fade alarm sound when doors are opened
+modify:
+{
+	match:
+	{
+		"targetname" "door_open_relay"
+	}
+	insert:
+	{
+		"OnTrigger" "alarm_sound,FadeOut,5,3,-1"
+		"OnTrigger" "alarm_sound,Kill,,10,-1"
+	}
 }

--- a/cfg/stripper/zonemod/maps/cwm3_drain.cfg
+++ b/cfg/stripper/zonemod/maps/cwm3_drain.cfg
@@ -123,41 +123,7 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
-; --- First hut / fence
-{
-	"classname" "env_physics_blocker"
-	"origin" "-678 -416 400"
-	"mins" "-106 -100 -126"
-	"maxs" "106 100 126"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "-402 -509 400"
-	"mins" "-170 -3 -126"
-	"maxs" "170 3 126"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Second hut
-{
-	"classname" "env_physics_blocker"
-	"origin" "574 -128 320"
-	"mins" "-66 -68 -64"
-	"maxs" "66 68 64"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "507 -132 185"
-	"mins" "-7 -44 -72"
-	"maxs" "7 44 72"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-; --- Second gate skip
+; --- Block jumping around the fence by the second gate to skip the 2nd half of the event / get back up after the drop
 {
 	"classname" "env_physics_blocker"
 	"origin" "350 -756 176"
@@ -376,14 +342,466 @@ add:
     "origin" "504 128 256"
     "angles" "0 55 0"
 }
+
+; ################  ITEM SPAWN CHANGES  ###############
+; =====================================================
+; ==           PILL / ITEM / WEAPON SPAWNS           ==
+; ==   Remove or change pill, item & weapon spawns   ==
+; =====================================================
+; --- Ensure both SMG and shotgun always spawn in the sewer exit room
+modify:
 {
-    "classname" "env_physics_blocker"
-    "targetname" "EB003"
-    "BlockType" "1"
-    "initialstate" "1"
-    "maxs" "8 120 500"
-    "mins" "0 0 0"
-    "origin" "384 96 120"
+	match:
+	{
+		"hammerid" "358199"
+	}
+	replace:
+	{
+		"weapon_selection" "tier1_shotgun"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "358212"
+	}
+	replace:
+	{
+		"weapon_selection" "any_smg"
+	}
 }
 
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
+add:
+; --- Ammo pile by the van after the event (also accessible from the other side of the fence)
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "1376 -1707 120"
+	"angles" "0 90 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
 
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+add:
+; --- Block survivors from accessing the wall cavity by the starting saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1563 480 -240"
+	"mins" "-107 -96 -112"
+	"maxs" "107 96 112"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1728 480 -168"
+	"mins" "-64 -96 -56"
+	"maxs" "64 96 56"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from standing on the signal boxes around the event
+{
+	"classname" "env_physics_blocker"
+	"origin" "-560 240 760"
+	"mins" "-48 -16 -648"
+	"maxs" "48 16 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-648 -523 760"
+	"mins" "-48 -16 -648"
+	"maxs" "48 16 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors getting onto the higher platforms around the event
+; --- Sewer exit side
+{
+	"classname" "env_physics_blocker"
+	"origin" "-372 776 840"
+	"mins" "-140 -136 -568"
+	"maxs" "140 136 568"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-648 448 840"
+	"mins" "-152 -192 -568"
+	"maxs" "152 192 568"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1072 -248 840"
+	"mins" "-288 -504 -568"
+	"maxs" "288 504 568"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Halfway point side
+
+; --- Block survivors from getting on or behind the fences around the event
+; --- Sewer exit side
+{
+	"classname" "env_physics_blocker"
+	"origin" "-234 -101.5 760"
+	"mins" "-2 -65.5 -648"
+	"maxs" "2 65.5 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-234 -381.5 760"
+	"mins" "-2 -128.5 -648"
+	"maxs" "2 128.5 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-406 -508 760"
+	"mins" "-170 -2 -648"
+	"maxs" "170 2 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Halfway point side
+{
+	"classname" "env_physics_blocker"
+	"origin" "386.5 158 760"
+	"mins" "-2.5 -65 -648"
+	"maxs" "2.5 65 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "387.5 -465 760"
+	"mins" "-3.5 -66 -648"
+	"maxs" "3.5 66 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "369.5 -693 760"
+	"mins" "-1.5 -65 -648"
+	"maxs" "1.5 65 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "497.5 -757 760"
+	"mins" "-126.5 -1 -648"
+	"maxs" "126.5 1 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from standing on the metal shacks around the event
+{
+	"classname" "env_physics_blocker"
+	"origin" "-678 -416 849.5"
+	"mins" "-106 -100 -558.5"
+	"maxs" "106 100 558.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "574 -128 833.5"
+	"mins" "-66 -68 -574.5"
+	"maxs" "66 68 574.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "504.5 -132 760"
+	"mins" "-3.5 -44 -648"
+	"maxs" "3.5 44 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block standing on the windows at the drop after the event
+{
+	"classname" "env_physics_blocker"
+	"origin" "-587 -949.5 399"
+	"mins" "-5 -42.5 -245"
+	"maxs" "5 42.5 245"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-587 -1077.5 399"
+	"mins" "-5 -42.5 -245"
+	"maxs" "5 42.5 245"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from standing on the back of the truck after the event
+{
+	"classname" "env_physics_blocker"
+	"origin" "-71.5 -1659 380"
+	"mins" "-14.5 -13 -212"
+	"maxs" "14.5 13 212"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from going over a fence after the event to skip to the end saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "1427.14 -2104.04 760"
+	"angles" "0 2.5 0"
+	"mins" "-2 -49 -648"
+	"maxs" "2 49 648"
+	"boxmins" "-2 -49 -648"
+	"boxmaxs" "2 49 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1432.28 -2020.43 760"
+	"angles" "0 -3 0"
+	"mins" "-2 -24.5 -648"
+	"maxs" "2 24.5 648"
+	"boxmins" "-2 -24.5 -648"
+	"boxmaxs" "2 24.5 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1436 -1940 833"
+	"mins" "-4 -48 -575"
+	"maxs" "4 48 575"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1435.72 -1840.04 760"
+	"angles" "0 1.5 0"
+	"mins" "-2 -49 -648"
+	"maxs" "2 49 648"
+	"boxmins" "-2 -49 -648"
+	"boxmaxs" "2 49 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1427.38 -1735.84 760"
+	"angles" "0 7.5 0"
+	"mins" "-2 -49 -648"
+	"maxs" "2 49 648"
+	"boxmins" "-2 -49 -648"
+	"boxmaxs" "2 49 648"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivor access to windows near the van after the event
+{
+	"classname" "env_physics_blocker"
+	"origin" "1474 -1660 582"
+	"mins" "-158 -4 -50"
+	"maxs" "158 4 50"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors accessing the apartment roof with ledge hangs
+{
+	"classname" "env_physics_blocker"
+	"origin" "2208 -1344 1021"
+	"mins" "-416 -232 -387"
+	"maxs" "416 232 387"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors accessing a balcony near the apartments fire escape
+{
+	"classname" "env_physics_blocker"
+	"origin" "1732 -1128 967"
+	"mins" "-36 -24 -441"
+	"maxs" "36 24 441"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors dropping into a window from the fire escape to skip the apartments
+{
+	"classname" "prop_dynamic"
+	"origin" "1813 -1120 378.444"
+	"angles" "0 270 0"
+	"model" "models/props_pipes/gutter_512_002a.mdl"
+	"solid" "0"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1818 -1112 393"
+	"mins" "-10 -8 -64"
+	"maxs" "10 8 64"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1856 -1096 462.5"
+	"mins" "-36 -24 -27.5"
+	"maxs" "36 24 27.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from standing on semi truck by the end saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "2534.5 -2476.51 936"
+	"angles" "0 244.5 0"
+	"mins" "-52.5 -267.5 -824"
+	"maxs" "52.5 267.5 824"
+	"boxmins" "-52.5 -267.5 -824"
+	"boxmaxs" "52.5 267.5 824"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2852 -2598 178"
+	"angles" "0 -10 0"
+	"mins" "-36 -54 -66"
+	"maxs" "36 54 66"
+	"boxmins" "-36 -54 -66"
+	"boxmaxs" "36 54 66"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+; --- Block out of bounds area by the end saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "3782 -3120 936"
+	"mins" "-70 -20 -824"
+	"maxs" "70 20 824"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3832 -2662 936"
+	"mins" "-20 -454 -824"
+	"maxs" "20 454 824"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3797.5 -2097.5 936"
+	"angles" "0 66.5 0"
+	"mins" "-51.5 -266.5 -824"
+	"maxs" "51.5 266.5 824"
+	"boxmins" "-51.5 -266.5 -824"
+	"boxmaxs" "51.5 266.5 824"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3911.5 -1775.5 936"
+	"angles" "0 336 0"
+	"mins" "-51.5 -266.5 -824"
+	"maxs" "51.5 266.5 824"
+	"boxmins" "-51.5 -266.5 -824"
+	"boxmaxs" "51.5 266.5 824"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+; --- Clipping to fix getting stuck on car stops by the end saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "3600 -2444 114.5"
+	"mins" "-48 -4 -2.5"
+	"maxs" "48 4 2.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3384 -2444 114.5"
+	"mins" "-48 -4 -2.5"
+	"maxs" "48 4 2.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3160 -2448 114.5"
+	"mins" "-48 -4 -2.5"
+	"maxs" "48 4 2.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2952 -2448 114.5"
+	"mins" "-48 -4 -2.5"
+	"maxs" "48 4 2.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "2740 -2444 114.5"
+	"mins" "-48 -4 -2.5"
+	"maxs" "48 4 2.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "1836 -2448 114.5"
+	"mins" "-48 -4 -2.5"
+	"maxs" "48 4 2.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Clipping to fix getting stuck on fallen fence by the end saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "2644 -2472 118.5"
+	"mins" "-84 -40 -6.5"
+	"maxs" "84 40 6.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}

--- a/cfg/stripper/zonemod/maps/cwm3_drain.cfg
+++ b/cfg/stripper/zonemod/maps/cwm3_drain.cfg
@@ -313,36 +313,6 @@ add:
 	"team" "2"
 }
 
-; =====================================================
-; ==                   STUCK SPOTS                   ==
-; ==  Prevent players from getting stuck in the map  ==
-; =====================================================
-
-add:
-; --- Block a shortcut on the 2 metal-doors
-; --- 添加空气墙阻挡近路
-{
-    "classname" "env_physics_blocker"
-    "targetname" "EB001"
-    "BlockType" "1"
-    "initialstate" "1"
-    "maxs" "200 760 500"
-    "mins" "-4 -128 -120"
-    "origin" "608 -640 256"
-}
-{
-    "classname" "env_physics_blocker"
-    "targetname" "EB002"
-    "BlockType" "1"
-    "initialstate" "1"
-    "maxs" "4 128 500"
-    "mins" "-4 -128 -80"
-    "boxmaxs" "4 128 500"
-    "boxmins" "-4 -128 -80"
-    "origin" "504 128 256"
-    "angles" "0 55 0"
-}
-
 ; ################  ITEM SPAWN CHANGES  ###############
 ; =====================================================
 ; ==           PILL / ITEM / WEAPON SPAWNS           ==
@@ -454,7 +424,28 @@ add:
 	"BlockType" "1"
 }
 ; --- Halfway point side
-
+; --- 添加空气墙阻挡近路
+{
+    "classname" "env_physics_blocker"
+    "targetname" "EB001"
+    "BlockType" "1"
+    "initialstate" "1"
+    "maxs" "200 760 500"
+    "mins" "-4 -128 -120"
+    "origin" "608 -640 256"
+}
+{
+    "classname" "env_physics_blocker"
+    "targetname" "EB002"
+    "BlockType" "1"
+    "initialstate" "1"
+    "maxs" "4 128 500"
+    "mins" "-4 -128 -80"
+    "boxmaxs" "4 128 500"
+    "boxmins" "-4 -128 -80"
+    "origin" "504 128 256"
+    "angles" "0 55 0"
+}
 ; --- Block survivors from getting on or behind the fences around the event
 ; --- Sewer exit side
 {
@@ -804,4 +795,46 @@ add:
 	"maxs" "84 40 6.5"
 	"initialstate" "1"
 	"BlockType" "0"
+}
+
+; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
+; =====================================================
+; ==                      PROPS                      ==
+; ==       New props for balance and SI spawns       ==
+; =====================================================
+add:
+; --- Additional pipe on the drop before the sewer exit to assist with climbing back up
+{
+	"classname" "prop_dynamic"
+	"origin" "-592 -1328 -488"
+	"angles" "0 180 0"
+	"model" "models/props_pipes/pipeset32d_corner128d_001a.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+add:
+; --- Infected ladder to climb up to the walkway after the starting saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "-2240 -2333 -50"
+    "angles" "0 270 0"
+    "model" "*77"
+    "normal.x" "0"
+    "normal.y" "-1"
+    "normal.z" "0"
+    "team" "2"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1344 -940 -430"
+	"mins" "-32 -6 -6"
+	"maxs" "32 6 6"
+	"initialstate" "1"
+	"BlockType" "1"
 }

--- a/cfg/stripper/zonemod/maps/cwm4_building.cfg
+++ b/cfg/stripper/zonemod/maps/cwm4_building.cfg
@@ -98,3 +98,189 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+
+; ################  ITEM SPAWN CHANGES  ###############
+; =====================================================
+; ==           PILL / ITEM / WEAPON SPAWNS           ==
+; ==   Remove or change pill, item & weapon spawns   ==
+; =====================================================
+; --- Ensure both SMG and shotgun always spawn in the kitchen
+modify:
+{
+	match:
+	{
+		"hammerid" "209182"
+	}
+	replace:
+	{
+		"weapon_selection" "any_smg"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "209184"
+	}
+	replace:
+	{
+		"weapon_selection" "tier1_shotgun"
+	}
+}
+; --- Ensure both SMG and shotgun always spawn in the side room before the tank
+{
+	match:
+	{
+		"hammerid" "209196"
+	}
+	replace:
+	{
+		"weapon_selection" "any_smg"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "209194"
+	}
+	replace:
+	{
+		"weapon_selection" "tier1_shotgun"
+	}
+}
+; ---  Ensure both SMG and shotgun always spawn up the stairs after the tank
+{
+	match:
+	{
+		"hammerid" "209206"
+	}
+	replace:
+	{
+		"weapon_selection" "any_smg"
+	}
+}
+{
+	match:
+	{
+		"hammerid" "209208"
+	}
+	replace:
+	{
+		"weapon_selection" "tier1_shotgun"
+	}
+}
+
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
+add:
+; --- Ammo pile by the one way drop hole
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "483 -29 576"
+	"angles" "0 90 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+add:
+; --- Wooden boards as a guide to make dropping to the middle floor easier (with clipping to allow ledge hangs)
+{
+	"classname" "prop_dynamic"
+	"origin" "277 781 1152"
+	"angles" "0 333 0"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "255.82 818.73 1152.5"
+	"angles" "0 333 0"
+	"mins" "-36.5 -24.5 -0.5"
+	"maxs" "36.5 24.5 0.5"
+	"boxmins" "-36.5 -24.5 -0.5"
+	"boxmaxs" "36.5 24.5 0.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-579 819 1152"
+	"angles" "0 202 0"
+	"model" "models/props_highway/plywood_02.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-525.5 814.73 1153.5"
+	"angles" "0 202 0"
+	"mins" "-48.5 -24.5 -0.5"
+	"maxs" "48.5 24.5 0.5"
+	"boxmins" "-48.5 -24.5 -0.5"
+	"boxmaxs" "48.5 24.5 0.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Metal plate and board as a guide to make dropping to the lower floor easier (with clipping to allow ledge hangs)
+{
+	"classname" "prop_dynamic"
+	"origin" "13 806 960.5"
+	"angles" "0 15 0"
+	"model" "models/props_urban/metal_plate001.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "13 806 960.5"
+	"angles" "0 15 0"
+	"mins" "-66.5 -36.5 -0.5"
+	"maxs" "66.5 36.5 0.75"
+	"boxmins" "-66.5 -36.5 -0.5"
+	"boxmaxs" "66.5 36.5 0.75"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "-388 758 960"
+	"angles" "0 310.5 0"
+	"model" "models/props_highway/plywood_01.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-393.13 800.96 960.5"
+	"angles" "0 310.5 0"
+	"mins" "-36.5 -24.5 -0.5"
+	"maxs" "36.5 24.5 0.5"
+	"boxmins" "-36.5 -24.5 -0.5"
+	"boxmaxs" "36.5 24.5 0.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}

--- a/scripts/vscripts/nav_fixes/cwm1_intro_navfixes.nut
+++ b/scripts/vscripts/nav_fixes/cwm1_intro_navfixes.nut
@@ -1,0 +1,92 @@
+printl("\n[NavFixes] cwm1_intro_navfixes initialized\n")
+
+//Fix 1: Fix jesus spot on top of bus outside saferoom//
+//Issue: Nav area has one way connections, making it impossible for common to path
+function cwm1_intro_navfixes_fix1()
+{
+	//Get nav areas:
+	//Problematic nav areas (on top of bus)
+	local fix1_jesusNav_a = NavMesh.GetNavAreaByID(20667)
+	local fix1_jesusNav_b = NavMesh.GetNavAreaByID(22510)
+	local fix1_jesusNav_c = NavMesh.GetNavAreaByID(29368)
+	local fix1_jesusNav_d = NavMesh.GetNavAreaByID(29526)
+	local fix1_jesusNav_e = NavMesh.GetNavAreaByID(20664)
+	//Nav areas to connect
+	local fix1_nav_ad1 = NavMesh.GetNavAreaByID(29514)
+	local fix1_nav_a2 = NavMesh.GetNavAreaByID(21456)
+	local fix1_nav_b1 = NavMesh.GetNavAreaByID(22512)
+	local fix1_nav_b2 = NavMesh.GetNavAreaByID(22740)
+	local fix1_nav_c = NavMesh.GetNavAreaByID(19033)
+	local fix1_nav_e1 = NavMesh.GetNavAreaByID(20307)
+	local fix1_nav_e2 = NavMesh.GetNavAreaByID(29429)
+	local fix1_nav_e3 = NavMesh.GetNavAreaByID(29369)
+	
+	//Create one-way connection between nav areas
+	fix1_nav_ad1.ConnectTo(fix1_jesusNav_a,-1)
+	fix1_nav_a2.ConnectTo(fix1_jesusNav_a,-1)
+	fix1_nav_b1.ConnectTo(fix1_jesusNav_b,-1)
+	fix1_nav_b2.ConnectTo(fix1_jesusNav_b,-1)
+	fix1_nav_c.ConnectTo(fix1_jesusNav_c,-1)
+	fix1_nav_ad1.ConnectTo(fix1_jesusNav_d,-1)
+	fix1_nav_e1.ConnectTo(fix1_jesusNav_e,-1)
+	fix1_nav_e2.ConnectTo(fix1_jesusNav_e,-1)
+	fix1_nav_e3.ConnectTo(fix1_jesusNav_e,-1)
+	
+	printl("\n[NavFixes] Fix 1 applied\n")
+}
+
+//Fix 2: Fix jesus spot on truck and buses after warehouse//
+//Issue: Nav area has one way connections, making it impossible for common to path
+function cwm1_intro_navfixes_fix2()
+{
+	//Get nav areas:
+	//Problematic nav areas
+	// Truck
+	local fix1_jesusNav_a = NavMesh.GetNavAreaByID(48708)
+	local fix1_jesusNav_b = NavMesh.GetNavAreaByID(48614)
+	local fix1_jesusNav_c = NavMesh.GetNavAreaByID(48607)
+	local fix1_jesusNav_d = NavMesh.GetNavAreaByID(48762)
+	// Bus 1
+	local fix1_jesusNav_e = NavMesh.GetNavAreaByID(48634)
+	local fix1_jesusNav_f = NavMesh.GetNavAreaByID(48705)
+	local fix1_jesusNav_g = NavMesh.GetNavAreaByID(48704)
+	// Bus 2
+	local fix1_jesusNav_h = NavMesh.GetNavAreaByID(48771)
+	local fix1_jesusNav_i = NavMesh.GetNavAreaByID(48824)
+	local fix1_jesusNav_j = NavMesh.GetNavAreaByID(48683)
+	//Nav areas to connect
+	local fix1_nav_a = NavMesh.GetNavAreaByID(48884)
+	local fix1_nav_b = NavMesh.GetNavAreaByID(48578)
+	local fix1_nav_c1 = NavMesh.GetNavAreaByID(48764)
+	local fix1_nav_c2 = NavMesh.GetNavAreaByID(48605)
+	local fix1_nav_d1 = NavMesh.GetNavAreaByID(48633)
+	local fix1_nav_d2 = NavMesh.GetNavAreaByID(49984)
+	local fix1_nav_e = NavMesh.GetNavAreaByID(50019)
+	local fix1_nav_f = NavMesh.GetNavAreaByID(50011)
+	local fix1_nav_g = NavMesh.GetNavAreaByID(48747)
+	local fix1_nav_h = NavMesh.GetNavAreaByID(48555)
+	local fix1_nav_i = NavMesh.GetNavAreaByID(48598)
+	local fix1_nav_j1 = NavMesh.GetNavAreaByID(48837)
+	local fix1_nav_j2 = NavMesh.GetNavAreaByID(48737)
+	
+	//Create one-way connection between nav areas
+	fix1_nav_a.ConnectTo(fix1_jesusNav_a,-1)
+	fix1_nav_b.ConnectTo(fix1_jesusNav_b,-1)
+	fix1_nav_c1.ConnectTo(fix1_jesusNav_c,-1)
+	fix1_nav_c2.ConnectTo(fix1_jesusNav_c,-1)
+	fix1_nav_d1.ConnectTo(fix1_jesusNav_d,-1)
+	fix1_nav_d2.ConnectTo(fix1_jesusNav_d,-1)
+	fix1_nav_e.ConnectTo(fix1_jesusNav_e,-1)
+	fix1_nav_f.ConnectTo(fix1_jesusNav_f,-1)
+	fix1_nav_g.ConnectTo(fix1_jesusNav_g,-1)
+	fix1_nav_h.ConnectTo(fix1_jesusNav_h,-1)
+	fix1_nav_i.ConnectTo(fix1_jesusNav_i,-1)
+	fix1_nav_j1.ConnectTo(fix1_jesusNav_j,-1)
+	fix1_nav_j2.ConnectTo(fix1_jesusNav_j,-1)
+	
+	printl("\n[NavFixes] Fix 2 applied\n")
+}
+
+
+cwm1_intro_navfixes_fix1()
+cwm1_intro_navfixes_fix2()

--- a/scripts/vscripts/nav_fixes/cwm2_warehouse_navfixes.nut
+++ b/scripts/vscripts/nav_fixes/cwm2_warehouse_navfixes.nut
@@ -1,0 +1,62 @@
+printl("\n[NavFixes] cwm2_warehouse_navfixes initialized\n")
+
+//Fix 1: Fix jesus spot on top of truck after the alarmed doors//
+//Issue: Nav area has one way connections, making it impossible for common to path
+function cwm2_warehouse_navfixes_fix1()
+{
+	//Get nav areas:
+	//Problematic nav areas (on top of truck)
+	local fix1_jesusNav_a = NavMesh.GetNavAreaByID(19271)
+	local fix1_jesusNav_b = NavMesh.GetNavAreaByID(19258)
+	local fix1_jesusNav_c = NavMesh.GetNavAreaByID(19256)
+	local fix1_jesusNav_d = NavMesh.GetNavAreaByID(19247)
+	//Nav areas to connect
+	local fix1_nav_a = NavMesh.GetNavAreaByID(19632)
+	local fix1_nav_b1 = NavMesh.GetNavAreaByID(19249)
+	local fix1_nav_b2 = NavMesh.GetNavAreaByID(19269)
+	local fix1_nav_c1 = NavMesh.GetNavAreaByID(19266)
+	local fix1_nav_c2 = NavMesh.GetNavAreaByID(19248)
+	local fix1_nav_d1 = NavMesh.GetNavAreaByID(19312)
+	local fix1_nav_d2 = NavMesh.GetNavAreaByID(19234)
+	
+	//Create one-way connection between nav areas
+	fix1_nav_a.ConnectTo(fix1_jesusNav_a,-1)
+	fix1_nav_b1.ConnectTo(fix1_jesusNav_b,-1)
+	fix1_nav_b2.ConnectTo(fix1_jesusNav_b,-1)
+	fix1_nav_c1.ConnectTo(fix1_jesusNav_c,-1)
+	fix1_nav_c2.ConnectTo(fix1_jesusNav_c,-1)
+	fix1_nav_d1.ConnectTo(fix1_jesusNav_d,-1)
+	fix1_nav_d2.ConnectTo(fix1_jesusNav_d,-1)
+	
+	printl("\n[NavFixes] Fix 1 applied\n")
+}
+
+//Fix 2: Fix jesus spot on top of van after the alarmed doors//
+//Issue: Nav area has one way connections, making it impossible for common to path
+function cwm2_warehouse_navfixes_fix2()
+{
+	//Get nav areas:
+	//Problematic nav areas (on top of van)
+	local fix1_jesusNav_a = NavMesh.GetNavAreaByID(18085)
+	local fix1_jesusNav_b = NavMesh.GetNavAreaByID(18070)
+	local fix1_jesusNav_c = NavMesh.GetNavAreaByID(16583)
+	//Nav areas to connect
+	local fix1_nav_a = NavMesh.GetNavAreaByID(16377)
+	local fix1_nav_b1 = NavMesh.GetNavAreaByID(18064)
+	local fix1_nav_b2 = NavMesh.GetNavAreaByID(16117)
+	local fix1_nav_c1 = NavMesh.GetNavAreaByID(19200)
+	local fix1_nav_c2 = NavMesh.GetNavAreaByID(16043)
+	
+	//Create one-way connection between nav areas
+	fix1_nav_a.ConnectTo(fix1_jesusNav_a,-1)
+	fix1_nav_b1.ConnectTo(fix1_jesusNav_b,-1)
+	fix1_nav_b2.ConnectTo(fix1_jesusNav_b,-1)
+	fix1_nav_c1.ConnectTo(fix1_jesusNav_c,-1)
+	fix1_nav_c2.ConnectTo(fix1_jesusNav_c,-1)
+	
+	printl("\n[NavFixes] Fix 2 applied\n")
+}
+
+
+cwm2_warehouse_navfixes_fix1()
+cwm2_warehouse_navfixes_fix2()


### PR DESCRIPTION
Some much needed bug fixes and QOL improvements 

## cwm1_intro
Added an ammo pile at the warehouse exit
Blocked room accessible from the awnings by the starting saferoom
Blocked balconies accessible from the awnings by the starting saferoom
Blocked standing on bus at the end of the street by the starting saferoom
Blocked standing on the porta-potties by the tents
Blocked tent by the fallen semi-trailer
Blocked standing on fallen semi-trailer before the warehouse
Blocked standing on the beige truck and trailer before the warehouse
Blocked survivors from getting on the warehouse roof
Blocked survivors from standing on the roll-up doors inside the warehouse
Blocked survivors from standing on the roof above the stairs after the warehouse
Blocked out of bounds areas for survivors by the starting saferoom
Blocked out of bounds area behind the CEDA trucks / tents
Blocked survivor out of bounds spot in bushes by the end saferoom
Blocked survivors getting on the end saferoom roof and going out of bounds
Blocked a sliding stuck spot behind a house by the starting saferoom
Blocked perma-stuck spot in some bushes to the right of the warehouse
Fixed a god spot on top of bus outside the starting saferoom
Fixed a god spots on top of truck / buses after the warehouse
Added a survivor ladder on front of red truck outside the starting saferoom
Added infected ladders on bus outside the starting saferoom
Added an infected ladder on hedge outside the starting saferoom
Added infected ladders on street corner fence outside the starting saferoom
Added an infected ladder on back of semi trailer before the tents
Added an infected ladder on fence at entrance to tents area
Added a survivor ladder to climb on front of orange truck outside the warehouse
Added infected ladders on trucks outside the warehouse
Added an infected ladder on fallen semi trailer outside the warehouse
Added an infected ladder on the far side of the warehouse by the truck

## cwm2_warehouse
Improved gas station roof blockers
Fixed a skip for the warehouse ladder
Improved blockers on shelves in the power plant area
Improved blockers to skip the apartments by climbing on the generator / electrical boxes
Fixed alarm sound fade out being applied at the wrong time
Added an ammo pile on the meeting table in the warehouse offices
Added an ammo pile in the shop at the start of the apartments
Blocked a skip over a fence by the starting saferoom
Blocked survivors being able to access the bridge
Blocked standing on gas station window frame
Blocked jumping over the hedges to skip the gas station
Blocked shelves to right of ladder in warehouse
Remove a hand-truck that can be used to access a god spot in the warehouse / skip the intended route
Blocked god spot shelves under the walkway in the warehouse
Blocked standing on shelf under the warehouse ladder
Blocked standing on a shelf to the left of the warehouse ladder
Blocked jumping on an electrical box on the warehouse walkway
Blocked standing on the support beams in the warehouse
Blocked shelves at the end of the walkway in the warehouse
Blocked being able to skip the event by jumping from a window in the offices over a fence
Blocked standing on blue food truck after the warehouse
Blocked standing on white truck after the warehouse
Blocked standing on an electrical box before the event button
Blocked a ledge that can be used to skip the apartments
Blocked survivors from accessing a room above the scaffolding
Fixed god spot on top of truck after the alarmed door
Fixed god spot on top of van after the alarmed door
Blocked a perma-stuck spot between some trucks after the gas station
Added an infected ladder on the starting saferoom
Added infected ladders on the truck outside the starting saferoom
Added an infected ladder on fallen delivery truck outside the starting saferoom
Added an infected ladder to climb over fence outside the starting saferoom
Added infected ladders to climb over the middle of the bridge outside the starting saferoom
Added infected ladders to climb on trucks after the gas station
Added an extra infected ladder to climb on awning at the warehouse entrance
Added an infected ladder to climb back over fallen shelves at the start of the warehouse
Adjusted infected ladder by the alarmed door to help prevent falling off / getting stuck
Added an infected ladder by fenced off power transformers to prevent a perma-stuck spot and climb over the fence

## cwm3_drain
Both an SMG and shotgun always spawn in the sewer exit room
Added an ammo pile by the van after the event
Blocked survivors from accessing the wall cavity by the starting saferoom
Blocked survivors from standing on the signal boxes around the event
Blocked survivors getting onto the higher platforms around the event
Blocked survivors from getting on or behind the fences around the event
Blocked survivors from standing on the metal shacks around the event
Blocked standing on the windows at the drop after the event
Blocked survivors from standing on the back of the truck after the event
Blocked survivors from going over a fence after the event to skip to the end saferoom
Blocked survivor access to windows near the van
Blocked survivors accessing the apartment roof with ledge hangs
Blocked survivors accessing a balcony near the apartments fire escape
Blocked survivors dropping into a window from the fire escape to skip the apartments
Blocked survivors from standing on semi truck by the end saferoom
Blocked out of bounds area by the end saferoom
Added clipping to fix getting stuck on car stops by the end saferoom
Added clipping to fix getting stuck on fallen fence by the end saferoom
Added an additional pipe on the drop before the sewer exit to assist with climbing back up
Added an infected ladder to climb up to the walkway after the starting saferoom

## cwm4_building
Ensured both SMG and shotgun always spawn in the kitchen
Ensured both SMG and shotgun always spawn in the side room before the tank
Ensured both SMG and shotgun always spawn up the stairs after the tank
Added an ammo pile by the one way drop hole
Added boards to guide players dropping between floors / make the drops easier