### PR TITLE
Fix Dark Carnival Remix ladders

### DIFF
--- a/cfg/stripper/zonemod/maps/dkr_m2_carnival.cfg
+++ b/cfg/stripper/zonemod/maps/dkr_m2_carnival.cfg
@@ -32,3 +32,21 @@ add:
 	"origin" "2912 6016 312"
 ;	"targetname" "eb_fix01"
 }
+
+
+; --- Fix broken infected ladder on telephone pole after the warehouse
+filter:
+{
+	"hammerid" "1184297"
+}
+add:
+{
+    "classname" "func_simpleladder"
+    "origin" "-1.00049 7.33105 -90.5992"
+    "angles" "0 0 3"
+    "model" "*205"
+    "normal.x" "0"
+    "normal.y" "-0.99863"
+    "normal.z" "-0.052336"
+    "team" "2"
+}

--- a/cfg/stripper/zonemod/maps/dkr_m3_tunneloflove.cfg
+++ b/cfg/stripper/zonemod/maps/dkr_m3_tunneloflove.cfg
@@ -67,3 +67,17 @@ modify:
 		"OnStartTouch" "tankspawn8_relay,Trigger,,0,1"
 	}
 }
+
+; --- Fix broken infected ladder on yellow tent before the coaster
+modify:
+{
+	match:
+	{
+		"hammerid" "6465157"
+	}
+	replace:
+	{
+		"normal.y" "0"
+		"normal.x" "-1"
+	}
+}


### PR DESCRIPTION
Map 2
Fix an unusable infected ladder on a telephone pole after the warehouse

Map 3
Fix a broken infected ladder on a yellow tent before the coaster