### PR TITLE
Haunted Forest fixes

### DIFF
--- a/cfg/stripper/zonemod/maps/hf01_theforest.cfg
+++ b/cfg/stripper/zonemod/maps/hf01_theforest.cfg
@@ -81,14 +81,443 @@ add:
 	"classname" "prop_dynamic"
 }
 
+
+; ############  DIRECTOR, EVENTS & NAV MESH ###########
+; =====================================================
+; ==          DIRECTOR & EVENT MODIFICATION          ==
+; ==  Modify existing director behaviour and events  ==
+; =====================================================
+; --- Speed up the really long intro camera sequence
+modify:
+{
+	match:
+	{
+		"targetname" "camera_intro_survivor_01"
+	}
+	replace:
+	{
+		"origin" "-11284 4974.61 126.821"
+	}
+}
+{
+	match:
+	{
+		"targetname" "camera_intro_survivor_02"
+	}
+	replace:
+	{
+		"origin" "-11278 4974.87 126.821"
+	}
+}
+{
+	match:
+	{
+		"targetname" "camera_intro_survivor_03"
+	}
+	replace:
+	{
+		"origin" "-11286 4974.52 126.821"
+	}
+}
+{
+	match:
+	{
+		"targetname" "camera_intro_survivor_04"
+	}
+	replace:
+	{
+		"origin" "-11275 4975 126.821"
+	}
+}
+{
+	match:
+	{
+		"targetname" "intro_train"
+	}
+	replace:
+	{
+		"target" "track08"
+		"origin" "-11283 4975 129"
+	}
+}
+{
+	match:
+	{
+		"classname" "path_track"
+	}
+	replace:
+	{
+		"orientationtype" "1"
+	}
+}
+{
+	match:
+	{
+		"targetname" "fade_intro"
+	}
+	replace:
+	{
+		"holdtime" "1"
+		"duration" "2"
+	}
+}
+{
+	match:
+	{
+		"targetname" "relay_intro_start"
+	}
+	delete:
+	{
+		"OnTrigger" "relay_intro_survivor_camerasTrigger14-1"
+	}
+	insert:
+	{
+		"OnTrigger" "relay_intro_survivor_cameras,Trigger,,3.5,-1"
+	}
+}
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+add:
+; --- Block survivors from standing on the tunnel exit after the starting saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "-11801 7784 506.5"
+	"mins" "-260 -208 -309.5"
+	"maxs" "260 208 309.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from climbing on the cliff behind the truck
+{
+	"classname" "env_physics_blocker"
+	"origin" "-12231.3 10271 388"
+	"angles" "0 25 0"
+	"mins" "-38 -57 -428"
+	"maxs" "38 57 428"
+	"boxmins" "-38 -57 -428"
+	"boxmaxs" "38 57 428"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivor access to cliff above the roadblock tunnel exit
+{
+	"classname" "env_physics_blocker"
+	"origin" "-7936 8684.5 336"
+	"mins" "-379 -283.5 -480"
+	"maxs" "379 283.5 480"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from climbing on the long tunnel entrance
+{
+	"classname" "env_physics_blocker"
+	"origin" "-5453 6844 536"
+	"mins" "-99 -28 -280"
+	"maxs" "99 28 280"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-5631.2 6817.25 536"
+	"angles" "0 18 0"
+	"mins" "-91 -28 -280"
+	"maxs" "91 28 280"
+	"boxmins" "-91 -28 -280"
+	"boxmaxs" "91 28 280"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-5864 6704 644"
+	"mins" "-96 -136 -172"
+	"maxs" "96 136 172"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-6496 6676 644"
+	"mins" "-536 -108 -172"
+	"maxs" "536 108 172"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-7128 6704 644"
+	"mins" "-96 -136 -172"
+	"maxs" "96 136 172"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from climbing on the hill by the tunnel exit
+{
+	"classname" "env_physics_blocker"
+	"origin" "-6716 3688 558"
+	"mins" "-84 -64 -414"
+	"maxs" "84 64 414"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-6644.5 3036 622"
+	"mins" "-187.5 -36 -350"
+	"maxs" "187.5 36 350"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from standing on the mine tunnel entrance (godspot)
+{
+	"classname" "env_physics_blocker"
+	"origin" "-4552 -692 543"
+	"mins" "-760 -60 -433"
+	"maxs" "760 60 433"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors from standing on the bridge archways
+{
+	"classname" "env_physics_blocker"
+	"origin" "-832 -2568.5 594"
+	"mins" "-134 -30.5 -314"
+	"maxs" "134 30.5 314"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-832 -3241.5 594"
+	"mins" "-134 -30.5 -314"
+	"maxs" "134 30.5 314"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivors standing on invisible walls either side of the bridge archways
+{
+	"classname" "env_physics_blocker"
+	"origin" "-612 -3247.5 448"
+	"mins" "-60 -2.5 -464"
+	"maxs" "60 2.5 464"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1052 -3247.5 448"
+	"mins" "-60 -2.5 -464"
+	"maxs" "60 2.5 464"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+
+; =====================================================
+; ==                  OUT OF BOUNDS                  ==
+; ==  Block players getting outside / under the map  ==
+; =====================================================
+; --- Block a survivor out of bounds spot at the starting saferoom
+add:
+{
+	"classname" "env_physics_blocker"
+	"origin" "-10308 4598 552"
+	"mins" "-4 -200 -592"
+	"maxs" "4 200 592"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Block survivor out of bounds spots on cliffs on the sides of the bridge before the end saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "-306 -1927 131"
+	"mins" "-194 -31 -107"
+	"maxs" "194 31 107"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-312 -4065 111"
+	"mins" "-176 -18 -127"
+	"maxs" "176 18 127"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1612 -4160 466"
+	"mins" "-76 -176 -442"
+	"maxs" "76 176 442"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+
 ; =====================================================
 ; ==                   STUCK SPOTS                   ==
 ; ==  Prevent players from getting stuck in the map  ==
 ; =====================================================
-
-; --- add a big rock fix a spot (Si can get the under of level)
-; --- 添加一块石头模型，阻止特感到地下
 add:
+; --- Fix a few spots where infected can get stuck behind fences around the starting saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "-10880 5250 146"
+	"mins" "-88 -9 -6"
+	"maxs" "88 9 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-10247.7 4942.73 66"
+	"angles" "0 60 0"
+	"mins" "-88 -13 -6"
+	"maxs" "88 13 6"
+	"boxmins" "-88 -13 -6"
+	"boxmaxs" "88 13 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-10166.3 5104.7 71"
+	"angles" "0 66 0"
+	"mins" "-88 -13 -6"
+	"maxs" "88 13 6"
+	"boxmins" "-88 -13 -6"
+	"boxmaxs" "88 13 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-10166.3 5104.7 84"
+	"angles" "0 66 0"
+	"mins" "0 -13 -6"
+	"maxs" "88 13 6"
+	"boxmins" "0 -13 -6"
+	"boxmaxs" "88 13 6"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Fix perma-stuck spots in 2 rock clusters by the truck
+{
+	"classname" "env_physics_blocker"
+	"origin" "-10928 8753 148"
+	"mins" "-32 -33 -84"
+	"maxs" "32 33 84"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-10353 10380 247"
+	"mins" "-32 -33 -84"
+	"maxs" "32 33 84"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Fix survivor perma-stuck spot by tree before the roadblock tunnel
+{
+	"classname" "env_physics_blocker"
+	"origin" "-9421.5 8705 -95"
+	"mins" "-61.5 -27 -183"
+	"maxs" "61.5 27 183"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+; --- Fix perma-stuck spot in rock cluster by the roadblock tunnel
+{
+	"classname" "env_physics_blocker"
+	"origin" "-9378 8645 -194"
+	"mins" "-32 -33 -84"
+	"maxs" "32 33 84"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Block a perma-stuck spot behind a bush near the truck (and block a displacement clip / stuck spot)
+{
+	"classname" "env_physics_blocker"
+	"origin" "-10975 10782 64"
+	"mins" "-217 -61 -62"
+	"maxs" "217 61 62"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Fix a perma-stuck spot in rock cluster on path around the roadblock tunnel
+{
+	"classname" "env_physics_blocker"
+	"origin" "-8143 8368 64"
+	"mins" "-32 -33 -84"
+	"maxs" "32 33 84"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Fix 5 perma-stuck spots in rock clusters around the house
+{
+	"classname" "env_physics_blocker"
+	"origin" "-7813 4458 211"
+	"mins" "-51 -33 -84"
+	"maxs" "51 33 84"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-8309 4120 156"
+	"mins" "-32 -33 -84"
+	"maxs" "32 33 84"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-8202 4293 111"
+	"mins" "-32 -33 -84"
+	"maxs" "32 33 84"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-7359 2237 179"
+	"mins" "-32 -33 -84"
+	"maxs" "32 33 84"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-6474 3033 248"
+	"mins" "-32 -33 -84"
+	"maxs" "32 33 84"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Fix sliding stuck spot in some fallen trees before the mines
+{
+	"classname" "env_physics_blocker"
+	"origin" "-4484 4243 -126"
+	"mins" "-28 -51 -33"
+	"maxs" "28 51 33"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Fix a perma-stuck spot in a rock cluster before the mines
+{
+	"classname" "env_physics_blocker"
+	"origin" "-4880 363 -72"
+	"mins" "-32 -33 -84"
+	"maxs" "32 33 84"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- add a big rock fix a spot (Si can get the under of level) before the mine
+; --- 添加一块石头模型，阻止特感到地下
 {
 	"classname" "prop_dynamic"
 	"origin" "-4048 -664 176"
@@ -98,4 +527,119 @@ add:
 	"model" "models/lostcoast/props_wasteland/rock_coast02c.mdl"
 	"disableshadows" "1"
 }
+; --- Fix a perma-stuck spot in a rock cluster after the mines
+{
+	"classname" "env_physics_blocker"
+	"origin" "-212 -822 133"
+	"mins" "-32 -33 -84"
+	"maxs" "32 33 84"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Fix a perma-stuck spot in a tree cluster after the mines
+{
+	"classname" "env_physics_blocker"
+	"origin" "-298.5 -894 207"
+	"mins" "-16.5 -18 -136"
+	"maxs" "16.5 18 136"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Block a stuck spot between cliff and skybox near the final bridge
+{
+	"classname" "env_physics_blocker"
+	"origin" "250 -2036 406"
+	"mins" "-336 -28 -502"
+	"maxs" "336 28 502"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Block a survivor perma-stuck spot after the final bridge
+{
+	"classname" "env_physics_blocker"
+	"origin" "-1464 -4207 131"
+	"mins" "-72 -42 -107"
+	"maxs" "72 42 107"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 
+
+; =====================================================
+; ==                 NUISANCE CHANGES                ==
+; ==      Clipping improvements, QOL map changes     ==
+; =====================================================
+
+
+; #############  LADDER CHANGES AND FIXES  ############
+; =====================================================
+; ==             LADDER ADDITIONS / FIXES            ==
+; ==              Add or change ladders              ==
+; =====================================================
+; --- Fix falling off the ladder in the starting saferoom
+modify:
+{
+	match:
+	{
+		"hammerid" "764352"
+	}
+	insert:
+	{
+		"origin" "5 3 0"
+	}
+}
+; --- Fix falling off the ladder by the truck
+{
+	match:
+	{
+		"hammerid" "653067"
+	}
+	insert:
+	{
+		"origin" "0 -1 0"
+	}
+}
+; --- Fix falling off a ladder by the roadblock tunnel
+{
+	match:
+	{
+		"hammerid" "876288"
+	}
+	insert:
+	{
+		"origin" "0 2 0"
+	}
+}
+; --- Fix falling off a ladder before the mines
+{
+	match:
+	{
+		"hammerid" "758418"
+	}
+	insert:
+	{
+		"origin" "-1 0 2"
+	}
+}
+; --- Fix being unable to climb a ladder from the right side after the mines
+{
+	match:
+	{
+		"hammerid" "647439"
+	}
+	insert:
+	{
+		"origin" "2 -1 0"
+	}
+}
+; --- Fix falling off a ladder after the mines
+{
+	match:
+	{
+		"hammerid" "647450"
+	}
+	insert:
+	{
+		"origin" "6 -2 0"
+	}
+}

--- a/cfg/stripper/zonemod/maps/hf01_theforest.cfg
+++ b/cfg/stripper/zonemod/maps/hf01_theforest.cfg
@@ -176,6 +176,22 @@ modify:
 	}
 }
 
+; =====================================================
+; ==                STATIC AMMO PILES                ==
+; ==          Add or modify ammo pile spawns         ==
+; =====================================================
+add:
+; --- Ammo pile in the back of the truck
+{
+	"classname" "weapon_ammo_spawn"
+	"origin" "-11361 9334 2"
+	"angles" "0 345 0"
+	"model" "models/props/terror/ammo_stack.mdl"
+	"solid" "6"
+	"disableshadows" "1"
+	"spawnflags" "2"
+}
+
 ; #############  MAP CLIPPING AND ISSUES  #############
 ; =====================================================
 ; ==                 EXPLOITS BLOCKED                ==
@@ -331,6 +347,23 @@ add:
 	"initialstate" "1"
 	"BlockType" "1"
 }
+; --- Block a survivor out of bounds spot behind the fence by the army truck
+{
+	"classname" "env_physics_blocker"
+	"origin" "-5264.5 9690 299.5"
+	"mins" "-55.5 -190 -516.5"
+	"maxs" "55.5 190 516.5"
+	"initialstate" "1"
+	"BlockType" "1"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-5238.5 9277.5 387"
+	"mins" "-29.5 -250.5 -429"
+	"maxs" "29.5 250.5 429"
+	"initialstate" "1"
+	"BlockType" "1"
+}
 ; --- Block survivor out of bounds spots on cliffs on the sides of the bridge before the end saferoom
 {
 	"classname" "env_physics_blocker"
@@ -457,6 +490,23 @@ add:
 	"initialstate" "1"
 	"BlockType" "0"
 }
+; --- Block a perma-stuck spot behind a fence near the army truck
+{
+	"classname" "env_physics_blocker"
+	"origin" "-5228.5 8928 -108"
+	"mins" "-19.5 -64 -92"
+	"maxs" "19.5 64 92"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-5225 9260 -117"
+	"mins" "-16 -265 -75"
+	"maxs" "16 265 75"
+	"initialstate" "1"
+	"BlockType" "0"
+}
 ; --- Fix 5 perma-stuck spots in rock clusters around the house
 {
 	"classname" "env_physics_blocker"
@@ -569,6 +619,197 @@ add:
 ; ==                 NUISANCE CHANGES                ==
 ; ==      Clipping improvements, QOL map changes     ==
 ; =====================================================
+; --- Fix incorrect glass color on hittable car
+modify:
+{
+	match:
+	{
+		"parentname" "prop_car1_tankhit"
+	}
+	replace:
+	{
+		"rendercolor" "255 255 255"
+	}
+}
+; --- Clipping on dead body in front of the truck
+add:
+{
+	"classname" "env_physics_blocker"
+	"origin" "-10971 9291 -35"
+	"mins" "-34 -30 -5"
+	"maxs" "34 30 5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-10971.5 9291.5 -27"
+	"mins" "-30.5 -26.5 -3"
+	"maxs" "30.5 26.5 3"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Clipping on dead body on the bridge before the end saferoom
+{
+	"classname" "env_physics_blocker"
+	"origin" "-742.5 -2271.5 29.5"
+	"mins" "-22.5 -17.5 -5.5"
+	"maxs" "22.5 17.5 5.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-718 -2267.5 33"
+	"mins" "-10 -16.5 -9"
+	"maxs" "10 16.5 9"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+{
+	"classname" "env_physics_blocker"
+	"origin" "-715 -2269.5 38.5"
+	"mins" "-7 -5.5 -14.5"
+	"maxs" "7 5.5 14.5"
+	"initialstate" "1"
+	"BlockType" "0"
+}
+; --- Remove "ghost" on the bridge before the end saferoom
+filter:
+{
+	"hammerid" "640717"
+}
+{
+	"targetname" "door_bridgeghost"
+}
+; --- Remove the scream sound before the end saferoom
+{
+	"hammerid" "705470"
+}
+; --- Reduced flashing on light in tunnel
+modify:
+{
+	match:
+	{
+		"targetname" "traintunnel_light_timer"
+	}
+	replace:
+	{
+		"LowerRandomBound" "0.75"
+		"UpperRandomBound" "1.5"
+	}
+	delete:
+	{
+		"OnTimer" "traintunnel_spotlightTurnOn0.2-1"
+		"OnTimer" "traintunnel_spriteShowSprite0.2-1"
+		"OnTimer" "traintunnel_bulbTurnOn0.2-1"
+	}
+	insert:
+	{
+		"OnTimer" "traintunnel_spotlight,TurnOn,,0.3,-1"
+		"OnTimer" "traintunnel_sprite,ShowSprite,,0.3,-1"
+		"OnTimer" "traintunnel_bulb,TurnOn,,0.3,-1"
+	}
+}
+; --- Fix area portals in tunnels having a low render distance
+modify:
+; --- Roadblock tunnel
+{
+	match:
+	{
+		"targetname" "portal_tunnel1"
+		"target" "illusion_tunnel1"
+	}
+	replace:
+	{
+		"FadeStartDist" "1500"
+		"FadeDist" "1600"
+	}
+}
+{
+	match:
+	{
+		"targetname" "portal_tunnel2"
+		"target" "illusion_tunnel2"
+	}
+	replace:
+	{
+		"FadeStartDist" "1500"
+		"FadeDist" "1600"
+	}
+}
+; --- Long tunnel
+{
+	match:
+	{
+		"targetname" "portal_tunnel1"
+		"target" "illusion_tunnelblack1"
+	}
+	replace:
+	{
+		"FadeStartDist" "1900"
+		"FadeDist" "2000"
+	}
+}
+{
+	match:
+	{
+		"targetname" "portal_tunnel2"
+		"target" "illusion_tunnelblack2"
+	}
+	replace:
+	{
+		"FadeStartDist" "1900"
+		"FadeDist" "2000"
+	}
+}
+; --- Mine Tunnel
+{
+	match:
+	{
+		"target" "illusion_mine1"
+	}
+	replace:
+	{
+		"FadeStartDist" "1500"
+		"FadeDist" "1600"
+	}
+}
+{
+	match:
+	{
+		"target" "illusion_mine2"
+	}
+	replace:
+	{
+		"FadeStartDist" "1500"
+		"FadeDist" "1600"
+	}
+}
+; --- End saferoom bridge
+{
+	match:
+	{
+		"target" "illusion_bridge1"
+	}
+	replace:
+	{
+		"FadeStartDist" "1500"
+		"FadeDist" "1600"
+	}
+}
+; --- Well
+{
+	match:
+	{
+		"target" "illusion_well2"
+	}
+	replace:
+	{
+		"FadeStartDist" "800"
+		"FadeDist" "900"
+	}
+}
 
 
 ; #############  LADDER CHANGES AND FIXES  ############


### PR DESCRIPTION
## Map 1
Sped up the really long intro sequence
Fixed buggy fade in during intro sequence
Blocked survivors from standing on the tunnel exit after the starting saferoom
Blocked survivors from climbing on the cliff behind the truck
Blocked survivor access to cliff above the roadblock tunnel exit
Blocked survivors from climbing on the long tunnel entrance
Blocked survivors from climbing on the hill by the tunnel exit
Blocked survivors from standing on the mine tunnel entrance
Blocked survivors from standing on the bridge archways
Blocked survivors standing on invisible walls either side of the bridge archways
Blocked a survivor out of bounds spot at the starting saferoom
Blocked survivor out of bounds spots on cliffs on the sides of the bridge before the end saferoom
Fixed a few spots where infected can get stuck behind fences around the starting saferoom
Fixed perma-stuck spots in 2 rock clusters by the truck
Fixed survivor perma-stuck spot by tree before the roadblock tunnel
Fixed perma-stuck spot in rock cluster by the roadblock tunnel
Blocked a perma-stuck spot behind a bush near the truck
Fixed a perma-stuck spot in rock cluster on path around the roadblock tunnel
Fixed 5 perma-stuck spots in rock clusters around the house
Fixed sliding stuck spot in some fallen trees before the mines
Fixed a perma-stuck spot in a rock cluster before the mines
Fixed a perma-stuck spot in a rock cluster after the mines
Fixed a perma-stuck spot in a tree cluster after the mines
Blocked a stuck spot between cliff and skybox near the final bridge
Blocked a survivor perma-stuck spot after the final bridge
Fixed falling off the ladder in the starting saferoom
Fixed falling off the ladder by the truck
Fixed falling off a ladder by the roadblock tunnel
Fixed falling off a ladder before the mines
Fixed being unable to climb a ladder from the right side after the mines
Fixed falling off a ladder after the mines
Added an ammo pile in the back of the truck
Blocked a survivor out of bounds spot behind the fence by the army truck
Blocked a perma-stuck spot behind a fence near the army truck
Fixed incorrect glass color on hittable car
Added clipping on dead body in front of the truck
Added clipping on dead body on the bridge before the end saferoom
Removed "ghost" on the bridge before the end saferoom
Removed the scream sound before the end saferoom
Reduced flashing on light in tunnel
Fixed area portals in tunnels having a low render distance