### PR TITLE
[Diescraper] m4 block the stair shortcut

### DIFF
--- a/cfg/stripper/zonemod/maps/l4d2_diescraper4_top_361.cfg
+++ b/cfg/stripper/zonemod/maps/l4d2_diescraper4_top_361.cfg
@@ -1,4 +1,32 @@
-; Diescraper Redux 4
+
+; =====================================================
+;  [l4d2_diescraper4_top_361] [m4/4] [Diescraper Redux]
+; =====================================================
+
+; ############  DIRECTOR AND EVENT CHANGES  ###########
+; =====================================================
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==       Modify director behaviour and events      ==
+; =====================================================
+
+; Remove script call that could muck with tank spawns
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	delete:
+	{
+		"OnMapSpawn" "directorBeginScriptdiescraper_noboss0-1"
+	}
+}
+
+; ################  ITEM SPAWN CHANGES  ###############
+; =====================================================
+; ==           PILL / ITEM / WEAPON SPAWNS           ==
+; ==   Remove or change pill, item & weapon spawns   ==
+; =====================================================
 
 ; Make sure we have both an uzi and shotgun in saferoom.
 modify:
@@ -13,52 +41,60 @@ modify:
 	}
 }
 
-; Block death window as you approach finale area
-add:
-{
-	"classname" "prop_dynamic"
-	"origin" "850 817 -128"
-	"angles" "0 274 0"
-	"solid" "6"
-	"rendercolor" "255 255 255"
-	"model" "models/props/cs_militia/boxes_frontroom.mdl"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "866 725 -128"
-	"angles" "0 340 0"
-	"solid" "6"
-	"rendercolor" "255 255 255"
-	"model" "models/props/cs_office/shelves_metal.mdl"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "854 671 -128"
-	"angles" "0 291 0"
-	"solid" "6"
-	"rendercolor" "255 255 255"
-	"model" "models/props/cs_militia/boxes_garage_lower.mdl"
-}
-{
-	"classname" "prop_dynamic"
-	"origin" "819 875 -128"
-	"angles" "0 272 0"
-	"solid" "6"
-	"rendercolor" "255 255 255"
-	"model" "models/props/cs_office/shelves_metal.mdl"
-}
-
-; Remove script call that could muck with tank spawns
+; Ensure safe room weapon selection
 modify:
 {
 	match:
 	{
-		"classname" "logic_auto"
+		"hammerid" "625290"
 	}
-	delete:
+	replace:
 	{
-		"OnMapSpawn" "directorBeginScriptdiescraper_noboss0-1"
+		"weapon_selection" "any_rifle"
 	}
+}
+{
+	match:
+	{
+		"hammerid" "625292"
+	}
+	replace:
+	{
+		"weapon_selection" "any_shotgun"
+	}
+}
+
+; Make ammo spawns consistent
+filter:
+{
+	"targetname" "finale_weapon_case"
+}
+{
+	"targetname" "finale_weapon_spawn2"
+}
+{
+	"targetname" "finale_weapon_spawn8"
+}
+{
+	"targetname" "finale_weapon_spawn10"
+}
+{
+	"targetname" "finale_weapon_spawn11"
+}
+{
+	"targetname" "finale_weapon_spawn12"
+}
+{
+	"targetname" "finale_weapon_spawn14"
+}
+{
+	"targetname" "finale_weapon_spawn15"
+}
+{
+	"targetname" "finale_weapon_spawn16"
+}
+{
+	"targetname" "finale_weapon_spawn17"
 }
 
 ; 4 static pill spawns
@@ -161,6 +197,46 @@ add:
 	"item18" "0"
 }
 
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+
+; Block death window as you approach finale area
+add:
+{
+	"classname" "prop_dynamic"
+	"origin" "850 817 -128"
+	"angles" "0 274 0"
+	"solid" "6"
+	"rendercolor" "255 255 255"
+	"model" "models/props/cs_militia/boxes_frontroom.mdl"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "866 725 -128"
+	"angles" "0 340 0"
+	"solid" "6"
+	"rendercolor" "255 255 255"
+	"model" "models/props/cs_office/shelves_metal.mdl"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "854 671 -128"
+	"angles" "0 291 0"
+	"solid" "6"
+	"rendercolor" "255 255 255"
+	"model" "models/props/cs_militia/boxes_garage_lower.mdl"
+}
+{
+	"classname" "prop_dynamic"
+	"origin" "819 875 -128"
+	"angles" "0 272 0"
+	"solid" "6"
+	"rendercolor" "255 255 255"
+	"model" "models/props/cs_office/shelves_metal.mdl"
+}
+
 ; Make it so infected can't break the glass
 modify:
 {
@@ -241,87 +317,32 @@ modify:
 	}
 }
 
-; Ensure safe room weapon selection
-modify:
-{
-	match:
-	{
-		"hammerid" "625290"
-	}
-	replace:
-	{
-		"weapon_selection" "any_rifle"
-	}
-}
-{
-	match:
-	{
-		"hammerid" "625292"
-	}
-	replace:
-	{
-		"weapon_selection" "any_shotgun"
-	}
-}
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
 
