### PR TITLE
Detour Ahead 3 Sewer drop tank ban

### DIFF
--- a/cfg/cfgogl/zonemod/mapinfo.txt
+++ b/cfg/cfgogl/zonemod/mapinfo.txt
@@ -1118,9 +1118,9 @@
 		"end_dist"			"245.495361"
 		"tank_ban_flow"
 		{
-			"During sewers"
+			"During sewers + double ladder drop"
 			{
-				"min"		"60"
+				"min"		"52"
 				"max"		"79"
 			}
 		}


### PR DESCRIPTION
Add ban range between 52 - 59% to block tanks on the double sewer drop (on top of the 60 - 79% ban already in place)

This tank range can result in different spawns between teams depending on the path they take and cause the tank to spawn too close