### PR TITLE
[Carried off] m1 hittable fix

### DIFF
--- a/cfg/stripper/zonemod/maps/cwm1_intro.cfg
+++ b/cfg/stripper/zonemod/maps/cwm1_intro.cfg
@@ -72,10 +72,11 @@ add:
 {
 	"classname" "env_physics_blocker"
 	"angles" "0 0 0"
-	"BlockType" "0"
+	"BlockType" "4"
 	"boxmaxs" "56 240 8"
 	"boxmins" "-8 -8 -180"
 	"initialstate" "1"
+	"targetname" "eb_fix01"
 	"origin" "3144 3848 120"
 }
 ; --- Add a clipwall beneath the grass in the tent area

--- a/cfg/stripper/zonemod/maps/cwm1_intro.cfg
+++ b/cfg/stripper/zonemod/maps/cwm1_intro.cfg
@@ -68,17 +68,27 @@ add:
 }
 
 add:
-; --- Block a hole
-; --- 添加入地空气墙
+; --- Block a hole at the back of the building near the fence gate
 {
-    "classname" "env_physics_blocker"
-    "angles" "0 0 0"
-    "BlockType" "0"
-    "maxs" "100 100 272"
-    "mins" "-8 -8 -8"
-    "initialstate" "1"
-    "targetname" "eb_fix1"
-    "origin" "3144 3856 152"
+	"classname" "env_physics_blocker"
+	"angles" "0 0 0"
+	"BlockType" "0"
+	"boxmaxs" "56 240 8"
+	"boxmins" "-8 -8 -180"
+	"initialstate" "1"
+	"origin" "3144 3848 120"
+}
+; --- Add a clipwall beneath the grass in the tent area
+; --- Prevent hittables from being swallowed
+{
+	"classname" "env_physics_blocker"
+	"angles" "0 0 0"
+	"BlockType" "4"
+	"boxmaxs" "1024 1600 -8.2"
+	"boxmins" "-2400 -600 -128"
+	"initialstate" "1"
+	"targetname" "eb_fix_large_displacement"
+	"origin" "3072 2008 120"
 }
 
 ; ############  DIRECTOR AND EVENT CHANGES  ###########


### PR DESCRIPTION
Adjust the shape of one clipwall that block a hole at the back of the building near the fence gate.

<img width="1022" height="595" alt="116" src="https://github.com/user-attachments/assets/b4c81cdf-c1a4-45f9-a289-d3ccb6e64e9f" />
<img width="1011" height="727" alt="115" src="https://github.com/user-attachments/assets/9318d7a8-a69c-451f-ab98-061f3b5cebd5" />

Add a clipwall beneath the grass in the tent area, to prevent hittables from being swallowed.
Demonstration video : [URL](https://www.bilibili.com/video/BV1JN4y1R7B2?t=6.3) , GIF demonstration and clipwall coverage shown in the image

<img width="426" height="240" alt="112a" src="https://github.com/user-attachments/assets/2e186db5-e9de-4730-821b-c97bfbbdba91" />
<img width="808" height="474" alt="112" src="https://github.com/user-attachments/assets/9db6886b-8728-4fa2-8090-9262f16870b0" />

 (for demonstration purposes only. In practice, this clipwall is placed just beneath the ground surface and does not hinder player movement)
<img width="777" height="546" alt="114" src="https://github.com/user-attachments/assets/9b7179ce-4a1d-46ab-a998-4eaf7dd8fae2" />

