### PR TITLE
Parish overgrowth first chapter

### DIFF
--- a/cfg/stripper/zonemod/maps/PR1_Waterfront_F.cfg
+++ b/cfg/stripper/zonemod/maps/PR1_Waterfront_F.cfg
@@ -1,0 +1,422 @@
+; =====================================================
+; ==============   Parish Overgrowth 1   ==============
+; =====================================================
+
+; ############  DIRECTOR AND EVENT CHANGES  ###########
+; =====================================================
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==       Modify director behaviour and events      ==
+; =====================================================
+
+; ################  ITEM SPAWN CHANGES  ###############
+; =====================================================
+; ==           PILL / ITEM / WEAPON SPAWNS           ==
+; ==   Remove or change pill, item & weapon spawns   ==
+; =====================================================
+; --- Remove unreachable weapon spawns
+filter:
+; --- Melee weapon
+{
+    "hammerid" "2066830"
+}
+
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
+
+; =====================================================
+; ==                 HITTABLE CHANGES                ==
+; ==           Add/remove/modify hittables           ==
+; =====================================================
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+add:
+; --- Block survivors from getting on the roof next to the bar
+{
+    "classname" "env_physics_blocker"
+    "origin" "-1454 -1470 134"
+    "mins" "-258 -194 -187.5"
+    "maxs" "258 194 187.5"
+    "initialstate" "1"
+    "BlockType" "1"
+}
+; --- Block survivors from getting on the roof of the blue building opposite the bar
+{
+    "classname" "env_physics_blocker"
+    "origin" "-592 -1664 59"
+    "mins" "-144 -384 -112.5"
+    "maxs" "144 384 112.5"
+    "initialstate" "1"
+    "BlockType" "1"
+}
+; --- Block survivors from getting on the roofs around the alley
+{
+    "classname" "env_physics_blocker"
+    "origin" "-1952 -1760 124"
+    "mins" "-128 -256 -196"
+    "maxs" "128 256 196"
+    "initialstate" "1"
+    "BlockType" "1"
+}
+; --- Block survivors from standing on the wall after the kitchen
+{
+    "classname" "env_physics_blocker"
+    "origin" "-3208 -240 -52"
+    "mins" "-10 -336 -188"
+    "maxs" "10 336 188"
+    "initialstate" "1"
+    "BlockType" "1"
+}
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+add:
+; --- Block area in saferoom above stairs from being accessed via warping / noclip to prevent the round from ending
+{
+    "classname" "env_physics_blocker"
+    "origin" "-4016 -1384 -88"
+    "mins" "-240 -40 -64"
+    "maxs" "240 40 64"
+    "initialstate" "1"
+    "BlockType" "0"
+}
+
+; =====================================================
+; ==                   STUCK SPOTS                   ==
+; ==  Prevent players from getting stuck in the map  ==
+; =====================================================
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+add:
+; --- Block items from falling down the small gap in saferoom
+{
+    "classname" "env_physics_blocker"
+    "origin" "676 664 -493"
+    "mins" "-4 -152 -11"
+    "maxs" "4 152 11"
+    "boxmins" "-4 -152 -11"
+    "boxmaxs" "4 152 11"
+    "initialstate" "1"
+    "BlockType" "4"
+}
+{
+    "classname" "env_physics_blocker"
+    "origin" "667 818 -379"
+    "mins" "-13 -2 -103"
+    "maxs" "13 2 103"
+    "boxmins" "-13 -2 -103"
+    "boxmaxs" "13 2 103"
+    "initialstate" "1"
+    "BlockType" "4"
+}
+; --- Clipping at top of ramp in saferoom to prevent getting stuck
+{
+    "classname" "env_physics_blocker"
+    "origin" "791 46 -374"
+    "mins" "-44 -3 -4"
+    "maxs" "44 3 4"
+    "initialstate" "1"
+    "BlockType" "0"
+}
+; --- Clipping on group of 3 plant pots that behave like ice
+{
+    "classname" "env_physics_blocker"
+    "origin" "76 -176 -341.5"
+    "mins" "-20 -21 -1"
+    "maxs" "20 21 1"
+    "initialstate" "1"
+    "BlockType" "0"
+}
+{
+    "classname" "env_physics_blocker"
+    "origin" "76 -55 -341.5"
+    "mins" "-20 -21 -1"
+    "maxs" "20 21 1"
+    "initialstate" "1"
+    "BlockType" "0"
+}
+{
+    "classname" "env_physics_blocker"
+    "origin" "77 74 -341.5"
+    "mins" "-20 -21 -1"
+    "maxs" "20 21 1"
+    "initialstate" "1"
+    "BlockType" "0"
+}
+filter:
+; --- Remove table and chairs on the balcony opposite the saferoom ramp
+{
+    "hammerid" "472733"
+}
+{
+    "hammerid" "472741"
+}
+{
+    "hammerid" "1064146"
+}
+; --- Remove a table in the bar that can fall over when spawning and blocks the doorway
+{
+    "hammerid" "461272"
+}
+; --- Fix LOS on jukebox in bar
+add:
+{
+    "classname" "logic_auto"
+    "OnMapSpawn" "losfix_jukebox_bar,AddOutput,mins -18 -11 -32,0,-1"
+    "OnMapSpawn" "losfix_jukebox_bar,AddOutput,maxs 18 11 32,0,-1"
+    "OnMapSpawn" "losfix_jukebox_bar,AddOutput,solid 2,0,-1"
+}
+{
+    "classname" "func_brush"
+    "origin" "-1492 -1684 -344"
+    "targetname" "losfix_jukebox_bar"
+}
+{
+    "classname" "env_physics_blocker"
+    "origin" "-1492 -1684 -344"
+    "mins" "-18.1 -11.1 -32.1"
+    "maxs" "18.1 11.1 32.1"
+    "initialstate" "1"
+    "BlockType" "0"
+}
+; --- Add missing glass to vehicles (hittable car)
+modify:
+{
+    match:
+    {
+        "hammerid" "2400432"
+    }
+    insert:
+    {
+        "targetname" "InstanceAuto1-car_physics"
+    }
+}
+add:
+{
+    "classname" "prop_dynamic"
+    "origin" "-1544.86 -1166.75 -375.257"
+    "angles" "0 0 0"
+    "model" "models/props_vehicles/cara_84sedan_glass.mdl"
+    "solid" "6"
+    "disableshadows" "1"
+    "parentname" "InstanceAuto1-car_physics"
+}
+; --- Add missing glass to vehicles (static car)
+add:
+{
+    "classname" "prop_dynamic"
+    "origin" "-876 -1661 -375.19"
+    "angles" "0 18.5 0"
+    "model" "models/props_vehicles/cara_82hatchback_wrecked_glass.mdl"
+    "solid" "6"
+    "disableshadows" "1"
+}
+
+; ###########  ADDITIONAL PROPS AND SPAWNS  ###########
+; =====================================================
+; ==                      PROPS                      ==
+; ==       New props for balance and SI spawns       ==
+; =====================================================
+add:
+; --- Fence cover to the left by the saferoom
+{
+    "classname" "prop_dynamic"
+    "origin" "119 -829 -376"
+    "angles" "0 90 0"
+    "model" "models/props_urban/fence_cover001_128.mdl"
+    "solid" "6"
+    "disableshadows" "1"
+}
+; --- Prop to get on end saferoom roof
+{
+    "classname" "prop_dynamic"
+    "origin" "-4208 -1080 -126"
+    "angles" "40 90 0"
+    "model" "models/props_highway/plywood_02.mdl"
+    "solid" "6"
+    "disableshadows" "1"
+}
+
+; =====================================================
+; ==             LADDER / ELEVATOR NERF              ==
+; ==   Nerf ladder & elevator attacks for infected   ==
+; =====================================================
+
+; ############  MAP SOUND AND GFX CHANGES  ############
+; =====================================================
+; ==                  SOUND REMOVAL                  ==
+; ==    Remove or adjust sounds played by the map    ==
+; =====================================================
+
+; =====================================================
+; ==             GFX / PARTICLES REMOVAL             ==
+; ==        Remove visual effects from the map       ==
+; =====================================================
+filter:
+; --- Remove F18 flyby at the start of the map
+{
+    "targetname" "f18_flyby"
+}
+{
+    "targetname" "f18_prop01"
+}
+{
+    "targetname" "f18_prop02"
+}
+{
+    "targetname" "f18_shake"
+}
+{
+    "targetname" "f18_sound_flyby"
+}
+{
+    "targetname" "f18_sound_flyby_rumble"
+}
+{
+    "targetname" "f18_sound_flyby2"
+}
+{
+    "hammerid" "1559961"
+}
+
+; ###############  TRIGGERS AND BRUSHES  ##############
+; =====================================================
+; ==                   CLIP REMOVAL                  ==
+; ==      Remove miscellaneous clips and brushes     ==
+; =====================================================
+filter:
+; --- Remove the clip that surrounds the saferoom blocking survivors from going in the water
+{
+    "hammerid" "1633358"
+}
+add:
+; --- Block survivors from getting on the building by the overturned truck
+{
+    "classname" "env_physics_blocker"
+    "BlockType" "1"
+    "initialstate" "1"
+    "maxs" "6 512 256"
+    "mins" "-4 -384 -80"
+    "origin" "-662 -880 -100.086"
+    "mapupdate" "1"
+}
+; --- Block survivors from getting out of bounds by the end saferoom
+{
+    "classname" "env_physics_blocker"
+    "BlockType" "1"
+    "initialstate" "1"
+    "maxs" "24 8 384"
+    "mins" "-24 -8 -80"
+    "origin" "-3832 -1144 -250"
+    "mapupdate" "1"
+}
+
+; =====================================================
+; ==              TRIGGER REMOVAL / FIX              ==
+; ==    Fix triggers that interfere with gameplay    ==
+; =====================================================
+; --- Disable jukebox to prevent trolling
+modify:
+{
+    match:
+    {
+        "targetname" "jukebox_button"
+    }
+    replace:
+    {
+        "spawnflags" "33"
+    }
+}
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+add:
+; --- Infected ladder to stop players getting perma-stuck behind a fence next to the end saferoom
+{
+    "classname" "func_simpleladder"
+    "origin" "-1347 153 -28"
+    "angles" "0 0 0"
+    "model" "*1"
+    "normal.x" "-1.00"
+    "normal.y" "0.00"
+    "normal.z" "0.00"
+    "team" "2"
+}
+add:
+; --- Infected ladder ladder near the kitchen
+{
+    "classname" "func_simpleladder"
+    "origin" "0 -138 0"
+    "angles" "0 0 0"
+    "model" "*87"
+    "normal.x" "1"
+    "normal.y" "0"
+    "normal.z" "0"
+    "team" "2"
+}
+
+; #######  MISCELLANEOUS / MAP SPECIFIC CHANGES  ######
+; =====================================================
+; ==                   BLANK HEADER                  ==
+; ==                Blank description                ==
+; =====================================================
+; --- Remove useless entities
+filter:
+; --- Forklift tires (2)
+{
+    "classname" "/.*prop_physics.*/"
+    "model" "models/props/cs_assault/forklift_brokenlift_tire3.mdl"
+}
+; --- Gift box
+{
+    "hammerid" "2512711"
+}
+; --- Fallen bookcase
+{
+    "hammerid" "2144896"
+}
+
+; --- Remove left over entities from original map
+filter:
+; --- Dynamic route related entities
+{
+    "targetname" "director_query"
+}
+{
+    "targetname" "case_route"
+}
+; --- skylight_02 window related entities
+{
+    "targetname" "skylight_02"
+}
+{
+    "targetname" "portal_window_09"
+}
+{
+    "hammerid" "468266"
+}
+
+; --- Remove blocked window near the overturned truck
+filter:
+{
+    "hammerid" "469394"
+}
+{
+    "hammerid" "465931"
+}
+{
+    "hammerid" "1683490"
+}

