### PR TITLE
Fix bug by player not in game for some plugins(no compiled plugin)

### DIFF
--- a/addons/sourcemod/scripting/autopause.sp
+++ b/addons/sourcemod/scripting/autopause.sp
@@ -242,7 +242,7 @@ void Event_PlayerDisconnect(Event hEvent, char[] sEventName, bool dontBroadcast)
     if (!teamPlayers.ContainsKey(sAuthId)) 
         return;
 
-    if (GetClientTeam(client) == L4D_TEAM_SURVIVOR && !IsPlayerAlive(client))
+    if (IsClientInGame(client) && GetClientTeam(client) == L4D_TEAM_SURVIVOR && !IsPlayerAlive(client))
     {
         if (convarDebug.BoolValue)
         {

--- a/addons/sourcemod/scripting/bequiet.sp
+++ b/addons/sourcemod/scripting/bequiet.sp
@@ -68,7 +68,7 @@ Action TeamSay_Callback(int client, char[] command, int args)
         return Plugin_Handled;
     }
     
-    if (bSpecSeeChat && GetClientTeam(client) != 1)
+    if (bSpecSeeChat && IsValidClient(client) && GetClientTeam(client) != 1)
     {
         char sChat[256];
         GetCmdArgString(sChat, 256);

--- a/addons/sourcemod/scripting/l4d2_ghost_warp.sp
+++ b/addons/sourcemod/scripting/l4d2_ghost_warp.sp
@@ -112,7 +112,8 @@ Action Cmd_WarpToSurvivor(int iClient, int iArgs)
 		return Plugin_Handled;
 	}
 
-	if (GetClientTeam(iClient) != L4D2Team_Infected
+	if (!IsClientInGame(iClient)
+		|| GetClientTeam(iClient) != L4D2Team_Infected
 		|| GetEntProp(iClient, Prop_Send, "m_isGhost", 1) < 1
 		|| !IsPlayerAlive(iClient)
 	) {
@@ -225,7 +226,8 @@ void Hook_OnPostThinkPost(int iClient)
 		return;
 	}
 
-	if (GetClientTeam(iClient) != L4D2Team_Infected
+	if (!IsClientInGame(iClient)
+		|| GetClientTeam(iClient) != L4D2Team_Infected
 		|| GetEntProp(iClient, Prop_Send, "m_isGhost", 1) < 1
 		|| !IsPlayerAlive(iClient)
 	) {

--- a/addons/sourcemod/scripting/playermanagement.sp
+++ b/addons/sourcemod/scripting/playermanagement.sp
@@ -560,6 +560,10 @@ stock int GetPummelQueueAttacker(int client)
 
 stock L4D2Team GetClientTeamEx(int client)
 {
+	if (!IsClientInGame(client))
+	{
+		return L4D2Team_None;
+	}
 	return view_as<L4D2Team>(GetClientTeam(client));
 }
 

--- a/addons/sourcemod/scripting/readyup/player.inc
+++ b/addons/sourcemod/scripting/readyup/player.inc
@@ -98,8 +98,8 @@ void SetClientFrozen(int client, bool freeze)
 
 bool IsPlayer(int client)
 {
-	int team = GetClientTeam(client);
-	return (team == L4D2Team_Survivor || team == L4D2Team_Infected);
+	return IsClientInGame(client) && IsClientConnected(client)
+		&& (GetClientTeam(client) == L4D2Team_Survivor || GetClientTeam(client) == L4D2Team_Infected);
 }
 
 void ReturnPlayerToSaferoom(int client, bool flagsSet = true)


### PR DESCRIPTION
L 05/23/2026 - 20:43:21: [SM] Blaming: optional/readyup.smx   
L 05/23/2026 - 20:43:21: [SM] Call stack trace:  
L 05/23/2026 - 20:43:21: [SM]   [0] GetClientTeam  
L 05/23/2026 - 20:43:21: [SM]   [1] Line 101, readyup/player.inc::IsPlayer  
L 05/23/2026 - 20:43:21: [SM]   [2] Line 27, readyup/command.inc::Ready_Cmd  
L 05/23/2026 - 20:43:21: [SM]   [3] Line 417, readyup.sp::Vote_Callback  
L 05/23/2026 - 20:43:22: [SM] Exception reported: Client 2 is not in game  

L 01/04/2026 - 09:39:10: Info (map "c2m1_highway") (file "/root/steamcmd/l4d2/left4dead2/addons/sourcemod/logs/errors_20260104.log")  
L 01/04/2026 - 09:39:10: [SM] Exception reported: Client 7 is not in game  
L 01/04/2026 - 09:39:10: [SM] Blaming: optional/autopause.smx  
L 01/04/2026 - 09:39:10: [SM] Call stack trace:  
L 01/04/2026 - 09:39:10: [SM]   [0] GetClientTeam  
L 01/04/2026 - 09:39:10: [SM]   [1] Line 246, j:\Documents\GitHub\L4D2-Competitive-Rework\addons\sourcemod\scripting\autopause.sp::Event_PlayerDisconnect  
L 01/04/2026 - 09:39:10: [SM] Exception reported: Client 7 is not in game  
L 01/04/2026 - 09:39:10: [SM] Blaming: optional/autopause.smx  
L 01/04/2026 - 09:39:10: [SM] Call stack trace:  
L 01/04/2026 - 09:39:10: [SM]   [0] GetClientTeam  
L 01/04/2026 - 09:39:10: [SM]   [1] Line 246, j:\Documents\GitHub\L4D2-Competitive-Rework\addons\sourcemod\scripting\autopause.sp::Event_PlayerDisconnect  
L 01/04/2026 - 09:39:10: [SM]   [3] FireEvent  
L 01/04/2026 - 09:39:10: [SM]   [4] Line 104, cannounce\suppress.sp::event_PlayerDisconnect_Suppress  
L 01/04/2026 - 09:39:10: [SM]   [5] Line 216, cannounce.sp::event_PlayerDisconnect  
L 01/04/2026 - 09:57:35: Error log file session closed.  

L 03/22/2026 - 11:57:43: SourceMod error session started  
L 03/22/2026 - 11:57:43: Info (map "c1m1_hotel") (file "/root/steamcmd/test/left4dead2/addons/sourcemod/logs/errors_20260322.log")  
L 03/22/2026 - 11:57:43: [SM] Exception reported: Client 5 is not in game  
L 03/22/2026 - 11:57:43: [SM] Blaming: fixes/bequiet.smx  
L 03/22/2026 - 11:57:43: [SM] Call stack trace:  
L 03/22/2026 - 11:57:43: [SM]   [0] GetClientTeam  
L 03/22/2026 - 11:57:43: [SM]   [1] Line 71, C:\Users\Sir\Documents\GitHub\L4D2-Competitive-Rework\addons\sourcemod\scripting\bequiet.sp::TeamSay_Callback  
L 03/22/2026 - 12:18:38: Error log file session closed.  

L 03/07/2026 - 13:09:14: [SM] Exception reported: Client 6 is not in game  
L 03/07/2026 - 13:09:14: [SM] Blaming: optional/playermanagement.smx  
L 03/07/2026 - 13:09:14: [SM] Call stack trace:  
L 03/07/2026 - 13:09:14: [SM]   [0] GetClientTeam  
L 03/07/2026 - 13:09:14: [SM]   [1] Line 563, C:\Users\Sir\Documents\GitHub\L4D2-Competitive-Rework\addons\sourcemod\scripting\playermanagement.sp::GetClientTeamEx  
L 03/07/2026 - 13:09:14: [SM]   [2] Line 164, C:\Users\Sir\Documents\GitHub\L4D2-Competitive-Rework\addons\sourcemod\scripting\playermanagement.sp::Spectate_Cmd  
L 03/07/2026 - 13:22:14: Error log file session closed.  

L 05/23/2026 - 22:18:21: [SM] Exception reported: Client 6 is not in game  
L 05/23/2026 - 22:18:21: [SM] Blaming: optional/l4d2_ghost_warp.smx  
L 05/23/2026 - 22:18:21: [SM] Call stack trace:  
L 05/23/2026 - 22:18:21: [SM]   [0] GetClientTeam  
L 05/23/2026 - 22:18:21: [SM]   [1] Line 123, C:\Users\Sir\Documents\GitHub\L4D2-Competitive-Rework\addons\sourcemod\scripting\l4d2_ghost_warp.sp::Cmd_WarpToSurvivor  
