### PR TITLE
[detour ahead] m3 navigation fix

### DIFF
--- a/cfg/stripper/zonemod/maps/cdta_03warehouse.cfg
+++ b/cfg/stripper/zonemod/maps/cdta_03warehouse.cfg
@@ -1085,6 +1085,48 @@ add:
 	"team" "2"
 }
 
+; ######  NAVIGATIONS ATTRIBUTE / BLOCK CHANGES  ######
+; =====================================================
+; ==                   NAVIGATIONS                   ==
+; ==      Navigation fix , Flow block changes        ==
+; =====================================================
+
+
+; --- fix the navigation atrribute [obscured] make Si spawn IN Svv sight
+; --- 修复[obscured]（强制复活）属性导致的特感可以在人类视线内复活的区域
+
+; --- the wirehouse 出门仓库
+add:
+{
+	"classname" "point_nav_attribute_region"
+	"crouch" "0"
+	"maxs" "600 400 180"
+	"mins" "-600 -200 -20"
+	"mob_only" "0"
+	"precise" "0"
+	"remove_attributes" "1"
+	"spawnflags" "4096"
+	"stairs" "0"
+	"tank_only" "0"
+	"targetname" "nav_fix_obscured_remove01"
+	"origin" "-4880 -6248 348"
+}
+
+; --- hotel entrance 公寓入口
+{
+	"classname" "point_nav_attribute_region"
+	"crouch" "0"
+	"maxs" "200 128 80"
+	"mins" "-200 -128 -20"
+	"mob_only" "0"
+	"precise" "0"
+	"remove_attributes" "1"
+	"spawnflags" "4096"
+	"stairs" "0"
+	"tank_only" "0"
+	"targetname" "nav_fix_obscured_remove02"
+	"origin" "-400 -7296 340"
+}
 
 ; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
 ; =====================================================


### PR DESCRIPTION
thanks @mk report.
fix the navigation atrribute [obscured] make Si spawn IN Svv sight

<img width="1672" height="914" alt="11" src="https://github.com/user-attachments/assets/527caa78-1bd1-4ee7-98e1-9503521aa0c1" />

the wirehouse

<img width="1632" height="859" alt="12" src="https://github.com/user-attachments/assets/4c164532-bdca-4483-8e6e-3f1c6fba2f88" />

the hotel entrance