--- a/cfg/stripper/zonemod/maps/PR1_Waterfront_F.cfg
+++ b/cfg/stripper/zonemod/maps/PR1_Waterfront_F.cfg
@@ -36,6 +36,15 @@ filter:
 ; ==      Block intentionally performed exploits     ==
 ; =====================================================
 add:
+; --- Block survivors from getting on the burning building near saferoom
+{
+    "classname" "env_physics_blocker"
+    "origin" "-408 -128 -34"
+    "mins" "-249 -192 -178"
+    "maxs" "249 192 178"
+    "initialstate" "1"
+    "BlockType" "1"
+}
 ; --- Block survivors from getting on the roof next to the bar
 {
     "classname" "env_physics_blocker"
@@ -356,7 +365,7 @@ add:
     "team" "2"
 }
 add:
-; --- Infected ladder ladder near the kitchen
+; --- Infected ladder near the kitchen
 {
     "classname" "func_simpleladder"
     "origin" "0 -138 0"


### PR DESCRIPTION
Added some recent fixes from zonemod to the first chapter since the map layout is very similar Some were already brought in the new version of the map, but still has some missing Tried to match some changes from c5m1_waterfront.cfg Also brought some new changes
- Added a new infected ladder next to the kitchen
- Unlocked a path for SI near the overturned truck
- Removed some useless entities
- Removed unreachable melee spawn