### PR TITLE
DKR 2.0 Fix map 2 ladder

### DIFF
--- a/cfg/stripper/zonemod/maps/dkr_m2_carnival.cfg
+++ b/cfg/stripper/zonemod/maps/dkr_m2_carnival.cfg
@@ -33,20 +33,15 @@ add:
 ;	"targetname" "eb_fix01"
 }
 
-
 ; --- Fix broken infected ladder on telephone pole after the warehouse
-filter:
+modify:
 {
-	"hammerid" "1184297"
-}
-add:
-{
-    "classname" "func_simpleladder"
-    "origin" "-1.00049 7.33105 -90.5992"
-    "angles" "0 0 3"
-    "model" "*205"
-    "normal.x" "0"
-    "normal.y" "-0.99863"
-    "normal.z" "-0.052336"
-    "team" "2"
+	match:
+	{
+		"hammerid" "1184297"
+	}
+	insert:
+	{
+		"origin" "-5 -5 10"
+	}
 }


### PR DESCRIPTION
Fix broken infected ladder on telephone pole after the warehouse - now working correctly on both versions of the map

NF said he would fix this so this can be removed eventually