### PR TITLE
[outline] m4 unlock more pills

### DIFF
--- a/cfg/cfgogl/zonemod/mapinfo.txt
+++ b/cfg/cfgogl/zonemod/mapinfo.txt
@@ -2989,7 +2989,7 @@
 	{
 		"ItemLimits"
 		{
-			"pain_pills"	"4"
+			"pain_pills"	"6"
 		}
 	}
 	


### PR DESCRIPTION
According to the author's (Taiga) update . The update type was by-vpk :
adjust level score from 700 to 900.
adjust pills from 4 to 6.
adjust tanks from 1 to 2 (finale script).
(now m4 has 3 tanks totally)