-; Make ammo spawns consistent
-filter:
-{
-	"targetname" "finale_weapon_case"
-}
-{
-	"targetname" "finale_weapon_spawn2"
-}
-{
-	"targetname" "finale_weapon_spawn8"
-}
-{
-	"targetname" "finale_weapon_spawn10"
-}
-{
-	"targetname" "finale_weapon_spawn11"
-}
-{
-	"targetname" "finale_weapon_spawn12"
-}
-{
-	"targetname" "finale_weapon_spawn14"
-}
-{
-	"targetname" "finale_weapon_spawn15"
-}
-{
-	"targetname" "finale_weapon_spawn16"
-}
-{
-	"targetname" "finale_weapon_spawn17"
-}
-
-
-
-
-; creat 2 clip wallls block the stair shortcut
+; creat clip wallls block the stair shortcut
 add:
 {
 	"classname" "env_player_blocker"
 	"BlockType" "1"
 	"initialstate" "1"
-	"maxs" "64 40 160"
-	"mins" "-64 -40 0"
-	"targetname" "stair_blocker_01"
-	"origin" "-192 64 -408"
+	"maxs" "64 40 120"
+	"mins" "-64 -40 -80"
+	"targetname" "stair_svv_clipwall_01"
+	"origin" "-192 64 -328"
 }
 {
-	"classname" "env_player_blocker"
-	"angles" "0 0 -25"
+	"classname" "env_physics_blocker"
+	"angles" "0 0 55"
 	"BlockType" "1"
+	"boxmaxs" "32 32 160"
+	"boxmins" "-32 -32 -160"
 	"initialstate" "1"
-	"maxs" "32 40 160"
-	"mins" "-36 -60 -60"
-	"boxmaxs" "32 40 160"
-	"boxmins" "-36 -60 -60"
-	"targetname" "stair_blocker_02"
-	"origin" "-160 -16 -328"
+	"targetname" "stair_svv_clipwall_02"
+	"origin" "-160 -16 -320"
 }
 {
 	"classname" "env_player_blocker"
@@ -329,8 +350,28 @@ add:
 	"initialstate" "1"
 	"maxs" "64 40 120"
 	"mins" "-64 -40 -20"
-	"targetname" "stair_blocker_03"
+	"targetname" "stair_svv_clipwall_03"
 	"origin" "-192 -112 -280"
+}
+{
+	"classname" "env_physics_blocker"
+	"angles" "-31 0 0"
+	"BlockType" "1"
+	"boxmaxs" "32 40 100"
+	"boxmins" "-32 -40 -100"
+	"initialstate" "1"
+	"targetname" "stair_svv_clipwall_04"
+	"origin" "-232 64 -312"
+}
+{
+	"classname" "env_physics_blocker"
+	"angles" "0 0 0"
+	"BlockType" "1"
+	"boxmaxs" "32 64 160"
+	"boxmins" "-32 -64 -40"
+	"initialstate" "1"
+	"targetname" "stair_svv_clipwall_05"
+	"origin" "-160 -16 -304"
 }
 
 {
@@ -384,20 +425,18 @@ add:
 add:
 {
 	"classname" "logic_auto"
-	"OnMapSpawn" "stair_blocker_remover_trig,AddOutput,mins -32 -60 -32,0,-1"
-	"OnMapSpawn" "stair_blocker_remover_trig,AddOutput,maxs 32 60 32,0,-1"
-	"OnMapSpawn" "stair_blocker_remover_trig,AddOutput,solid 2,0,-1"
+	"OnMapSpawn" "trig_clipwall_remover,AddOutput,mins -32 -60 -32,0,-1"
+	"OnMapSpawn" "trig_clipwall_remover,AddOutput,maxs 32 60 32,0,-1"
+	"OnMapSpawn" "trig_clipwall_remover,AddOutput,solid 2,0,-1"
 }
 {
 	"classname" "trigger_once"
 	"origin" "656 64 -240"
-	"targetname" "stair_blocker_remover_trig"
+	"targetname" "trig_clipwall_remover"
 	"filtername" "filter_survivor"
 	"spawnflags" "1"
 	"startdisabled" "0"
-	"OnStartTouch" "stair_blocker_01,Disable,,0,-1"
-	"OnStartTouch" "stair_blocker_02,Disable,,0,-1"
-	"OnStartTouch" "stair_blocker_03,Disable,,0,-1"
+	"OnStartTouch" "stair_svv_clipwall_0*,Disable,,0,-1"
 }
 
 


### PR DESCRIPTION
Block the stair shortcut precisely, because the old clipwall  can not 100% block the shortcut. : [video](https://dl.flxcs.net/ft/cv/oe/cp/3a/gi/dk/nw/9v/bb/dw/g5/8a/p/dr4.mp4
)
Fix: added a diagonal player clip on the left staircase, and optimized the naming and removal logic of the existing clipwall.
Reorganized the structure of the cfg code , making it more organized.
<img width="1321" height="880" alt="1" src="https://github.com/user-attachments/assets/26b22abe-c7d3-41af-a845-fd53b34482b8" />
<img width="1327" height="816" alt="2" src="https://github.com/user-attachments/assets/d555d6f1-c3ab-4287-a85e-797bb9245950" />
