### PR TITLE
DKR4 Fix 2 broken ladders

### DIFF
--- a/cfg/stripper/zonemod/maps/dkr_m4_ferris.cfg
+++ b/cfg/stripper/zonemod/maps/dkr_m4_ferris.cfg
@@ -19,3 +19,29 @@ modify:
 		"OnVersus" "directorBeginScriptwitch_glow0-1"
 	}
 }
+
+
+; --- Fix falling off a ladder to climb on the kitchen at the event
+modify:
+{
+	match:
+	{
+		"hammerid" "40456"
+	}
+	insert:
+	{
+		"origin" "4 -4 3"
+	}
+}
+; --- Fix broken ladder behind the kitchen at the event
+{
+	match:
+	{
+		"hammerid" "4620699"
+	}
+	replace:
+	{
+	    "normal.x" "-1"
+		"normal.y" "0"
+	}
+}


### PR DESCRIPTION
Fix 2 broken ladders at the start of the event on Dark Carnival Remix