### PR TITLE
[No echo] m3 clipwall fix

### DIFF
--- a/cfg/stripper/zonemod/maps/noecho_m3.cfg
+++ b/cfg/stripper/zonemod/maps/noecho_m3.cfg
@@ -1,0 +1,25 @@
+; =====================================================
+; ============ [noecho_m3] [m3/5] [no echo match]
+; =====================================================
+
+; #############  MAP CLIPPING AND ISSUES  #############
+; =====================================================
+; ==                 EXPLOITS BLOCKED                ==
+; ==      Block intentionally performed exploits     ==
+; =====================================================
+
+; add clipwall for the truck model near the alarm event door
+; prevent Svv from skipping the event
+add:
+{
+	"classname" "env_physics_blocker"
+	"angles" "0 20 0"
+	"BlockType" "1"
+	"maxs" "64 56 1000"
+	"mins" "-64 -56 -128"
+	"boxmaxs" "64 56 1000"
+	"boxmins" "-64 -56 -128"
+	"initialstate" "1"
+	"targetname" "eb_fix01"
+	"origin" "1328 4760 152"
+}


### PR DESCRIPTION

url  (from @mk) :  [video](https://cdn.discordapp.com/attachments/1473837280643907785/1516638871868408019/Desktop_2026-06-16_23-57-13.mp4?ex=6a335f84&is=6a320e04&hm=790870447694bbf134608bf5bcb73f602601867e7354161cd8f350a624e7a196&)
to fix : 
add clipwall for the truck model near the horde event door, prevent Svv from skipping the event
<img width="1255" height="748" alt="m3" src="https://github.com/user-attachments/assets/d63b4345-eca4-490f-8f42-0c3617c6406c" />

