### PR TITLE
cwm1 truck skip + oob/stuck fixes

### DIFF
--- a/cfg/stripper/zonemod/maps/cwm1_intro.cfg
+++ b/cfg/stripper/zonemod/maps/cwm1_intro.cfg
@@ -204,73 +204,73 @@ add:
 	"BlockType" "1"
 }
 ; --- Block tent by the fallen semi-trailer
-{
-	"classname" "env_physics_blocker"
-	"origin" "2265.73 2542.02 760"
-	"angles" "0 -1 0"
-	"mins" "-190 -5 -520"
-	"maxs" "190 5 520"
-	"boxmins" "-190 -5 -520"
-	"boxmaxs" "190 5 520"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "2270.27 2801.98 760"
-	"angles" "0 -1 0"
-	"mins" "-190 -5 -520"
-	"maxs" "190 5 520"
-	"boxmins" "-190 -5 -520"
-	"boxmaxs" "190 5 520"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "2081.03 2675.26 760"
-	"angles" "0 -1 0"
-	"mins" "-3 -125 -520"
-	"maxs" "3 125 520"
-	"boxmins" "-3 -125 -520"
-	"boxmaxs" "3 125 520"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "2454.97 2668.74 760"
-	"angles" "0 -1 0"
-	"mins" "-3 -125 -520"
-	"maxs" "3 125 520"
-	"boxmins" "-3 -125 -520"
-	"boxmaxs" "3 125 520"
-	"initialstate" "1"
-	"BlockType" "1"
-}
+;{
+;	"classname" "env_physics_blocker"
+;	"origin" "2265.73 2542.02 760"
+;	"angles" "0 -1 0"
+;	"mins" "-190 -5 -520"
+;	"maxs" "190 5 520"
+;	"boxmins" "-190 -5 -520"
+;	"boxmaxs" "190 5 520"
+;	"initialstate" "1"
+;	"BlockType" "1"
+;}
+;{
+;	"classname" "env_physics_blocker"
+;	"origin" "2270.27 2801.98 760"
+;	"angles" "0 -1 0"
+;	"mins" "-190 -5 -520"
+;	"maxs" "190 5 520"
+;	"boxmins" "-190 -5 -520"
+;	"boxmaxs" "190 5 520"
+;	"initialstate" "1"
+;	"BlockType" "1"
+;}
+;{
+;	"classname" "env_physics_blocker"
+;	"origin" "2081.03 2675.26 760"
+;	"angles" "0 -1 0"
+;	"mins" "-3 -125 -520"
+;	"maxs" "3 125 520"
+;	"boxmins" "-3 -125 -520"
+;	"boxmaxs" "3 125 520"
+;	"initialstate" "1"
+;	"BlockType" "1"
+;}
+;{
+;	"classname" "env_physics_blocker"
+;	"origin" "2454.97 2668.74 760"
+;	"angles" "0 -1 0"
+;	"mins" "-3 -125 -520"
+;	"maxs" "3 125 520"
+;	"boxmins" "-3 -125 -520"
+;	"boxmaxs" "3 125 520"
+;	"initialstate" "1"
+;	"BlockType" "1"
+;}
 ; --- Block standing on fallen semi-trailer before the warehouse
-{
-	"classname" "env_physics_blocker"
-	"origin" "1838.11 2506.13 748"
-	"angles" "0 -35 0"
-	"mins" "-58.5 -266.5 -532"
-	"maxs" "58.5 266.5 532"
-	"boxmins" "-58.5 -266.5 -532"
-	"boxmaxs" "58.5 266.5 532"
-	"initialstate" "1"
-	"BlockType" "1"
-}
-{
-	"classname" "env_physics_blocker"
-	"origin" "2021.64 2621.78 748"
-	"angles" "0 -35 0"
-	"mins" "-25.5 -66.5 -532"
-	"maxs" "25.5 66.5 532"
-	"boxmins" "-25.5 -66.5 -532"
-	"boxmaxs" "25.5 66.5 532"
-	"initialstate" "1"
-	"BlockType" "1"
-}
+;{
+;	"classname" "env_physics_blocker"
+;	"origin" "1838.11 2506.13 748"
+;	"angles" "0 -35 0"
+;	"mins" "-58.5 -266.5 -532"
+;	"maxs" "58.5 266.5 532"
+;	"boxmins" "-58.5 -266.5 -532"
+;	"boxmaxs" "58.5 266.5 532"
+;	"initialstate" "1"
+;	"BlockType" "1"
+;}
+;{
+;	"classname" "env_physics_blocker"
+;	"origin" "2021.64 2621.78 748"
+;	"angles" "0 -35 0"
+;	"mins" "-25.5 -66.5 -532"
+;	"maxs" "25.5 66.5 532"
+;	"boxmins" "-25.5 -66.5 -532"
+;	"boxmaxs" "25.5 66.5 532"
+;	"initialstate" "1"
+;	"BlockType" "1"
+;}
 ; --- Block standing on the beige truck and trailer before the warehouse
 {
 	"classname" "env_physics_blocker"
@@ -358,6 +358,31 @@ add:
 ; ==                  OUT OF BOUNDS                  ==
 ; ==  Block players getting outside / under the map  ==
 ; =====================================================
+; --- Block infected out of bounds / under the map spots in the river
+{
+	"classname" "env_physics_blocker"
+	"origin" "-447 480 -141"
+	"mins" "-2049 -96 -51"
+	"maxs" "2049 96 51"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-240 -360 -160"
+	"mins" "-16 -1272 -32"
+	"maxs" "16 1272 32"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "5752 416 -156"
+	"mins" "-136 -32 -36"
+	"maxs" "136 32 36"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Block out of bounds areas for survivors by the starting saferoom
 ; --- Hedges
 {
@@ -630,12 +655,51 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Block a perma-stuck spot between 2 tents
+{
+	"classname" "env_physics_blocker"
+	"origin" "2320 1812 161.5"
+	"mins" "-50 -8 -49.5"
+	"maxs" "50 8 49.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Block perma-stuck spot in some bushes to the right of the warehouse
 {
 	"classname" "env_physics_blocker"
 	"origin" "141.5 3512.5 168"
 	"mins" "-45.5 -136.5 -56"
 	"maxs" "45.5 136.5 56"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+; --- Clipping on car stops by the starting saferoom to prevent getting stuck
+{
+	"classname" "env_physics_blocker"
+	"origin" "3476 -2750 122.5"
+	"mins" "-6 -49 -2.5"
+	"maxs" "6 49 2.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3476 -2596 122.5"
+	"mins" "-6 -49 -2.5"
+	"maxs" "6 49 2.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "3475 -2448 122.5"
+	"mins" "-6 -49 -2.5"
+	"maxs" "6 49 2.5"
 	"initialstate" "1"
 	"BlockType" "0"
 }


### PR DESCRIPTION
Unblocked the precious truck skip before the warehouse
Blocked infected out of bounds / under the map spots in the river
Blocked a perma-stuck spot between 2 tents
Added clipping on car stops by the starting saferoom to prevent getting stuck