### PR TITLE
[Outline] m4 unlock more pills

### DIFF
--- a/cfg/cfgogl/zonemod/mapinfo.txt
+++ b/cfg/cfgogl/zonemod/mapinfo.txt
@@ -2987,9 +2987,12 @@
 //=============== Outline 跨越边境
 	"outline_m4"
 	{
+	//	"max_distance"		"800"
+	//	900 now, consider reduce score because its too long stages? not sure how to do
+	//	现版本自带是900分，考虑降低路程分？不确定如何做
 		"ItemLimits"
 		{
-			"pain_pills"	"4"
+			"pain_pills"	"6"
 		}
 	}
 	


### PR DESCRIPTION
According to the author's (Taiga) update . The update type was by-vpk : adjust level score from 700 to 900.
adjust pills from 4 to 6.
adjust tanks from 1 to 2 (finale script).
(now m4 has 3 tanks totally)

new script stages snippet : 
```
...
	 A_CustomFinale_StageCount = 5
	 
         A_CustomFinale1 = SCRIPTED 
	 A_CustomFinaleValue1 = "outline_m4_tank1"

	 A_CustomFinale2 = PANIC
	 A_CustomFinaleValue2 = 3

	 A_CustomFinale3 = DELAY
	 A_CustomFinaleValue3 = 10
	 
	 A_CustomFinale4 = SCRIPTED 
	 A_CustomFinaleValue4 = "outline_m4_tank2"
	 
	 A_CustomFinale5 = DELAY
	 A_CustomFinaleValue5 = 10
...
```