### PR TITLE
[detour ahead] m3 more navigation fix

### DIFF
--- a/cfg/stripper/zonemod/maps/cdta_03warehouse.cfg
+++ b/cfg/stripper/zonemod/maps/cdta_03warehouse.cfg
@@ -1138,16 +1138,16 @@ add:
 ; =====================================================
 
 
-; --- fix the navigation atrribute [obscured] make Si spawn IN Svv sight
+; --- remove the navigation atrribute [obscured] make Si spawn IN Svv sight
 ; --- 修复[obscured]（强制复活）属性导致的特感可以在人类视线内复活的区域
 
-; --- the wirehouse 出门仓库
+; --- the warehouse 出门仓库
 add:
 {
 	"classname" "point_nav_attribute_region"
 	"crouch" "0"
-	"maxs" "600 400 180"
-	"mins" "-600 -200 -20"
+	"maxs" "760 400 180"
+	"mins" "-600 -600 -20"
 	"mob_only" "0"
 	"precise" "0"
 	"remove_attributes" "1"
@@ -1158,7 +1158,7 @@ add:
 	"origin" "-4880 -6248 348"
 }
 
-; --- hotel entrance 公寓入口
+; --- apartment entrance 公寓入口
 {
 	"classname" "point_nav_attribute_region"
 	"crouch" "0"


### PR DESCRIPTION
Added fixes for missing navigation area attributes.
Corrected the description of the comments.
thanks onric9.
now the 2 blue areas are fixed.
<img width="1920" height="1080" alt="111" src="https://github.com/user-attachments/assets/f49d9b97-6cfc-4197-aac7-3736e09e71d9" />
